### PR TITLE
Refactor email configuration for UW SMTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,25 +67,25 @@ CYTOCV_MICROSOFT_LOGIN_URL=https://login.microsoftonline.com
 # -----------------------------------------------------------------------------
 # Email backend class.
 CYTOCV_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
-# SMTP host.
-CYTOCV_EMAIL_HOST=smtp.gmail.com
-# SMTP username (often full email address).
+# SMTP host. Use 127.0.0.1 when relaying through local Postfix.
+CYTOCV_EMAIL_HOST=127.0.0.1
+# SMTP username. Leave blank when local Postfix handles authentication.
 CYTOCV_EMAIL_HOST_USER=
-# SMTP password or app password.
+# SMTP password. Leave blank when local Postfix handles authentication.
 CYTOCV_EMAIL_HOST_PASSWORD=
-# SMTP port.
-CYTOCV_EMAIL_PORT=587
-# Transport toggles. Do not set both to 1.
-CYTOCV_EMAIL_USE_TLS=1
+# SMTP port. Local Postfix typically listens on 25.
+CYTOCV_EMAIL_PORT=25
+# Transport toggles. Do not set both to 1. Keep both at 0 for local Postfix.
+CYTOCV_EMAIL_USE_TLS=0
 CYTOCV_EMAIL_USE_SSL=0
 # Optional SMTP timeout in seconds (blank uses Django default).
-CYTOCV_EMAIL_TIMEOUT=
+CYTOCV_EMAIL_TIMEOUT=30
 # allauth email verification mode: none, optional, mandatory.
 CYTOCV_ACCOUNT_EMAIL_VERIFICATION=
 # Default sender for system emails.
-CYTOCV_DEFAULT_FROM_EMAIL=no-reply@noreply.x.edu
+CYTOCV_DEFAULT_FROM_EMAIL=
 # Reply-To header for system emails.
-CYTOCV_EMAIL_REPLY_TO=no-reply@noreply.x.edu
+CYTOCV_EMAIL_REPLY_TO=
 
 # -----------------------------------------------------------------------------
 # Google reCAPTCHA (optional)

--- a/cytocv/accounts/tests_email_config.py
+++ b/cytocv/accounts/tests_email_config.py
@@ -1,0 +1,22 @@
+from django.test import SimpleTestCase, override_settings
+
+from accounts.views.login import _recovery_sender_email
+from accounts.views.signup import _sender_email
+
+
+class AuthEmailSenderConfigTests(SimpleTestCase):
+    @override_settings(
+        DEFAULT_FROM_EMAIL="cytocv@uw.edu",
+        EMAIL_HOST_USER="cytocv",
+    )
+    def test_auth_flows_prefer_default_from_email_over_smtp_username(self):
+        self.assertEqual(_sender_email(), "cytocv@uw.edu")
+        self.assertEqual(_recovery_sender_email(), "cytocv@uw.edu")
+
+    @override_settings(
+        DEFAULT_FROM_EMAIL="",
+        EMAIL_HOST_USER="cytocv",
+    )
+    def test_auth_flows_fall_back_to_smtp_username_when_from_email_missing(self):
+        self.assertEqual(_sender_email(), "cytocv")
+        self.assertEqual(_recovery_sender_email(), "cytocv")

--- a/cytocv/accounts/views/login.py
+++ b/cytocv/accounts/views/login.py
@@ -100,7 +100,16 @@ def _recovery_resend_wait_seconds(request: HttpRequest) -> int:
 
 def _recovery_sender_email() -> str:
     """Return the sender address used for password recovery emails."""
-    return settings.EMAIL_HOST_USER
+    return (
+        (getattr(settings, "DEFAULT_FROM_EMAIL", "") or "").strip()
+        or (getattr(settings, "EMAIL_HOST_USER", "") or "").strip()
+    )
+
+
+def _recovery_reply_to_list() -> list[str] | None:
+    """Return a normalized reply-to list for recovery emails."""
+    reply_to = (getattr(settings, "EMAIL_REPLY_TO", "") or "").strip()
+    return [reply_to] if reply_to else None
 
 
 def _add_error(errors: dict[str, list[str]], field: str, message: str) -> None:
@@ -325,9 +334,8 @@ def _handle_password_recovery(request: HttpRequest) -> HttpResponse:
             minutes_valid=RECOVERY_CODE_TTL_SECONDS // 60,
             recipient_name=recipient_name,
         )
