### PR TITLE
Add px to GFPDot min distance label

### DIFF
--- a/yeastweb/templates/pre-process.html
+++ b/yeastweb/templates/pre-process.html
@@ -601,7 +601,7 @@
                   <input type="checkbox" name="selected_analysis" value="{{ analysis }}" />
                   <span class="analysis-switch"></span>
                   {% if analysis == 'GFPDot' %}
-                    <span class="field-label">Min. distance:</span><input class="num-entry" type="number" name="distance" id="distance" />
+                    <span class="field-label">Min. distance (px):</span><input class="num-entry" type="number" name="distance" id="distance" />
                   {% endif %}
                 </label>
                 {% endfor %}


### PR DESCRIPTION
Clarify the GFPDot min distance input by appending the pixel unit in the label so users understand values are in pixels.

Fixes #87 