### PR TITLE
Adjust contour detection across mCherry, GFP, and DAPI and add alternate mCherry detection mode fixes #118 fixes #120

### DIFF
--- a/cytocv/accounts/preferences.py
+++ b/cytocv/accounts/preferences.py
@@ -29,6 +29,7 @@ DEFAULT_USER_PREFERENCES: dict[str, Any] = {
         "gfp_threshold": 66,
         "nuclear_cellular_mode": "green_nucleus",
         "gfp_filter_enabled": False,
+        "alternate_mcherry_detection": False,
         "mcherry_width_unit": "px",
         "gfp_distance_unit": "px",
         "microns_per_pixel": DEFAULT_MICRONS_PER_PIXEL,
@@ -115,6 +116,9 @@ def normalize_preferences_payload(raw_payload: Any) -> dict[str, Any]:
     )
     normalized["experiment_defaults"]["gfp_filter_enabled"] = _as_bool(
         defaults_payload.get("gfp_filter_enabled"), default=False
+    )
+    normalized["experiment_defaults"]["alternate_mcherry_detection"] = _as_bool(
+        defaults_payload.get("alternate_mcherry_detection"), default=False
     )
 
     raw_required_channels = defaults_payload.get("manual_required_channels", [])

--- a/cytocv/accounts/views/profile.py
+++ b/cytocv/accounts/views/profile.py
@@ -972,6 +972,7 @@ def preferences_view(request: HttpRequest) -> HttpResponse:
             enforce_wavelengths = _post_bool(request, "enforce_wavelengths")
             show_legacy_plugins = _post_bool(request, "show_legacy_plugins")
             gfp_filter_enabled = _post_bool(request, "gfp_filter_enabled")
+            alternate_mcherry_detection = _post_bool(request, "alternate_mcherry_detection")
             manual_required_channels = [
                 channel
                 for channel in request.POST.getlist("manual_required_channels")
@@ -1006,6 +1007,7 @@ def preferences_view(request: HttpRequest) -> HttpResponse:
                     "show_legacy_plugins": show_legacy_plugins,
                     "manual_required_channels": manual_required_channels,
                     "gfp_filter_enabled": gfp_filter_enabled,
+                    "alternate_mcherry_detection": alternate_mcherry_detection,
                 }
             )
             next_defaults.update(measurement_defaults)

--- a/cytocv/core/cell_analysis/Analysis.py
+++ b/cytocv/core/cell_analysis/Analysis.py
@@ -21,5 +21,5 @@ class Analysis:
         self.output_dir = output_dir
 
     @abstractmethod
-    def calculate_statistics(self, best_contours, contours_data,red_image, green_image,mcherry_line_width_input, gfp_distance, gfp_threshold):
+    def calculate_statistics(self, best_contours, contours_data, red_image, green_image, mcherry_line_width_input, gfp_distance, gfp_threshold):
         pass

--- a/cytocv/core/cell_analysis/dapi_nucleus_intensity.py
+++ b/cytocv/core/cell_analysis/dapi_nucleus_intensity.py
@@ -10,7 +10,7 @@ from core.image_processing import calculate_intensity_mask
 
 class DAPI_NucleusIntensity(Analysis):
     name = "DAPI_NucleusIntensity"
-    def calculate_statistics(self, best_contours, contours_data,red_image=None, green_image=None,mcherry_line_width_input=None, gfp_distance=0, gfp_threshold=66):
+    def calculate_statistics(self, best_contours, contours_data,red_image=None, green_image=None, mcherry_line_width_input=None, gfp_distance=0, gfp_threshold=66):
         """
             This function calculate the nucleus intensity within a green image
             :param best_contour: Contours data contain best contours for DAPI

--- a/cytocv/core/contour_processing/contour_operations.py
+++ b/cytocv/core/contour_processing/contour_operations.py
@@ -6,7 +6,7 @@ import scipy.ndimage as ndi
 from skimage.segmentation import watershed
 from skimage.feature import peak_local_max
 
-def find_contours(images:GrayImage, gfp_filter_enabled=False):
+def find_contours(images:GrayImage, gfp_filter_enabled=False, alternate_mcherry_detection=False):
     """
     This function finds contours in an image and returns them as a numpy array.
     :param images: Gray scale image list
@@ -19,73 +19,111 @@ def find_contours(images:GrayImage, gfp_filter_enabled=False):
     gray_gfp = images.get_image('GFP')
 
     dot_contours = []
