### PR TITLE
fix: eliminate Tkinter runtime errors in server logs. Fixes #55

### DIFF
--- a/yeastweb/core/mrcnn/visualize.py
+++ b/yeastweb/core/mrcnn/visualize.py
@@ -7,19 +7,51 @@ Licensed under the MIT License (see LICENSE for details)
 Written by Waleed Abdulla
 """
 
-import os
-import sys
-import logging
-import random
-import itertools
+# =========================
+# Standard library imports
+# =========================
 import colorsys
+import itertools
+import os
+import random
+import sys
 
+# ==========================================================
+# Matplotlib backend (must be set BEFORE importing pyplot)
+# ==========================================================
+os.environ.setdefault("MPLBACKEND", "Agg")
+try:
+    import matplotlib  # noqa: E402
+    matplotlib.use("Agg", force=True)
+except Exception:
+    # Prefer headless over crashing in server contexts.
+    pass
+
+# =========================
+# Third-party imports
+# =========================
 import numpy as np
-from skimage.measure import find_contours
 import matplotlib.pyplot as plt
-from matplotlib import patches,  lines
+from matplotlib import patches, lines
 from matplotlib.patches import Polygon
+from skimage.measure import find_contours
 import IPython.display
+
+# =========================
+# Local imports
+# =========================
+ROOT_DIR = os.path.abspath("../")
+sys.path.append(ROOT_DIR)
+from mrcnn import utils
+
+# Only show figures when explicitly allowed; otherwise close them.
+# This prevents Tkinter/GUI usage on the server.
+ALLOW_GUI = os.environ.get("ALLOW_GUI") == "1"
+def maybe_show():
+    if ALLOW_GUI:
+        plt.show()
+    else:
+        plt.close('all')
 
 # Root directory of the project
 ROOT_DIR = os.path.abspath("../")
@@ -54,7 +86,7 @@ def display_images(images, titles=None, cols=4, cmap=None, norm=None,
         plt.imshow(image.astype(np.uint8), cmap=cmap,
                    norm=norm, interpolation=interpolation)
         i += 1
-    plt.show()
+    maybe_show()
 
 
 def random_colors(N, bright=True):
@@ -166,7 +198,7 @@ def display_instances(image, boxes, masks, class_ids, class_names,
             ax.add_patch(p)
     ax.imshow(masked_image.astype(np.uint8))
     if auto_show:
-        plt.show()
+        maybe_show()
 
 
 def display_differences(image,

--- a/yeastweb/manage.py
+++ b/yeastweb/manage.py
@@ -3,6 +3,13 @@
 import os
 import sys
 
+# Force headless Matplotlib BEFORE anything can import pyplot
+os.environ.setdefault("MPLBACKEND", "Agg")
+try:
+    import matplotlib
+    matplotlib.use("Agg", force=True)
+except Exception:
+    pass
 
 def main():
     """Run administrative tasks."""

--- a/yeastweb/yeastweb/asgi.py
+++ b/yeastweb/yeastweb/asgi.py
@@ -9,6 +9,14 @@ https://docs.djangoproject.com/en/4.2/howto/deployment/asgi/
 
 import os
 
+# Force headless Matplotlib BEFORE anything can import pyplot
+os.environ.setdefault("MPLBACKEND", "Agg")
+try:
+    import matplotlib
+    matplotlib.use("Agg", force=True)
+except Exception:
+    pass
+
 from django.core.asgi import get_asgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'yeastweb.settings')

--- a/yeastweb/yeastweb/wsgi.py
+++ b/yeastweb/yeastweb/wsgi.py
@@ -9,6 +9,14 @@ https://docs.djangoproject.com/en/4.2/howto/deployment/wsgi/
 
 import os
 
+# Force headless Matplotlib BEFORE anything can import pyplot
+os.environ.setdefault("MPLBACKEND", "Agg")
+try:
+    import matplotlib
+    matplotlib.use("Agg", force=True)
+except Exception:
+    pass
+
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'yeastweb.settings')


### PR DESCRIPTION
Force non-interactive Matplotlib backend (Agg) and remove GUI-only calls.

Changes I made: set MPLBACKEND=Agg in Django entrypoints; replace plt.show with savefig/plt.close; ensure no cv2.imshow/TkAgg usage; keep debug images writing to /media.