-        from_email = settings.EMAIL_HOST_USER
-        reply_to = getattr(settings, "EMAIL_REPLY_TO", None)
-        reply_to_list = [reply_to] if reply_to else None
+        from_email = _recovery_sender_email()
+        reply_to_list = _recovery_reply_to_list()
         try:
             email_message = EmailMessage(
                 subject,

--- a/cytocv/accounts/views/signup.py
+++ b/cytocv/accounts/views/signup.py
@@ -171,7 +171,16 @@ def _resend_wait_seconds(request: HttpRequest) -> int:
 
 def _sender_email() -> str:
     """Return the from address used for verification emails."""
-    return settings.EMAIL_HOST_USER
+    return (
+        (getattr(settings, "DEFAULT_FROM_EMAIL", "") or "").strip()
+        or (getattr(settings, "EMAIL_HOST_USER", "") or "").strip()
+    )
+
+
+def _reply_to_list() -> list[str] | None:
+    """Return a normalized reply-to list for outbound auth emails."""
+    reply_to = (getattr(settings, "EMAIL_REPLY_TO", "") or "").strip()
+    return [reply_to] if reply_to else None
 
 
 def _summarize_password_errors(messages: list[str]) -> str:
@@ -449,9 +458,8 @@ def signup(request: HttpRequest) -> HttpResponse:
                 recipient_name=values.get("first_name", ""),
             )
 
-            from_email = settings.EMAIL_HOST_USER
-            reply_to = getattr(settings, "EMAIL_REPLY_TO", None)
-            reply_to_list = [reply_to] if reply_to else None
+            from_email = _sender_email()
+            reply_to_list = _reply_to_list()
 
             try:
                 email_message = EmailMessage(
@@ -503,9 +511,8 @@ def signup(request: HttpRequest) -> HttpResponse:
                 recipient_name=values.get("first_name", ""),
             )
 