-    if gray_mcherry_3 is not None:
-        # Use a two-step process with Otsu thresholding to tighten the contours
-        low_val, _ = cv2.threshold(
-            gray_mcherry_3,
-            0.65,
-            255,
-            cv2.THRESH_BINARY + cv2.THRESH_OTSU,
-        )
-        _, bright_thresh = cv2.threshold(
-            gray_mcherry_3,
-            low_val + 11,
-            255,
-            cv2.THRESH_BINARY,
-        )
-        # _, bright_thresh = cv2.threshold(
-        #     gray_mcherry_3,
-        #     0.65,
-        #     255,
-        #     cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU,
-        # )
-        dot_contours, _ = cv2.findContours(bright_thresh, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
-        dot_contours = [cnt for cnt in dot_contours if cv2.contourArea(cnt) < 100]  # remove border contour
-
-    # finding threshold
-    # ret_mcherry, thresh_mcherry = cv2.threshold(images.get_image('gray_mcherry_3'), 0, 1,
-    #                                             cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU)
-    # ret, thresh = cv2.threshold(images.get_image('gray_mcherry'), 0, 1,
-    #                             cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU)
-
-    thresh_mcherry = None
-    thresh = None
     contours = []
     contours_mcherry = []
     bestContours = []
     bestContours_mcherry = []
-    if gray_mcherry_3 is not None and gray_mcherry is not None:
-        thresh_mcherry = cv2.Canny(gray_mcherry_3, 50, 150)
-        # TODO: thresh seems to always be empty; are thresh and thresh_mcherry even being used?
-        thresh = cv2.Canny(gray_mcherry, 50, 150)
-
-        # Try again with less restrictive thresholding if nothing was found
-        if np.max(thresh) == 0:
-            # _, thresh_mcherry = cv2.threshold(
+    if not alternate_mcherry_detection:
+        if gray_mcherry_3 is not None:
+            # Use a two-step process with Otsu thresholding to tighten the contours
+            low_val, _ = cv2.threshold(
+                gray_mcherry_3,
+                0.65,
+                255,
+                cv2.THRESH_BINARY + cv2.THRESH_OTSU,
+            )
+            _, bright_thresh = cv2.threshold(
+                gray_mcherry_3,
+                low_val + 11,
+                255,
+                cv2.THRESH_BINARY,
+            )
+            # _, bright_thresh = cv2.threshold(
             #     gray_mcherry_3,
-            #     0,
-            #     1,
-            #     cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU,
+            #     0.65,
+            #     255,
+            #     cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU,
             # )
+            dot_contours, _ = cv2.findContours(bright_thresh, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+            dot_contours = [cnt for cnt in dot_contours if cv2.contourArea(cnt) < 100]  # remove border contour
+
+        # finding threshold
+        # ret_mcherry, thresh_mcherry = cv2.threshold(images.get_image('gray_mcherry_3'), 0, 1,
+        #                                             cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU)
+        # ret, thresh = cv2.threshold(images.get_image('gray_mcherry'), 0, 1,
+        #                             cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU)
+
+        thresh_mcherry = None
+        thresh = None
+        contours = []
+        contours_mcherry = []
+        bestContours = []
+        bestContours_mcherry = []
+        if gray_mcherry_3 is not None and gray_mcherry is not None:
+            thresh_mcherry = cv2.Canny(gray_mcherry_3, 50, 150)
+            # TODO: thresh seems to always be empty; are thresh and thresh_mcherry even being used?
+            thresh = cv2.Canny(gray_mcherry, 50, 150)
+
+            # Try again with less restrictive thresholding if nothing was found
+            if np.max(thresh) == 0:
+                # _, thresh_mcherry = cv2.threshold(
+                #     gray_mcherry_3,
+                #     0,
+                #     1,
+                #     cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU,
+                # )
+                _, thresh = cv2.threshold(
+                    gray_mcherry,
+                    0,
+                    1,
+                    cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU,
+                )
+            
+            if np.max(thresh_mcherry) == 0:
+                _, thresh_mcherry = cv2.threshold(
+                    gray_mcherry_3,
+                    0,
+                    1,
+                    cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU,
+                )
+
+            contours, _ = cv2.findContours(thresh, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+            contours_mcherry, _ = cv2.findContours(thresh_mcherry, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+            bestContours = get_largest(contours)
+            bestContours_mcherry = get_largest(contours_mcherry)
+    else:
+        # Alternate mCherry detection mode where we try to find one contour that surrounds all the speckles
+        gray_mcherry_3 = cv2.GaussianBlur(gray_mcherry_3, (9, 9), 0)
+        if gray_mcherry_3 is not None:
+            _, bright_thresh = cv2.threshold(
+                gray_mcherry_3,
+                3,
+                255,
+                cv2.THRESH_BINARY,
+            )
+            dot_contours, _ = cv2.findContours(bright_thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+            # dot_contours = [cnt for cnt in dot_contours if cv2.contourArea(cnt) < 100]  # remove border contour
+
+        thresh_mcherry = None
+        thresh = None
+        contours = []
+        contours_mcherry = []
+        bestContours = []
+        bestContours_mcherry = []
+        if gray_mcherry_3 is not None and gray_mcherry is not None:
             _, thresh = cv2.threshold(
                 gray_mcherry,
-                0,
-                1,
-                cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU,
+                5,
+                255,
+                cv2.THRESH_BINARY,
             )
-        
-        if np.max(thresh_mcherry) == 0:
-            _, thresh_mcherry = cv2.threshold(
-                gray_mcherry_3,
-                0,
-                1,
-                cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU,
-            )
+            
+            thresh_mcherry = bright_thresh
 
-        contours, _ = cv2.findContours(thresh, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
-        contours_mcherry, _ = cv2.findContours(thresh_mcherry, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
-        bestContours = get_largest(contours)
-        bestContours_mcherry = get_largest(contours_mcherry)
+            contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+            contours_mcherry, _ = cv2.findContours(thresh_mcherry, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+            bestContours = get_largest(contours)
+            bestContours_mcherry = get_largest(contours_mcherry)
 
     # finding threshold
     # ret_dapi_3, thresh_dapi_3 = cv2.threshold(images.get_image('gray_dapi_3'), 0, 1,

--- a/cytocv/core/contour_processing/contour_operations.py
+++ b/cytocv/core/contour_processing/contour_operations.py
@@ -20,7 +20,7 @@ def find_contours(images:GrayImage, gfp_filter_enabled=False):
 
     dot_contours = []
     if gray_mcherry_3 is not None:
-        # Use a two-step process with the Otsu thresholding to tighten the contours, also 
+        # Use a two-step process with Otsu thresholding to tighten the contours
         low_val, _ = cv2.threshold(
             gray_mcherry_3,
             0.65,
@@ -39,7 +39,7 @@ def find_contours(images:GrayImage, gfp_filter_enabled=False):
         #     255,
         #     cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU,
         # )
-        dot_contours, _ = cv2.findContours(bright_thresh, 1, 2)
+        dot_contours, _ = cv2.findContours(bright_thresh, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
         dot_contours = [cnt for cnt in dot_contours if cv2.contourArea(cnt) < 100]  # remove border contour
 
     # finding threshold
@@ -82,8 +82,8 @@ def find_contours(images:GrayImage, gfp_filter_enabled=False):
                 cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU,
             )
 
-        contours, _ = cv2.findContours(thresh, cv2.RETR_LIST, 2)
-        contours_mcherry, _ = cv2.findContours(thresh_mcherry, cv2.RETR_LIST, 2)
+        contours, _ = cv2.findContours(thresh, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+        contours_mcherry, _ = cv2.findContours(thresh_mcherry, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
         bestContours = get_largest(contours)
         bestContours_mcherry = get_largest(contours_mcherry)
 
@@ -100,7 +100,7 @@ def find_contours(images:GrayImage, gfp_filter_enabled=False):
     bestContours_dapi = []
     bestContours_dapi_3 = []
     if gray_dapi_3 is not None and gray_dapi is not None:
-        # TODO: Work-in-progress hybrid Otsu/Canny solution, at present seemingly still worse than Canny alone
+        # NOTE: Hybrid Canny-Otsu
         # blur_3 = cv2.GaussianBlur(gray_dapi_3, (5, 5), 0)
         # blur = cv2.GaussianBlur(gray_dapi, (5, 5), 0)
 
@@ -113,19 +113,48 @@ def find_contours(images:GrayImage, gfp_filter_enabled=False):
         # thresh_dapi_3 = cv2.Canny(blur_3, low_thresh_3, thresh_dapi_3)
         # thresh_dapi = cv2.Canny(blur, low_thresh, thresh_dapi)
 
-        thresh_dapi_3 = cv2.Canny(gray_dapi_3, 60, 70)
-        thresh_dapi = cv2.Canny(gray_dapi, 60, 70)
+        # NOTE: Canny
+        # thresh_dapi_3 = cv2.Canny(gray_dapi_3, 60, 70)
+        # thresh_dapi = cv2.Canny(gray_dapi, 60, 70)
 
-        # TODO: Best kernel for closing so far, but better probably exists
-        kernel = np.ones((3, 3), np.uint8)
-        thresh_dapi_3 = cv2.morphologyEx(thresh_dapi_3, cv2.MORPH_CLOSE, kernel)
-        thresh_dapi = cv2.morphologyEx(thresh_dapi, cv2.MORPH_CLOSE, kernel)
+        # # TODO: Best kernel for closing so far, but better probably exists
+        # kernel = np.ones((3, 3), np.uint8)
+        # thresh_dapi_3 = cv2.morphologyEx(thresh_dapi_3, cv2.MORPH_CLOSE, kernel)
+        # thresh_dapi = cv2.morphologyEx(thresh_dapi, cv2.MORPH_CLOSE, kernel)
 
-        contours_dapi, _ = cv2.findContours(thresh_dapi, cv2.RETR_LIST, 2)
-        contours_dapi_3, _ = cv2.findContours(thresh_dapi_3, cv2.RETR_LIST, 2)
-        contours_dapi_3 = [
-            cnt for cnt in contours_dapi_3 if cv2.contourArea(cnt) > 100 #and cv2.contourArea(cnt) < 1000
-        ]
+        # Use a two-step process with Otsu thresholding
+        low_val, _ = cv2.threshold(
+            gray_dapi,
+            0.65,
+            255,
+            cv2.THRESH_BINARY + cv2.THRESH_OTSU,
+        )
+        _, thresh_dapi = cv2.threshold(
+            gray_dapi,
+            low_val + 20,
+            255,
+            cv2.THRESH_BINARY,
+        )
+
+        low_val, _ = cv2.threshold(
+            gray_dapi_3,
+            0.65,
+            255,
+            cv2.THRESH_BINARY + cv2.THRESH_OTSU,
+        )
+        _, thresh_dapi_3 = cv2.threshold(
+            gray_dapi_3,
+            low_val + 17,
+            255,
+            cv2.THRESH_BINARY,
+        )
+
+        contours_dapi, _ = cv2.findContours(thresh_dapi, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+        contours_dapi_3, _ = cv2.findContours(thresh_dapi_3, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+        # contours_dapi_3 = [
+        #     cnt for cnt in contours_dapi_3 if cv2.contourArea(cnt) > 100 #and cv2.contourArea(cnt) < 1000
+        # ]
+        # TODO: Should get_largest be changed to get the highest intensity instead of the largest area? Or perhaps some combination of both?
         bestContours_dapi = get_largest(contours_dapi)
         bestContours_dapi_3 = get_largest(contours_dapi_3) if contours_dapi_3 else []
 
@@ -134,7 +163,7 @@ def find_contours(images:GrayImage, gfp_filter_enabled=False):
         thresh_gfp = cv2.Canny(gray_gfp, 50, 150)
         kernel = cv2.getStructuringElement(cv2.MORPH_CROSS, (3, 3))
         thresh_gfp = cv2.morphologyEx(thresh_gfp, cv2.MORPH_CLOSE, kernel)
-        contours_gfp, _ = cv2.findContours(thresh_gfp, cv2.RETR_LIST, 2)
+        contours_gfp, _ = cv2.findContours(thresh_gfp, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
         if gfp_filter_enabled:
             contours_gfp = filterContours(contours_gfp)     # NOTE: If you notice cells where "obvious" green dots are missing, this is likely to blame
 

--- a/cytocv/core/contour_processing/contour_operations.py
+++ b/cytocv/core/contour_processing/contour_operations.py
@@ -20,12 +20,25 @@ def find_contours(images:GrayImage, gfp_filter_enabled=False):
 
     dot_contours = []
     if gray_mcherry_3 is not None:
-        _, bright_thresh = cv2.threshold(
+        # Use a two-step process with the Otsu thresholding to tighten the contours, also 
+        low_val, _ = cv2.threshold(
             gray_mcherry_3,
             0.65,
-            1,
-            cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU,
+            255,
+            cv2.THRESH_BINARY + cv2.THRESH_OTSU,
         )
+        _, bright_thresh = cv2.threshold(
+            gray_mcherry_3,
+            low_val + 11,
+            255,
+            cv2.THRESH_BINARY,
+        )
+        # _, bright_thresh = cv2.threshold(
+        #     gray_mcherry_3,
+        #     0.65,
+        #     255,
+        #     cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU,
+        # )
         dot_contours, _ = cv2.findContours(bright_thresh, 1, 2)
         dot_contours = [cnt for cnt in dot_contours if cv2.contourArea(cnt) < 100]  # remove border contour
 
@@ -43,18 +56,27 @@ def find_contours(images:GrayImage, gfp_filter_enabled=False):
     bestContours_mcherry = []
     if gray_mcherry_3 is not None and gray_mcherry is not None:
         thresh_mcherry = cv2.Canny(gray_mcherry_3, 50, 150)
+        # TODO: thresh seems to always be empty; are thresh and thresh_mcherry even being used?
         thresh = cv2.Canny(gray_mcherry, 50, 150)
 
         # Try again with less restrictive thresholding if nothing was found
         if np.max(thresh) == 0:
-            _, thresh_mcherry = cv2.threshold(
-                gray_mcherry_3,
+            # _, thresh_mcherry = cv2.threshold(
+            #     gray_mcherry_3,
+            #     0,
+            #     1,
+            #     cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU,
+            # )
+            _, thresh = cv2.threshold(
+                gray_mcherry,
                 0,
                 1,
                 cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU,
             )
-            _, thresh = cv2.threshold(
-                gray_mcherry,
+        
+        if np.max(thresh_mcherry) == 0:
+            _, thresh_mcherry = cv2.threshold(
+                gray_mcherry_3,
                 0,
                 1,
                 cv2.ADAPTIVE_THRESH_GAUSSIAN_C | cv2.THRESH_OTSU,

--- a/cytocv/core/contour_processing/contour_operations.py
+++ b/cytocv/core/contour_processing/contour_operations.py
@@ -160,7 +160,22 @@ def find_contours(images:GrayImage, gfp_filter_enabled=False):
 
     contours_gfp = []
     if gray_gfp is not None:
-        thresh_gfp = cv2.Canny(gray_gfp, 50, 150)
+        # gray_gfp = cv2.GaussianBlur(gray_gfp, (3, 3), 0)
+        # thresh_gfp = cv2.Canny(gray_gfp, 50, 150)
+        
+        # Use two-step Otsu process to recognize more signals -- can use the optional filtering to get rid of extra if too much is found
+        low_val, _ = cv2.threshold(
+            gray_gfp,
+            0.65,
+            255,
+            cv2.THRESH_BINARY + cv2.THRESH_OTSU,
+        )
+        _, thresh_gfp = cv2.threshold(
+            gray_gfp,
+            low_val + 13,
+            255,
+            cv2.THRESH_BINARY,
+        )
         kernel = cv2.getStructuringElement(cv2.MORPH_CROSS, (3, 3))
         thresh_gfp = cv2.morphologyEx(thresh_gfp, cv2.MORPH_CLOSE, kernel)
         contours_gfp, _ = cv2.findContours(thresh_gfp, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)

--- a/cytocv/core/tests/test_accounts_preferences.py
+++ b/cytocv/core/tests/test_accounts_preferences.py
@@ -1369,6 +1369,10 @@ class ChannelVisibilityPreferenceTests(TestCase):
             response,
             "Filter out low-confidence GFP signal contours in challenging images.",
         )
+        self.assertContains(
+            response,
+            "Utilize an alternate mCherry detection mode where the tool attempts to find a single contour to surround all speckles.",
+        )
         self.assertContains(response, 'id="reviewChangesBackdrop"', html=False)
         self.assertContains(response, 'class="review-backdrop popup-backdrop"', html=False)
         self.assertContains(response, 'class="review-modal popup-surface"', html=False)

--- a/cytocv/core/views/experiment.py
+++ b/cytocv/core/views/experiment.py
@@ -314,6 +314,7 @@ def experiment(request):
             gfp_threshold = 66
 
         gfp_filter_enabled = request.POST.get("gfpFilterEnabled", False)
+        alternate_mcherry_detection = request.POST.get("alternateMCherryDetection", False)
 
         # Persist user analysis choices now so preprocess step no longer owns selection.
         request.session["selected_analysis"] = requirement_summary["selected_plugins"]
@@ -331,6 +332,7 @@ def experiment(request):
             default="green_nucleus",
         )
         request.session["gfpFilterEnabled"] = gfp_filter_enabled
+        request.session["alternateMCherryDetection"] = alternate_mcherry_detection
 
         module_enabled = _parse_bool(request.POST.get("cytocv_analysis_enabled"), default=False)
         enforce_layer_count = module_enabled and _parse_bool(

--- a/cytocv/core/views/pre_process.py
+++ b/cytocv/core/views/pre_process.py
@@ -295,6 +295,8 @@ def pre_process(request, uuids):
             nuclear_cellular_mode = "green_nucleus"
         gfp_filter_enabled_raw = request.POST.get('gfpFilterEnabled', request.session.get('gfpFilterEnabled', 'False'))
         gfp_filter_enabled = gfp_filter_enabled_raw == 'true'
+        alternate_mcherry_detection_raw = request.POST.get('alternateMCherryDetection', request.session.get('alternateMCherryDetection', 'False'))
+        alternate_mcherry_detection = alternate_mcherry_detection_raw == 'true'
         try:
             mcherry_width = int(mcherry_width_raw)
         except (TypeError, ValueError):
@@ -320,6 +322,7 @@ def pre_process(request, uuids):
         request.session['threshold'] = gfp_threshold
         request.session["nuclear_cellular_mode"] = nuclear_cellular_mode
         request.session['gfpFilterEnabled'] = gfp_filter_enabled
+        request.session['alternateMCherryDetection'] = alternate_mcherry_detection
 
         # Track when we first enter phases to mark progress once
         preprocess_marked = False

--- a/cytocv/core/views/segment_image.py
+++ b/cytocv/core/views/segment_image.py
@@ -161,6 +161,7 @@ def get_stats(
     gfp_distance,
     gfp_threshold,
     gfp_filter_enabled=False,
+    alternate_mcherry_detection=False,
     cached_images=None,
 ):
     # loading configuration
@@ -207,7 +208,7 @@ def get_stats(
         return Image.fromarray(edit_testing_rgb), Image.fromarray(edit_GFP_img_rgb), Image.fromarray(edit_DAPI_img_rgb)
 
     preprocessed_images = preprocess_image_to_gray(images, kernel_deviation_input, kernel_size_input)
-    contours_data = find_contours(preprocessed_images, gfp_filter_enabled)
+    contours_data = find_contours(preprocessed_images, gfp_filter_enabled, alternate_mcherry_detection)
 
     best_contour_data = {}
     best_contour_dapi = None
@@ -1009,6 +1010,7 @@ def segment_image(request, uuids):
         if gfp_threshold < 0:
             gfp_threshold = 66
         gfp_filter_enabled = request.session.get('gfpFilterEnabled', 'False')
+        alternate_mcherry_detection = request.session.get('alternateMCherryDetection', 'False')
 
         # Build a proper 'conf' dict with required keys for get_stats
         conf = {
@@ -1021,6 +1023,7 @@ def segment_image(request, uuids):
             'analysis' : selected_analysis,
             'nuclear_cellular_mode': request.session.get("nuclear_cellular_mode", "green_nucleus"),
             'gfp_filter_enabled': request.session.get("gfpFilterEnabled", "False"),
+            'alternate_mcherry_detection': request.session.get("alternateMCherryDetection", "False"),
         }
 
         if cancelled():
@@ -1087,6 +1090,7 @@ def segment_image(request, uuids):
                 gfp_distance,
                 gfp_threshold,
                 gfp_filter_enabled,
+                alternate_mcherry_detection,
                 cached_images=cell_image_cache.get(cell_number),
             )
 

--- a/cytocv/templates/form/experiment.html
+++ b/cytocv/templates/form/experiment.html
@@ -1587,6 +1587,24 @@
                             <span class="slider"></span>
                         </label>
                     </div>
+                    <div class="toggle-row" id="alternateMCherryRow">
+                        <div class="toggle-text">
+                            <span class="toggle-label-row">
+                                <span class="toggle-label">Enable Alternate mCherry Detection</span>
+                                <button
+                                    type="button"
+                                    class="info-dot compact advanced-info-dot"
+                                    id="alternateMCherryInfoDot"
+                                    data-info-text="Utilize an alternate mCherry detection mode where the tool attempts to find a single contour to surround all speckles."
+                                    aria-label="Utilize an alternate mCherry detection mode where the tool attempts to find a single contour to surround all speckles."
+                                >i</button>
+                            </span>
+                        </div>
+                        <label class="switch">
+                            <input type="checkbox" id="alternateMCherryDetection">
+                            <span class="slider"></span>
+                        </label>
+                    </div>
                     <div class="toggle-row" id="moduleToggleRow">
                         <div class="toggle-text">
                             <span class="toggle-label-row">
@@ -1839,6 +1857,7 @@
         gfpThreshold: 66,
         nuclearCellularMode: 'green_nucleus',
         gfpFilterEnabled: false,
+        alternateMCherryDetection: false,
         mCherryWidthUnit: 'px',
         gfpDistanceUnit: 'px',
         micronsPerPixel: DEFAULT_MICRONS_PER_PIXEL,
@@ -1886,6 +1905,7 @@
             showLegacyPlugins: !!serverPreferenceDefaults.show_legacy_plugins,
             manualRequiredChannels: manualChannels,
             gfpFilterEnabled: !!serverPreferenceDefaults.gfp_filter_enabled,
+            alternateMCherryDetection: !!serverPreferenceDefaults.alternate_mcherry_detection,
         };
         localStorage.setItem(advancedKey, JSON.stringify(advancedPayload));
 
@@ -3157,6 +3177,7 @@
         });
 
         const gfpFilterEnabled = document.getElementById('gfpFilterEnabled');
+        const alternateMCherryDetection = document.getElementById('alternateMCherryDetection');
         const moduleToggle = document.getElementById('cytocvAnalysisEnabled');
         const layerToggle = document.getElementById('enforceLayerCount');
         const wavelengthToggle = document.getElementById('enforceWavelengths');
@@ -3164,6 +3185,13 @@
         if (gfpFilterEnabled) {
             gfpFilterEnabled.addEventListener('change', () => {
                 statsState.gfpFilterEnabled = gfpFilterEnabled.checked;
+                persistAdvancedSettings();
+                syncStatsUI();
+            });
+        }
+        if (alternateMCherryDetection) {
+            alternateMCherryDetection.addEventListener('change', () => {
+                statsState.alternateMCherryDetection = alternateMCherryDetection.checked;
                 persistAdvancedSettings();
                 syncStatsUI();
             });
@@ -3244,6 +3272,7 @@
         }
 
         statsState.gfpFilterEnabled = typeof stored.gfpFilterEnabled === 'boolean' ? stored.gfpFilterEnabled : false;
+        statsState.alternateMCherryDetection = typeof stored.alternateMCherryDetection === 'boolean' ? stored.alternateMCherryDetection : false;
         statsState.moduleEnabled = typeof stored.moduleEnabled === 'boolean' ? stored.moduleEnabled : false;
         statsState.enforceLayerCount = typeof stored.enforceLayerCount === 'boolean' ? stored.enforceLayerCount : false;
         statsState.enforceAllWavelengths = typeof stored.enforceAllWavelengths === 'boolean' ? stored.enforceAllWavelengths : false;
@@ -3314,6 +3343,7 @@
             showLegacyPlugins: !!statsState.showLegacyPlugins,
             manualRequiredChannels: [...statsState.manualRequiredChannels],
             gfpFilterEnabled: !!statsState.gfpFilterEnabled,
+            alternateMCherryDetection: !!statsState.alternateMCherryDetection,
         }));
     }
 
@@ -3396,7 +3426,9 @@
         const wavelengthRow = document.getElementById('wavelengthCheckRow');
         const optionalChecksNote = document.getElementById('optionalChecksNote');
         const gfpFilterEnabled = document.getElementById('gfpFilterEnabled');
+        const alternateMCherryDetection = document.getElementById('alternateMCherryDetection');
         const gfpFilterRow = document.getElementById('gfpFilterRow');
+        const alternateMCherryRow = document.getElementById('alternateMCherryRow');
 
         statToggleElements.forEach((toggle, pluginId) => {
             toggle.checked = statsState.selectedPlugins.has(pluginId);
@@ -3443,6 +3475,18 @@
                 gfpFilterRow.classList.add('disabled');
                 gfpFilterEnabled.checked = false;
                 statsState.gfpFilterEnabled = gfpFilterEnabled.checked;
+            }
+        }
+        if (alternateMCherryDetection) {
+            alternateMCherryDetection.checked = !!statsState.alternateMCherryDetection;
+            const mCherryUsed = isChannelUsed('mCherry');
+            alternateMCherryDetection.disabled = !mCherryUsed;
+            if (mCherryUsed) {
+                alternateMCherryRow.classList.remove('disabled');
+            } else {
+                alternateMCherryRow.classList.add('disabled');
+                alternateMCherryDetection.checked = false;
+                statsState.alternateMCherryDetection = alternateMCherryDetection.checked;
             }
         }
 
@@ -3607,6 +3651,7 @@
             gfpThreshold: Number.isFinite(Number(statsState.gfpThreshold)) ? Number(statsState.gfpThreshold) : 66,
             nuclearCellularMode: statsState.nuclearCellularMode === 'red_nucleus' ? 'red_nucleus' : 'green_nucleus',
             gfpFilterEnabled: !!statsState.gfpFilterEnabled,
+            alternateMCherryDetection: !!statsState.alternateMCherryDetection,
             mCherryWidthUnit: normalizeLengthUnit(statsState.mCherryWidthUnit),
             gfpDistanceUnit: normalizeLengthUnit(statsState.gfpDistanceUnit),
             micronsPerPixel: sanitizeMicronsPerPixel(statsState.micronsPerPixel),
@@ -3648,6 +3693,7 @@
             statsState.gfpThreshold = Number.isFinite(parsedThreshold) && parsedThreshold >= 0 ? parsedThreshold : 66;
             statsState.nuclearCellularMode = snapshot.nuclearCellularMode === 'red_nucleus' ? 'red_nucleus' : 'green_nucleus';
             statsState.gfpFilterEnabled = !!snapshot.gfpFilterEnabled;
+            statsState.alternateMCherryDetection = !!snapshot.alternateMCherryDetection;
             if (!statsState.showLegacyPlugins) {
                 statsPlugins.forEach((plugin) => {
                     if (plugin.is_legacy) {
@@ -4332,6 +4378,7 @@
             formData.append('threshold', String(statsState.gfpThreshold));
             formData.append('nuclear_cellular_mode', statsState.nuclearCellularMode);
             formData.append('gfpFilterEnabled', String(statsState.gfpFilterEnabled));
+            formData.append('alternateMCherryDetection', String(statsState.alternateMCherryDetection));
             const sharedLengthUnit = statsState.mCherryWidthUnit === statsState.gfpDistanceUnit
                 ? statsState.mCherryWidthUnit
                 : 'mixed';

--- a/cytocv/templates/workflow_defaults.html
+++ b/cytocv/templates/workflow_defaults.html
@@ -1186,6 +1186,7 @@ main.main > section.panel {
           </div>
           <div class="row"><div class="row-copy"><label for="show_legacy_plugins">Show legacy plugins by default</label><p>Reveal DAPI-based plugins in the statistics list.</p></div><label class="sw"><input type="checkbox" id="show_legacy_plugins" name="show_legacy_plugins" {% if preferences.experiment_defaults.show_legacy_plugins %}checked{% endif %}><span class="sl"></span></label></div>
           <div class="row"><div class="row-copy"><span class="row-label-line"><label for="gfp_filter_enabled">Enable GFP minimum-size filter</label><button type="button" class="prefs-info-dot prefs-warning-dot" id="prefsGfpFilterExperimentalDot" data-info-text="Experimental setting: This filter may improve performance on noisy datasets, but behavior can vary across image quality, exposure, and channel mapping. Validate outputs before using results for conclusions." aria-label="Experimental setting warning">&#9888;</button></span><p>Filter out low-confidence GFP signal contours in challenging images.</p></div><label class="sw"><input type="checkbox" id="gfp_filter_enabled" name="gfp_filter_enabled" {% if preferences.experiment_defaults.gfp_filter_enabled %}checked{% endif %}><span class="sl"></span></label></div>
+          <div class="row"><div class="row-copy"><span class="row-label-line"><label for="alternate_mcherry_detection">Enable alternate mCherry detection where a contour surrounds all speckles</label></span><p>Utilize an alternate mCherry detection mode where the tool attempts to find a single contour to surround all speckles.</p></div><label class="sw"><input type="checkbox" id="alternate_mcherry_detection" name="alternate_mcherry_detection" {% if preferences.experiment_defaults.alternate_mcherry_detection %}checked{% endif %}><span class="sl"></span></label></div>
         </div>
         <div class="card action-card" data-workflow-action-card="advanced">
           <p class="section-eyebrow card-title">Save Advanced Settings</p>
@@ -2042,6 +2043,7 @@ main.main > section.panel {
   const advancedWavelengthCheckRow = document.getElementById('advancedWavelengthCheckRow');
   const showLegacyPluginsInput = document.getElementById('show_legacy_plugins');
   const gfpFilterEnabledInput = document.getElementById('gfp_filter_enabled');
+  const alternateMCherryDetectionInput = document.getElementById('alternate_mcherry_detection');
   const autoSaveExperimentsInput = document.getElementById('auto_save_experiments');
   const showSavedFileChannelsInput = document.getElementById('show_saved_file_channels');
   const showSavedFileScalesInput = document.getElementById('show_saved_file_scales');
@@ -2217,6 +2219,7 @@ main.main > section.panel {
     enforceWavelengths: !!(enforceWavelengthsInput && enforceWavelengthsInput.checked),
     showLegacyPlugins: !!(showLegacyPluginsInput && showLegacyPluginsInput.checked),
     gfpFilterEnabled: !!(gfpFilterEnabledInput && gfpFilterEnabledInput.checked),
+    alternateMCherryDetection: !!(alternateMCherryDetectionInput && alternateMCherryDetectionInput.checked),
     requiredChannels: sortByOrder([...manualRequiredChannels], channelOrder),
     overrideChannels: sortByOrder([...overrides], channelOrder),
   });
@@ -2335,6 +2338,12 @@ main.main > section.panel {
       'Enable GFP minimum-size filter',
       fromSnapshot.gfpFilterEnabled,
       toSnapshot.gfpFilterEnabled
+    );
+    pushToggleChange(
+      changes,
+      'Enable alternate mCherry detection where a contour surrounds all speckles',
+      fromSnapshot.alternateMCherryDetection,
+      toSnapshot.alternateMCherryDetection
     );
 
     const beforeRequired = new Set(fromSnapshot.requiredChannels || []);
@@ -2462,6 +2471,7 @@ main.main > section.panel {
     if (enforceWavelengthsInput) enforceWavelengthsInput.checked = snapshot.enforceWavelengths;
     if (showLegacyPluginsInput) showLegacyPluginsInput.checked = snapshot.showLegacyPlugins;
     if (gfpFilterEnabledInput) gfpFilterEnabledInput.checked = snapshot.gfpFilterEnabled;
+    if (alternateMCherryDetectionInput) alternateMCherryDetectionInput.checked = snapshot.alternateMCherryDetection;
     manualRequiredChannels.clear();
     (snapshot.requiredChannels || []).forEach((channel) => {
       if (channel && !alwaysRequired.has(channel)) {


### PR DESCRIPTION
- Adjusts the contour detection for mCherry to reduce cases where multiple contours are grouped together
- Adjusts DAPI and GFP contour detection to improve accuracy, especially with varying brightness
- Adds alternative mCherry contour detection mode which attempts to outline all speckles based on other experiments