-            from_email = settings.EMAIL_HOST_USER
-            reply_to = getattr(settings, "EMAIL_REPLY_TO", None)
-            reply_to_list = [reply_to] if reply_to else None
+            from_email = _sender_email()
+            reply_to_list = _reply_to_list()
 
             try:
                 email_message = EmailMessage(

--- a/cytocv/cytocv/settings.py
+++ b/cytocv/cytocv/settings.py
@@ -382,19 +382,19 @@ EMAIL_BACKEND = (_get_env(
     "django.core.mail.backends.smtp.EmailBackend",
     prefer_env_file=True,
 ) or "").strip() or "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_HOST = _get_env("CYTOCV_EMAIL_HOST", "smtp.gmail.com", prefer_env_file=True)
-EMAIL_HOST_USER = _get_env(
+EMAIL_HOST = (_get_env("CYTOCV_EMAIL_HOST", "127.0.0.1", prefer_env_file=True) or "").strip()
+EMAIL_HOST_USER = (_get_env(
     "CYTOCV_EMAIL_HOST_USER",
-    "cytocv@gmail.com",
+    "",
     prefer_env_file=True,
-)
-EMAIL_HOST_PASSWORD = _get_env(
+) or "").strip()
+EMAIL_HOST_PASSWORD = (_get_env(
     "CYTOCV_EMAIL_HOST_PASSWORD",
     "",
     prefer_env_file=True,
-)
-EMAIL_PORT = _parse_env_int("CYTOCV_EMAIL_PORT", 587, prefer_env_file=True)
-EMAIL_USE_TLS = _parse_env_bool("CYTOCV_EMAIL_USE_TLS", True, prefer_env_file=True)
+) or "").strip()
+EMAIL_PORT = _parse_env_int("CYTOCV_EMAIL_PORT", 25, prefer_env_file=True)
+EMAIL_USE_TLS = _parse_env_bool("CYTOCV_EMAIL_USE_TLS", False, prefer_env_file=True)
 EMAIL_USE_SSL = _parse_env_bool("CYTOCV_EMAIL_USE_SSL", False, prefer_env_file=True)
 if EMAIL_USE_TLS and EMAIL_USE_SSL:
     raise ImproperlyConfigured(
@@ -406,16 +406,23 @@ EMAIL_TIMEOUT = (
     if _email_timeout_raw
     else None
 )
-DEFAULT_FROM_EMAIL = _get_env(
+_default_from_email = (_get_env(
     "CYTOCV_DEFAULT_FROM_EMAIL",
-    "no-reply@noreply.x.edu",
+    "",
     prefer_env_file=True,
-)
-EMAIL_REPLY_TO = _get_env(
+) or "").strip()
+DEFAULT_FROM_EMAIL = _default_from_email or EMAIL_HOST_USER
+EMAIL_REPLY_TO = ((_get_env(
     "CYTOCV_EMAIL_REPLY_TO",
-    "no-reply@noreply.x.edu",
+    "",
     prefer_env_file=True,
-)
+) or "").strip()) or DEFAULT_FROM_EMAIL
+
+if ACCOUNT_EMAIL_VERIFICATION != "none" and not DEFAULT_FROM_EMAIL:
+    raise ImproperlyConfigured(
+        "Configure CYTOCV_DEFAULT_FROM_EMAIL or CYTOCV_EMAIL_HOST_USER "
+        "when email verification is enabled."
+    )
 
 # Google reCAPTCHA
 RECAPTCHA_ENABLED = os.getenv("CYTOCV_RECAPTCHA_ENABLED", "0") == "1"

--- a/docs/ops/environment-reference.md
+++ b/docs/ops/environment-reference.md
@@ -152,14 +152,14 @@ This document is the authoritative reference for environment variables consumed 
 
 - Required: no
 - Type: string
-- Default: `smtp.gmail.com`
+- Default: `127.0.0.1`
 - Effect: SMTP host
 
 ### `CYTOCV_EMAIL_HOST_USER`
 
 - Required: no
 - Type: string
-- Default: `cytocv@gmail.com` in settings fallback
+- Default: empty
 - Effect: SMTP username
 
 ### `CYTOCV_EMAIL_HOST_PASSWORD`
@@ -173,14 +173,14 @@ This document is the authoritative reference for environment variables consumed 
 
 - Required: no
 - Type: integer
-- Default: `587`
+- Default: `25`
 - Effect: SMTP port
 
 ### `CYTOCV_EMAIL_USE_TLS`
 
 - Required: no
 - Type: boolean-like string
-- Default: `1`
+- Default: `0`
 - Effect: enables TLS
 - Notes: cannot be enabled together with `CYTOCV_EMAIL_USE_SSL`
 
@@ -202,14 +202,14 @@ This document is the authoritative reference for environment variables consumed 
 
 - Required: no
 - Type: string
-- Default: `no-reply@noreply.x.edu`
+- Default: empty, then falls back to `CYTOCV_EMAIL_HOST_USER`
 - Effect: default sender
 
 ### `CYTOCV_EMAIL_REPLY_TO`
 
 - Required: no
 - Type: string
-- Default: `no-reply@noreply.x.edu`
+- Default: empty, then falls back to `CYTOCV_DEFAULT_FROM_EMAIL`
 - Effect: reply-to address
 
 ## reCAPTCHA Settings

--- a/docs/vm-deployment-guide/README.md
+++ b/docs/vm-deployment-guide/README.md
@@ -157,16 +157,16 @@ CYTOCV_MICROSOFT_CLIENT_SECRET=
 CYTOCV_MICROSOFT_TENANT=organizations
 CYTOCV_MICROSOFT_LOGIN_URL=https://login.microsoftonline.com
 CYTOCV_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
-CYTOCV_EMAIL_HOST=smtp.gmail.com
+CYTOCV_EMAIL_HOST=127.0.0.1
 CYTOCV_EMAIL_HOST_USER=
 CYTOCV_EMAIL_HOST_PASSWORD=
-CYTOCV_EMAIL_PORT=587
-CYTOCV_EMAIL_USE_TLS=1
+CYTOCV_EMAIL_PORT=25
+CYTOCV_EMAIL_USE_TLS=0
 CYTOCV_EMAIL_USE_SSL=0
-CYTOCV_EMAIL_TIMEOUT=
+CYTOCV_EMAIL_TIMEOUT=30
 CYTOCV_ACCOUNT_EMAIL_VERIFICATION=optional
-CYTOCV_DEFAULT_FROM_EMAIL=no-reply@cytocv.uwb.edu
-CYTOCV_EMAIL_REPLY_TO=no-reply@cytocv.uwb.edu
+CYTOCV_DEFAULT_FROM_EMAIL=cytocv@uw.edu
+CYTOCV_EMAIL_REPLY_TO=cytocv@uw.edu
 CYTOCV_RECAPTCHA_ENABLED=1
 CYTOCV_RECAPTCHA_SITE_KEY=
 CYTOCV_RECAPTCHA_SECRET_KEY=
@@ -520,25 +520,25 @@ If SMTP is not ready yet, keep:
 
 ```env
 CYTOCV_ACCOUNT_EMAIL_VERIFICATION=optional
-CYTOCV_DEFAULT_FROM_EMAIL=no-reply@cytocv.uwb.edu
-CYTOCV_EMAIL_REPLY_TO=no-reply@cytocv.uwb.edu
+CYTOCV_DEFAULT_FROM_EMAIL=cytocv@uw.edu
+CYTOCV_EMAIL_REPLY_TO=cytocv@uw.edu
 ```
 
 Do not set `mandatory` until you have:
 
 - an approved sender address
-- SMTP host
-- SMTP port
-- TLS/SSL requirements
-- service account username
-- SMTP password or app password
+- either local Postfix relay on the VM or direct SMTP settings
+- any SMTP credential required by the relay you are using
 
-Once UW IT provides those, update:
+For the local Postfix relay setup, keep Django on localhost and configure Postfix separately:
 
 ```env
-CYTOCV_EMAIL_HOST=<smtp host>
-CYTOCV_EMAIL_HOST_USER=<smtp username>
-CYTOCV_EMAIL_HOST_PASSWORD=<smtp password>
+CYTOCV_EMAIL_HOST=127.0.0.1
+CYTOCV_EMAIL_HOST_USER=
+CYTOCV_EMAIL_HOST_PASSWORD=
+CYTOCV_EMAIL_PORT=25
+CYTOCV_EMAIL_USE_TLS=0
+CYTOCV_EMAIL_USE_SSL=0
 CYTOCV_ACCOUNT_EMAIL_VERIFICATION=mandatory
 ```
 


### PR DESCRIPTION
Separates visible sender addresses from SMTP authentication in auth emails, removes Gmail-style fallback defaults, adds regression coverage for sender selection, and updates env/docs for production SMTP configuration.