### PR TITLE
docs: add cytocv2 deployment record and local installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Primary entry points:
 
 - User documentation: [docs/user/getting-started.md](docs/user/getting-started.md)
 - Developer architecture: [docs/developer/architecture-overview.md](docs/developer/architecture-overview.md)
+- Local installation and troubleshooting: [docs/developer/local-installation-and-troubleshooting.md](docs/developer/local-installation-and-troubleshooting.md)
 - Developer codebase map: [docs/developer/codebase-map.md](docs/developer/codebase-map.md)
 - Operations deployment guide: [docs/ops/deployment-guide.md](docs/ops/deployment-guide.md)
 - Operations environment reference: [docs/ops/environment-reference.md](docs/ops/environment-reference.md)
@@ -186,6 +187,7 @@ For operational deployment material, use these documents:
 - PostgreSQL setup: [docs/ops/postgres-setup.md](docs/ops/postgres-setup.md)
 - March 2026 VM step-by-step guide: [docs/vm-deployment-guide/README.md](docs/vm-deployment-guide/README.md)
 - March 2026 VM rollout record: [docs/vm-deployment-record/README.md](docs/vm-deployment-record/README.md)
+- Replacement `cytocv2.uwb.edu` VM rollout record: [docs/vm-deployment-record-cytocv2/README.md](docs/vm-deployment-record-cytocv2/README.md)
 
 The VM-specific documents are especially important for infrastructure similar to the UWB VM used during the March 2026 rollout.
 

--- a/cytocv/templates/base.html
+++ b/cytocv/templates/base.html
@@ -8,8 +8,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}CytoCV{% endblock title %}</title>
     <meta name="description" content="{% block meta_description %}CytoCV image analysis platform.{% endblock meta_description %}">
-    <link rel="icon" type="image/x-icon" href="{{ uwb_favicon_ico }}?v=4">
-    <link rel="shortcut icon" type="image/x-icon" href="{{ uwb_favicon_ico }}?v=4">
+    <link rel="icon" type="image/png" href="{{ uwb_logo_png }}?v=6">
+    <link rel="shortcut icon" type="image/png" href="{{ uwb_logo_png }}?v=6">
     <link rel="apple-touch-icon" href="{{ uwb_logo_png }}?v=4">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="CytoCV">

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This directory is the canonical documentation home for CytoCV. The root `README.
 - PDFs in `docs/research/` are derived formal deliverables.
 - Diagrams live in `docs/diagrams/`.
 - Obsolete or superseded material should move to `docs/archive/`.
-- Historical project records that should remain readable but are not part of the active doc system may remain in dedicated subfolders such as `docs/vm-deployment-record/`.
+- Historical project records that should remain readable but are not part of the active doc system may remain in dedicated subfolders such as `docs/vm-deployment-record/` and `docs/vm-deployment-record-cytocv2/`.
 
 ## User Documentation
 
@@ -23,6 +23,7 @@ This directory is the canonical documentation home for CytoCV. The root `README.
 
 - [`developer/architecture-overview.md`](developer/architecture-overview.md)
 - [`developer/codebase-map.md`](developer/codebase-map.md)
+- [`developer/local-installation-and-troubleshooting.md`](developer/local-installation-and-troubleshooting.md)
 - [`developer/request-flows.md`](developer/request-flows.md)
 - [`developer/data-flow-and-artifacts.md`](developer/data-flow-and-artifacts.md)
 - [`developer/extending-analysis.md`](developer/extending-analysis.md)
@@ -61,3 +62,5 @@ Formal PDF deliverables:
 - Diagram catalog: [`diagrams/README.md`](diagrams/README.md)
 - Documentation standards: [`templates/document-style-guide.md`](templates/document-style-guide.md)
 - License: [`license/README.md`](license/README.md)
+- Historical deployment record (first UWB VM): [`vm-deployment-record/README.md`](vm-deployment-record/README.md)
+- Historical deployment record (replacement `cytocv2` VM): [`vm-deployment-record-cytocv2/README.md`](vm-deployment-record-cytocv2/README.md)

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -52,5 +52,6 @@ Documentation must be updated when any of these change:
 
 ## Related Documents
 
+- [`local-installation-and-troubleshooting.md`](local-installation-and-troubleshooting.md)
 - [`testing-guide.md`](testing-guide.md)
 - [`../templates/document-style-guide.md`](../templates/document-style-guide.md)

--- a/docs/developer/local-installation-and-troubleshooting.md
+++ b/docs/developer/local-installation-and-troubleshooting.md
@@ -1,0 +1,411 @@
+# Local Installation And Troubleshooting
+
+## Purpose
+
+This guide is the in-depth local installation reference for running CytoCV from a fresh checkout. It covers the intended local setup path and the most common local errors that appear during installation, startup, migration, and the first analysis run.
+
+This document is for local development and local validation. For VM/server deployment, use:
+
+- [`../vm-deployment-guide/README.md`](../vm-deployment-guide/README.md)
+- [`../ops/deployment-guide.md`](../ops/deployment-guide.md)
+
+## Recommended Local Shape
+
+Use this as the default local configuration:
+
+- Python `3.11.5`
+- project-specific virtual environment
+- SQLite backend
+- `.env` copied from `.env.example`
+- Mask R-CNN weights file under `cytocv/core/weights/deepretina_final.h5`
+- run commands from `cytocv/` when using `manage.py`
+
+SQLite is the intended local-development database. PostgreSQL should be treated as an explicit local validation path, not the default local setup.
+
+## Fresh Local Install
+
+### 1. Create and activate a virtual environment
+
+Windows PowerShell:
+
+```powershell
+python -m venv cyto_cv
+.\cyto_cv\Scripts\Activate.ps1
+python --version
+```
+
+Linux shell:
+
+```bash
+python3.11 -m venv cyto_cv
+source cyto_cv/bin/activate
+python --version
+```
+
+Expected result:
+
+```text
+Python 3.11.5
+```
+
+If your default interpreter is not `3.11.5`, stop and fix that first.
+
+### 2. Install dependencies
+
+```bash
+python -m pip install --upgrade pip setuptools wheel
+python -m pip install -r requirements.txt --no-cache-dir
+```
+
+On Linux, seeing this line is expected:
+
+```text
+Ignoring tensorflow-intel: markers 'sys_platform == "win32"' don't match your environment
+```
+
+### 3. Create `.env`
+
+Copy `.env.example` to `.env` in the repository root.
+
+Windows PowerShell:
+
+```powershell
+Copy-Item .env.example .env
+```
+
+Linux shell:
+
+```bash
+cp .env.example .env
+```
+
+For a standard local install, make sure at least these values are set:
+
+```env
+CYTOCV_SECRET_KEY=change-me-local
+CYTOCV_DEBUG=1
+CYTOCV_ALLOWED_HOSTS=localhost,127.0.0.1
+CYTOCV_DB_BACKEND=sqlite
+CYTOCV_ACCOUNT_EMAIL_VERIFICATION=none
+CYTOCV_RECAPTCHA_ENABLED=0
+```
+
+Local notes:
+
+- keep `CYTOCV_DB_BACKEND=sqlite` unless you are intentionally validating PostgreSQL
+- keep auth-provider credentials blank unless you are actively testing OAuth
+- keep reCAPTCHA disabled locally unless you are intentionally testing that flow
+
+### 4. Add the required weights file
+
+The current runtime expects the Mask R-CNN weights file here:
+
+```text
+cytocv/core/weights/deepretina_final.h5
+```
+
+Do not rely on `cytocv/core/mrcnn/weights/` alone. The active inference runtime resolves the weights from `cytocv/core/weights/`.
+
+If `gdown` is not installed yet:
+
+```bash
+python -m pip install gdown
+```
+
+Then download the file:
+
+```bash
+gdown --fuzzy "https://drive.google.com/file/d/1moUKvWFYQoWg0z63F0JcSd3WaEPa4UY7/view?usp=sharing" -O ./cytocv/core/weights/deepretina_final.h5
+```
+
+Verify:
+
+```bash
+python -c "from pathlib import Path; print(Path('cytocv/core/weights/deepretina_final.h5').resolve())"
+```
+
+### 5. Run migrations
+
+Change into the Django project directory first:
+
+Windows PowerShell:
+
+```powershell
+cd .\cytocv
+```
+
+Linux shell:
+
+```bash
+cd ./cytocv
+```
+
+Then try the normal path:
+
+```bash
+python manage.py migrate
+python manage.py check
+```
+
+### 6. Start the local server
+
+```bash
+python manage.py runserver
+```
+
+Open:
+
+```text
+http://localhost:8000/
+```
+
+## Optional: Local PostgreSQL Validation
+
+Only use this if you are intentionally validating production-like database behavior.
+
+When using PostgreSQL locally:
+
+- set `CYTOCV_DB_BACKEND=postgres`
+- fill in `CYTOCV_DB_NAME`, `CYTOCV_DB_USER`, `CYTOCV_DB_PASSWORD`, `CYTOCV_DB_HOST`, and `CYTOCV_DB_PORT`
+- use the setup in [`../ops/postgres-setup.md`](../ops/postgres-setup.md)
+
+If you are not specifically testing PostgreSQL, use SQLite locally instead.
+
+## Most Common Local Errors
+
+### 1. Wrong Python Version
+
+Symptom:
+
+```text
+Python 3.12.x
+```
+
+or imports/builds behave unexpectedly.
+
+Cause:
+
+- CytoCV is pinned to Python `3.11.5`
+
+Fix:
+
+- recreate the venv with Python `3.11.5`
+- do not continue on `3.12`
+
+### 2. `CYTOCV_DB_BACKEND is required`
+
+Symptom:
+
+```text
+CYTOCV_DB_BACKEND is required and must be set to 'sqlite' or 'postgres'
+```
+
+Cause:
+
+- `.env` is missing or does not define `CYTOCV_DB_BACKEND`
+
+Fix:
+
+```env
+CYTOCV_DB_BACKEND=sqlite
+```
+
+for standard local development.
+
+### 3. `SQLite is not allowed when CYTOCV_DEBUG=0`
+
+Symptom:
+
+```text
+Set CYTOCV_DB_BACKEND=postgres for production.
+```
+
+Cause:
+
+- local `.env` is using `CYTOCV_DEBUG=0` with SQLite
+
+Fix:
+
+- use `CYTOCV_DEBUG=1` locally, or
+- switch fully to PostgreSQL if you need production-like mode
+
+### 4. Missing Weights File
+
+Symptom:
+
+```text
+FileNotFoundError: Mask R-CNN weights file not found: .../cytocv/core/weights/deepretina_final.h5
+```
+
+Cause:
+
+- weights file is missing
+- file was placed only under `core/mrcnn/weights/`
+
+Fix:
+
+- put the file at `cytocv/core/weights/deepretina_final.h5`
+
+### 5. Migration Chain Problems
+
+Symptoms:
+
+```text
+App 'accounts' does not have migrations.
+App 'core' does not have migrations.
+```
+
+or:
+
+```text
+NodeNotFoundError: Migration core.0007_uploadedimage_scale_info dependencies reference nonexistent parent node
+```
+
+Cause:
+
+- the repository migration tracking is currently incomplete
+
+Local recovery path:
+
+```bash
+cd ..
+rm -f cytocv/accounts/migrations/0001_initial.py
+rm -f cytocv/core/migrations/0001_initial.py
+rm -f cytocv/core/migrations/0007_uploadedimage_scale_info.py
+cd cytocv
+python manage.py makemigrations accounts core
+python manage.py migrate
+python manage.py check
+```
+
+Important:
+
+- this is a local recovery workaround
+- it does not fix the underlying repository migration-tracking problem
+
+### 6. `no such table: accounts_customuser`
+
+Symptom:
+
+```text
+sqlite3.OperationalError: no such table: accounts_customuser
+```
+
+or the PostgreSQL equivalent.
+
+Cause:
+
+- migrations have not been applied cleanly
+
+Fix:
+
+- rerun `python manage.py migrate`
+- if the migration graph is broken, use the migration recovery path above
+
+### 7. `ImportError: libGL.so.1`
+
+This is primarily a Linux local-development issue.
+
+Symptom:
+
+```text
+ImportError: libGL.so.1: cannot open shared object file: No such file or directory
+```
+
+Cause:
+
+- OpenCV runtime library is missing
+
+Fix on Ubuntu/Debian:
+
+```bash
+sudo apt install -y libgl1 libglib2.0-0
+```
+
+### 8. `ModuleNotFoundError: No module named 'core.cell_analysis.analysis'`
+
+This is a Linux case-sensitivity issue.
+
+Cause:
+
+- imports expect `analysis.py`
+- the file is named `Analysis.py`
+
+Fix:
+
+- ensure the file is named:
+
+```text
+cytocv/core/cell_analysis/analysis.py
+```
+
+Windows can mask this problem. Linux will not.
+
+### 9. `Requested setting AUTH_USER_MODEL, but settings are not configured`
+
+Symptom:
+
+```text
+django.core.exceptions.ImproperlyConfigured: Requested setting AUTH_USER_MODEL, but settings are not configured.
+```
+
+Cause:
+
+- Django-dependent imports are being run from a plain `python -c ...` command outside the Django context
+
+Fix:
+
+- run those checks through `manage.py shell -c ...`
+- and run them from the `cytocv/` directory
+
+Example:
+
+```bash
+cd cytocv
+python manage.py shell -c "from core.mrcnn.inference_runtime import get_inference_runtime; print(get_inference_runtime())"
+```
+
+## First Analysis Validation
+
+After the site boots, validate the actual analysis path, not just the homepage.
+
+Recommended quick check:
+
+1. open `http://localhost:8000/`
+2. upload one known-good `.dv` file
+3. preprocess the file
+4. run analysis
+5. confirm the display page shows:
+   - segmented cells
+   - `mask.tif`
+   - statistics or expected empty-state behavior
+
+If the browser appears to reload or stall during analysis, inspect the server-side error immediately in the same terminal where `runserver` is active.
+
+## Local Verification Checklist
+
+Use this checklist after a fresh local install:
+
+```bash
+python --version
+cd cytocv
+python manage.py migrate
+python manage.py check
+python manage.py runserver
+```
+
+Then verify:
+
+- homepage loads
+- sign-in page loads
+- experiment page loads after login
+- one local `.dv` test file can reach preprocess
+- the weights file is found and inference can start
+
+## Related Documents
+
+- [`contributing.md`](contributing.md)
+- [`testing-guide.md`](testing-guide.md)
+- [`../user/getting-started.md`](../user/getting-started.md)
+- [`../user/troubleshooting.md`](../user/troubleshooting.md)
+- [`../ops/postgres-setup.md`](../ops/postgres-setup.md)

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -95,6 +95,7 @@ After a successful run, CytoCV should produce:
 
 ## Related Documents
 
+- [`../developer/local-installation-and-troubleshooting.md`](../developer/local-installation-and-troubleshooting.md)
 - [`workflow-guide.md`](workflow-guide.md)
 - [`analysis-options.md`](analysis-options.md)
 - [`troubleshooting.md`](troubleshooting.md)

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -107,6 +107,7 @@ Login, signup, or password recovery fails.
 
 ## Related Documents
 
+- [`../developer/local-installation-and-troubleshooting.md`](../developer/local-installation-and-troubleshooting.md)
 - [`getting-started.md`](getting-started.md)
 - [`../ops/environment-reference.md`](../ops/environment-reference.md)
 - [`../ops/security-and-privacy.md`](../ops/security-and-privacy.md)

--- a/docs/vm-deployment-guide/README.md
+++ b/docs/vm-deployment-guide/README.md
@@ -6,8 +6,9 @@ This is the clean deployment guide for bringing CytoCV up on a fresh Ubuntu VM. 
 
 Use this guide for the intended command sequence.
 
-Use the historical record for the exact March 2026 rollout, dead ends, and recovery work:
+Use the historical records for the exact March 2026 rollouts, dead ends, and recovery work:
 - [`../vm-deployment-record/README.md`](../vm-deployment-record/README.md)
+- [`../vm-deployment-record-cytocv2/README.md`](../vm-deployment-record-cytocv2/README.md)
 
 ## Before You Start
 
@@ -99,9 +100,38 @@ Ignoring tensorflow-intel: markers 'sys_platform == "win32"' don't match your en
 
 That is correct. `tensorflow-intel` is Windows-only.
 
+### Ubuntu 24.04 Note: `python3.11` Package May Be Missing
+
+On Ubuntu `24.04.4`, the default system Python may be `3.12.x`, and `apt` may not provide `python3.11` or `python3.11-venv` directly.
+
+If that happens, do not continue with Python `3.12` for this deployment. Build Python `3.11.5` from source and create the venv from that interpreter instead:
+
+```bash
+sudo apt update
+sudo apt install -y \
+  build-essential curl wget git nginx postgresql postgresql-contrib certbot python3-certbot-nginx \
+  libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
+  libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
+  libffi-dev liblzma-dev uuid-dev
+
+cd /tmp
+wget https://www.python.org/ftp/python/3.11.5/Python-3.11.5.tgz
+tar -xzf Python-3.11.5.tgz
+cd Python-3.11.5
+./configure --prefix=/opt/python3115 --enable-optimizations
+make -j"$(nproc)"
+sudo make altinstall
+
+/opt/python3115/bin/python3.11 --version
+cd ~/CytoCV
+/opt/python3115/bin/python3.11 -m venv cyto_cv
+source cyto_cv/bin/activate
+python --version
+```
+
 ## 4. Download the Model Weights
 
-The app requires `deepretina_final.h5` under `cytocv/core/weights/`.
+The current deployed runtime expects `deepretina_final.h5` under `cytocv/core/weights/`.
 
 If `gdown` is not already installed in the venv:
 
@@ -114,6 +144,15 @@ Download the weights:
 ```bash
 gdown --fuzzy "https://drive.google.com/file/d/1moUKvWFYQoWg0z63F0JcSd3WaEPa4UY7/view?usp=sharing" -O ~/CytoCV/cytocv/core/weights/deepretina_final.h5
 ls -lh ~/CytoCV/cytocv/core/weights/deepretina_final.h5
+```
+
+Important:
+
+- do not assume that placing the file only under `cytocv/core/mrcnn/weights/` is sufficient
+- the runtime used during the `cytocv2` rollout looked specifically for:
+
+```text
+~/CytoCV/cytocv/core/weights/deepretina_final.h5
 ```
 
 ## 5. Generate Secret Values
@@ -280,6 +319,30 @@ python manage.py check
 
 This is a deployment workaround, not the real long-term repository fix.
 
+### Linux Case-Sensitivity Caveat
+
+The repo also contains a Linux-sensitive import path in `cytocv/core/cell_analysis/`.
+
+Imports currently expect:
+
+```python
+from .analysis import Analysis
+```
+
+That means the file must be named:
+
+```text
+cytocv/core/cell_analysis/analysis.py
+```
+
+If the file is named `Analysis.py`, Windows development may appear to work, but Linux deployment can fail with:
+
+```text
+ModuleNotFoundError: No module named 'core.cell_analysis.analysis'
+```
+
+If that happens on the VM, rename the file to lowercase before retrying the workflow.
+
 ## 10. Smoke Test With Django `runserver`
 
 Before introducing Gunicorn and Nginx, verify that Django boots and can serve requests:
@@ -324,6 +387,11 @@ Once confirmed, stop the manual Gunicorn process with:
 ```bash
 Ctrl+C
 ```
+
+Important:
+
+- do not leave the manual Gunicorn process running before starting the `systemd` service
+- if it is still bound to `0.0.0.0:8000`, the `cytocv` service can fail with `Address already in use`
 
 ## 12. Create the Gunicorn `systemd` Service
 
@@ -401,6 +469,49 @@ Important:
 - do not add a `location /media/ { alias ... }` block here
 - CytoCV serves `/media/...` through Django, not directly through Nginx
 
+### Static Files in Production
+
+If the site loads but favicon or static assets return `404`, configure Django static collection explicitly.
+
+In `cytocv/cytocv/settings.py`, make sure you have:
+
+```python
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+```
+
+Then collect static files:
+
+```bash
+cd ~/CytoCV/cytocv
+source ~/CytoCV/cyto_cv/bin/activate
+python manage.py collectstatic --noinput
+```
+
+Add this block inside the active HTTPS Nginx `server { ... }` block:
+
+```nginx
+location /static/ {
+    alias /home/NETID/ngioanni/CytoCV/cytocv/staticfiles/;
+}
+```
+
+If the browser is also requesting `/favicon.ico`, you may need to serve that explicitly:
+
+```nginx
+location = /favicon.ico {
+    alias /home/NETID/ngioanni/CytoCV/cytocv/staticfiles/favicon.ico;
+}
+```
+
+If Nginx still returns `403` for `/static/...`, inspect filesystem traversal permissions on every parent directory. During the `cytocv2` rollout, the blocking path was:
+
+```text
+/home/NETID/ngioanni
+```
+
+and the fix was to allow directory traversal so Nginx could reach the collected static files.
+
 Enable the site:
 
 ```bash
@@ -436,6 +547,24 @@ Verify:
 
 ```bash
 curl -I https://cytocv.uwb.edu
+```
+
+### Firewall and Certbot Troubleshooting
+
+If Certbot times out while trying to validate `http://<host>/.well-known/acme-challenge/...`, first check whether the VM firewall is blocking HTTP:
+
+```bash
+sudo ufw status
+sudo ufw allow 'Nginx Full'
+sudo ufw status
+```
+
+If UFW is already open and Certbot still times out, the remaining blocker is likely upstream network/firewall policy outside the VM.
+
+If Certbot successfully issues the certificate but fails to install it automatically, make sure the Nginx site has an exact matching `server_name` for the target host, then retry:
+
+```bash
+sudo certbot install --cert-name cytocv.uwb.edu
 ```
 
 ## 15. OAuth and reCAPTCHA Production Values
@@ -548,6 +677,8 @@ Then restart:
 sudo systemctl restart cytocv
 ```
 
+The `cytocv2` redeploy still did not have final SMTP credentials from UW IT. Until those details are provided, email sign-up, verification, and recovery flows should still be treated as incomplete even if the rest of the deployment stack is healthy.
+
 ## 17. Verification Commands
 
 Run these after deployment:
@@ -566,6 +697,8 @@ curl -I http://127.0.0.1:8000
 curl -I http://127.0.0.1
 curl -I http://140.142.158.14
 ```
+
+If you intentionally lock `CYTOCV_ALLOWED_HOSTS` to the production hostname only, raw IP access may correctly fail with `DisallowedHost`. That is expected and safer than allowing the public IP unnecessarily.
 
 ## 18. Known Blocker: TensorFlow and Non-AVX CPUs
 
@@ -594,7 +727,35 @@ lscpu
 
 If `AVX` is absent, the deployment can host the website, but analysis cannot run on that VM. The fix is infrastructure, not Django configuration.
 
-## 19. Recommended Deployment Order Summary
+## 19. Additional Runtime Troubleshooting
+
+### OpenCV Import Fails With `libGL.so.1`
+
+If `python manage.py migrate` or app startup fails with:
+
+```text
+ImportError: libGL.so.1: cannot open shared object file: No such file or directory
+```
+
+install the OpenCV runtime libraries:
+
+```bash
+sudo apt install -y libgl1 libglib2.0-0
+```
+
+Then rerun the Django command.
+
+### Browser Tab Icon Still Missing After Staticfiles Are Working
+
+Even after `collectstatic` and Nginx aliasing are fixed, favicon behavior can still be affected by:
+
+- browser cache
+- requests to `/favicon.ico` instead of the template-linked asset path
+- an icon file that is visually too subtle at favicon size
+
+If the icon asset is correct but still does not appear, test the direct URLs in the browser and consider using a PNG favicon link instead of the ICO file.
+
+## 20. Recommended Deployment Order Summary
 
 Use this order:
 
@@ -615,7 +776,7 @@ Use this order:
 15. Configure reCAPTCHA and OAuth providers
 16. Configure SMTP and tighten email verification when ready
 
-## 20. Post-Deployment Recommendations
+## 21. Post-Deployment Recommendations
 
 After the server is up:
 

--- a/docs/vm-deployment-record-cytocv2/README.md
+++ b/docs/vm-deployment-record-cytocv2/README.md
@@ -1,0 +1,704 @@
+# CytoCV VM Deployment Record (`cytocv2.uwb.edu`, March 2026)
+
+Maintainer: Nicolas Gioanni
+
+This document is a deployment record, not a generic setup guide. It records what was actually done to bring CytoCV up on the replacement UWB VM at `cytocv2.uwb.edu`, the commands that were used, the failures that appeared, and the exact fixes that were applied.
+
+Use this as the historical log for the replacement VM rollout.
+
+For the clean step-by-step guide, see:
+- [`../vm-deployment-guide/README.md`](../vm-deployment-guide/README.md)
+
+For the first March 2026 UWB VM rollout record, see:
+- [`../vm-deployment-record/README.md`](../vm-deployment-record/README.md)
+
+## Scope
+
+- Target host: `cytocv2.uwb.edu`
+- Public IP during deployment: `128.95.57.95`
+- OS: Ubuntu 24.04.4 LTS
+- Default system Python on host: `3.12.3`
+- Installed deployment Python: `3.11.5` built from source under `/opt/python3115`
+- App stack:
+  - Django
+  - PostgreSQL
+  - Gunicorn managed by `systemd`
+  - Nginx reverse proxy
+  - Let's Encrypt HTTPS
+
+## Final State Reached
+
+By the end of this work:
+
+- the site was reachable at `https://cytocv2.uwb.edu`
+- PostgreSQL was installed and the `cytocv` database was created
+- Gunicorn was running under a `systemd` service named `cytocv`
+- Nginx was proxying traffic correctly and serving collected static files
+- HTTPS was enabled successfully with Certbot
+- TensorFlow imported successfully on this VM
+- the analysis pipeline was able to execute on the replacement VM
+- email/SMTP remained incomplete because production SMTP/account details were still missing
+
+## Important Caveats Exposed by This Deployment
+
+This rollout succeeded, but it exposed several repository and runtime issues that are easy to hit again on future Linux redeployments:
+
+- Ubuntu `24.04.4` did not provide `python3.11` via the expected apt package names, so Python `3.11.5` had to be built from source
+- the repository migration problem from the first VM still existed and required the same local migration recovery
+- the runtime expected Mask R-CNN weights at `cytocv/core/weights/deepretina_final.h5`
+- Linux case sensitivity broke `core.cell_analysis.analysis` because the file was named `Analysis.py`
+- production staticfiles were not fully configured until `STATIC_ROOT`, `collectstatic`, Nginx `/static/`, and filesystem traversal permissions were added
+
+## 1. AVX Check Succeeded on the Replacement VM
+
+The first check on the replacement VM was to make sure the CPU exposed `AVX`, because that had blocked TensorFlow on the first VM.
+
+Command used:
+
+```bash
+lscpu | grep -i avx
+```
+
+Observed result:
+
+- `avx`, `avx2`, and additional vector flags were present
+
+That established that this replacement VM was a valid TensorFlow host candidate.
+
+## 2. Ubuntu 24.04 Defaulted to Python 3.12, Not 3.11
+
+The expected apt packages for Python `3.11` were not available on this host.
+
+Commands used:
+
+```bash
+python3 --version
+lsb_release -a
+apt-cache policy python3
+apt-cache search python3-venv
+sudo apt install -y python3.11 python3.11-venv
+```
+
+Observed result:
+
+- `python3 --version` showed `Python 3.12.3`
+- `apt` could not locate `python3.11` or `python3.11-venv`
+
+That meant the deployment could not continue with the documented `python3.11` package path.
+
+## 3. Python 3.11.5 Was Built From Source
+
+To keep the deployment on the required interpreter version, Python `3.11.5` was built manually under `/opt/python3115`.
+
+Commands used:
+
+```bash
+sudo apt update
+sudo apt install -y \
+  build-essential curl wget git nginx postgresql postgresql-contrib certbot python3-certbot-nginx \
+  libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
+  libncurses-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
+  libffi-dev liblzma-dev uuid-dev
+
+cd /tmp
+wget https://www.python.org/ftp/python/3.11.5/Python-3.11.5.tgz
+tar -xzf Python-3.11.5.tgz
+cd Python-3.11.5
+./configure --prefix=/opt/python3115 --enable-optimizations
+make -j"$(nproc)"
+sudo make altinstall
+/opt/python3115/bin/python3.11 --version
+```
+
+Observed result:
+
+```text
+Python 3.11.5
+```
+
+## 4. Repository Clone and Virtual Environment Creation
+
+The repo was cloned and the venv was created from the newly built interpreter.
+
+Commands used:
+
+```bash
+cd ~
+git clone https://github.com/BrentLagesse/CytoCV.git
+cd ~/CytoCV
+/opt/python3115/bin/python3.11 -m venv cyto_cv
+source cyto_cv/bin/activate
+python --version
+python -m pip install --upgrade pip setuptools wheel
+python -m pip install -r requirements.txt --no-cache-dir
+python -m pip install gdown
+```
+
+Observed result:
+
+- `python --version` inside the venv showed `Python 3.11.5`
+- dependency installation completed successfully
+
+## 5. Initial Model Weight Download Used the Wrong Directory
+
+At first, the weights were downloaded into `cytocv/core/mrcnn/weights/`, which existed in the code layout but was not the path actually used by the deployed runtime.
+
+Commands used:
+
+```bash
+mkdir -p ~/CytoCV/cytocv/core/mrcnn/weights
+gdown --fuzzy "https://drive.google.com/file/d/1moUKvWFYQoWg0z63F0JcSd3WaEPa4UY7/view?usp=sharing" -O ~/CytoCV/cytocv/core/mrcnn/weights/deepretina_final.h5
+ls -lh ~/CytoCV/cytocv/core/mrcnn/weights/deepretina_final.h5
+```
+
+Later, runtime logs showed the app was actually looking for:
+
+```text
+/home/NETID/ngioanni/CytoCV/cytocv/core/weights/deepretina_final.h5
+```
+
+The weights file was eventually copied there:
+
+```bash
+mkdir -p ~/CytoCV/cytocv/core/weights
+cp ~/CytoCV/cytocv/core/mrcnn/weights/deepretina_final.h5 ~/CytoCV/cytocv/core/weights/deepretina_final.h5
+ls -lh ~/CytoCV/cytocv/core/weights/deepretina_final.h5
+```
+
+## 6. Production `.env` Was Created for the Replacement Host
+
+Secret values were generated and a production `.env` was created for `cytocv2.uwb.edu`.
+
+Commands used:
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(24))"
+python -c "import secrets; print(secrets.token_urlsafe(50))"
+nano ~/CytoCV/.env
+```
+
+Important values used during the replacement rollout included:
+
+```env
+CYTOCV_SECRET_KEY=<generated secret>
+CYTOCV_DEBUG=0
+CYTOCV_ALLOWED_HOSTS=cytocv2.uwb.edu
+CYTOCV_DB_BACKEND=postgres
+CYTOCV_DB_NAME=cytocv
+CYTOCV_DB_USER=cytocv_user
+CYTOCV_DB_PASSWORD=<generated db password>
+CYTOCV_DB_HOST=127.0.0.1
+CYTOCV_DB_PORT=5432
+CYTOCV_DB_CONN_MAX_AGE=60
+CYTOCV_DB_ATOMIC_REQUESTS=0
+CYTOCV_DB_SSLMODE=prefer
+CYTOCV_ACCOUNT_EMAIL_VERIFICATION=optional
+CYTOCV_RECAPTCHA_EXPECTED_HOSTNAMES=cytocv2.uwb.edu
+CYTOCV_SECURITY_STRICT=0
+```
+
+The important operational choice here was to keep `CYTOCV_ACCOUNT_EMAIL_VERIFICATION=optional`, because SMTP was still not fully configured.
+
+## 7. PostgreSQL Installation and Database Creation
+
+PostgreSQL was installed and the application role/database were created.
+
+Commands used:
+
+```bash
+sudo systemctl enable --now postgresql
+sudo -u postgres psql -c "CREATE ROLE cytocv_user WITH LOGIN PASSWORD 'PASTE_DB_PASSWORD_HERE';"
+sudo -u postgres psql -c "CREATE DATABASE cytocv OWNER cytocv_user;"
+sudo -u postgres psql -c "\du"
+sudo -u postgres psql -c "\l"
+```
+
+Observed result:
+
+- role `cytocv_user` existed
+- database `cytocv` existed
+
+## 8. Django Failed Initially Because `libGL.so.1` Was Missing
+
+The first Django migration attempt on the new VM failed before migrations could run because OpenCV could not load.
+
+Commands used:
+
+```bash
+cd ~/CytoCV/cytocv
+python manage.py migrate
+python manage.py check
+```
+
+Important error:
+
+```text
+ImportError: libGL.so.1: cannot open shared object file: No such file or directory
+```
+
+Fix used:
+
+```bash
+sudo apt install -y libgl1 libglib2.0-0
+```
+
+After that, Django could boot far enough to hit the next issue.
+
+## 9. Migration Recovery Was Required Again
+
+The migration-tracking issue from the first VM still existed on the replacement VM.
+
+Observed failure:
+
+```text
+django.db.utils.ProgrammingError: relation "accounts_customuser" does not exist
+```
+
+The recovery path used again was:
+
+```bash
+cd ~/CytoCV
+rm -f cytocv/accounts/migrations/0001_initial.py
+rm -f cytocv/core/migrations/0001_initial.py
+rm -f cytocv/core/migrations/0007_uploadedimage_scale_info.py
+cd ~/CytoCV/cytocv
+python manage.py makemigrations accounts core
+python manage.py migrate
+python manage.py check
+```
+
+Observed result:
+
+- migrations for `accounts` and `core` were regenerated locally
+- the full migration chain then applied successfully
+- `python manage.py check` reported no issues
+
+## 10. Gunicorn Was Validated Manually First
+
+Before creating the service, Gunicorn was started manually to confirm the WSGI app booted correctly.
+
+Commands used:
+
+```bash
+cd ~/CytoCV/cytocv
+gunicorn --bind 0.0.0.0:8000 --workers 3 --timeout 120 cytocv.wsgi:application
+ss -ltnp | grep 8000
+```
+
+Observed result:
+
+```text
+LISTEN ... 0.0.0.0:8000 ... users:(("gunicorn",pid=...,fd=3), ...)
+```
+
+This validated Gunicorn, but that manual process later had to be stopped before the `systemd` service could take over the port.
+
+## 11. Gunicorn `systemd` Service Was Created
+
+The permanent service was created at:
+
+```text
+/etc/systemd/system/cytocv.service
+```
+
+Service contents used:
+
+```ini
+[Unit]
+Description=CytoCV Gunicorn
+After=network.target postgresql.service
+
+[Service]
+User=ngioanni
+Group=ngioanni
+WorkingDirectory=/home/NETID/ngioanni/CytoCV/cytocv
+Environment="PATH=/home/NETID/ngioanni/CytoCV/cyto_cv/bin"
+ExecStart=/home/NETID/ngioanni/CytoCV/cyto_cv/bin/gunicorn --workers 3 --timeout 120 --bind 127.0.0.1:8000 cytocv.wsgi:application
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Commands used:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable cytocv
+sudo systemctl start cytocv
+sudo systemctl status cytocv --no-pager
+```
+
+At first, the service hit `Address already in use` because the manual Gunicorn process was still bound to port `8000`. The fix was:
+
+```bash
+sudo pkill -f "gunicorn --bind 0.0.0.0:8000"
+sudo systemctl restart cytocv
+sudo systemctl status cytocv --no-pager
+sudo ss -ltnp | grep 8000
+```
+
+Final observed state:
+
+- Gunicorn was listening at `127.0.0.1:8000` under `systemd`
+
+## 12. Nginx Was Configured as the Reverse Proxy
+
+The public Nginx site config was created at:
+
+```text
+/etc/nginx/sites-available/cytocv
+```
+
+Core config used:
+
+```nginx
+server {
+    server_name cytocv2.uwb.edu;
+
+    client_max_body_size 100M;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+The site was enabled with:
+
+```bash
+sudo ln -s /etc/nginx/sites-available/cytocv /etc/nginx/sites-enabled/cytocv
+sudo rm -f /etc/nginx/sites-enabled/default
+sudo nginx -t
+sudo systemctl reload nginx
+sudo systemctl status nginx --no-pager
+```
+
+## 13. Host Validation Was Tightened to Hostname-Only Access
+
+The replacement deployment was intentionally hardened to accept only the hostname rather than the raw public IP.
+
+Relevant `.env` values:
+
+```env
+CYTOCV_ALLOWED_HOSTS=cytocv2.uwb.edu
+CYTOCV_RECAPTCHA_EXPECTED_HOSTNAMES=cytocv2.uwb.edu
+```
+
+Practical effect:
+
+- requests made directly to `128.95.57.95` were rejected with `DisallowedHost`
+- requests made to `cytocv2.uwb.edu` succeeded
+
+This was expected and intentional after the final production hostname was in place.
+
+## 14. Certbot Initially Failed Because Port 80 Was Blocked by UFW
+
+The first Certbot attempt failed with an ACME timeout.
+
+Command used:
+
+```bash
+sudo certbot --nginx -d cytocv2.uwb.edu
+```
+
+Important error:
+
+```text
+Timeout during connect (likely firewall problem)
+```
+
+The VM was listening on port `80`, but UFW only allowed SSH.
+
+Commands used to confirm and fix:
+
+```bash
+sudo ss -ltnp | grep ':80'
+sudo ufw status
+sudo ufw allow 'Nginx Full'
+sudo ufw status
+```
+
+After that, Certbot could reach the VM.
+
+## 15. Certbot Issued the Certificate but Could Not Install It Automatically
+
+After port `80` was opened, Certbot successfully issued the certificate but failed to install it into Nginx.
+
+Observed error:
+
+```text
+Could not automatically find a matching server block for cytocv2.uwb.edu
+```
+
+Fix used:
+
+1. Make sure the active Nginx site had an exact `server_name cytocv2.uwb.edu;`
+2. Re-run installation explicitly
+
+Command used:
+
+```bash
+sudo certbot install --cert-name cytocv2.uwb.edu
+```
+
+Observed result:
+
+```text
+Successfully deployed certificate for cytocv2.uwb.edu to /etc/nginx/sites-enabled/cytocv
+```
+
+Final verification:
+
+```bash
+curl -I https://cytocv2.uwb.edu
+```
+
+Observed result:
+
+```text
+HTTP/1.1 200 OK
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+```
+
+## 16. Analysis First Failed Because the Runtime Could Not Find the Weights File
+
+Once the web stack was online, the first preprocess/analysis attempt failed inside the Mask R-CNN runtime.
+
+Logs used:
+
+```bash
+sudo journalctl -u cytocv -f
+```
+
+Important error:
+
+```text
+FileNotFoundError: Mask R-CNN weights file not found: /home/NETID/ngioanni/CytoCV/cytocv/core/weights/deepretina_final.h5
+```
+
+Fix used:
+
+```bash
+mkdir -p ~/CytoCV/cytocv/core/weights
+cp ~/CytoCV/cytocv/core/mrcnn/weights/deepretina_final.h5 ~/CytoCV/cytocv/core/weights/deepretina_final.h5
+sudo systemctl restart cytocv
+```
+
+That resolved the missing-weights error.
+
+## 17. Linux Case Sensitivity Broke `core.cell_analysis.analysis`
+
+The next analysis failure was Linux-specific.
+
+Important error:
+
+```text
+ModuleNotFoundError: No module named 'core.cell_analysis.analysis'
+```
+
+Cause:
+
+- imports expected `from .analysis import Analysis`
+- the file on disk was `Analysis.py`
+- Windows tolerated this mismatch, Linux did not
+
+Fix used:
+
+```bash
+cd ~/CytoCV/cytocv/core/cell_analysis
+mv Analysis.py analysis.py
+sudo systemctl restart cytocv
+```
+
+Verification command:
+
+```bash
+cd ~/CytoCV/cytocv
+python manage.py shell -c "from core.cell_analysis.analysis import Analysis; print(Analysis)"
+```
+
+Observed result:
+
+```text
+<class 'core.cell_analysis.analysis.Analysis'>
+```
+
+## 18. TensorFlow Was Confirmed to Work on the Replacement VM
+
+Unlike the first UWB VM, this host could import TensorFlow successfully.
+
+Command used:
+
+```bash
+cd ~/CytoCV
+source cyto_cv/bin/activate
+python -c "import tensorflow as tf; print(tf.__version__)"
+```
+
+Observed result:
+
+```text
+2.15.1
+```
+
+There were CPU-only warnings and TensorFlow startup noise, but not the fatal `Illegal instruction` seen on the first VM.
+
+## 19. Staticfiles Had to Be Configured Explicitly for Production
+
+The application templates referenced `UWBSTEM.ico` and `UWBSTEM.png`, and those files existed in the repository, but production static serving was not fully configured initially.
+
+The fix required four pieces:
+
+1. set `STATIC_ROOT`
+2. run `collectstatic`
+3. add an Nginx `/static/` alias
+4. allow directory traversal so Nginx could actually reach the files
+
+The settings change used was:
+
+```python
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+```
+
+Then:
+
+```bash
+cd ~/CytoCV/cytocv
+source ~/CytoCV/cyto_cv/bin/activate
+python manage.py collectstatic --noinput
+```
+
+Observed result:
+
+```text
+142 static files copied to '/home/NETID/ngioanni/CytoCV/cytocv/staticfiles'.
+```
+
+The Nginx HTTPS server then added:
+
+```nginx
+location /static/ {
+    alias /home/NETID/ngioanni/CytoCV/cytocv/staticfiles/;
+}
+```
+
+Direct file checks confirmed the assets existed:
+
+```bash
+ls -lh /home/NETID/ngioanni/CytoCV/cytocv/staticfiles/assets/UWBSTEM.ico
+ls -lh /home/NETID/ngioanni/CytoCV/cytocv/staticfiles/assets/UWBSTEM.png
+```
+
+But initial requests still returned `403`, which led to the final permission fix.
+
+## 20. Staticfile `403` Was Caused by Home Directory Traversal Permissions
+
+Even after `collectstatic` and Nginx aliasing, static requests initially failed with `403 Forbidden`.
+
+Diagnostic commands used:
+
+```bash
+curl -I -k https://127.0.0.1/static/assets/UWBSTEM.ico -H "Host: cytocv2.uwb.edu"
+namei -l /home/NETID/ngioanni/CytoCV/cytocv/staticfiles/assets/UWBSTEM.ico
+```
+
+The important path segment was:
+
+```text
+drwx------ ngioanni ngioanni /home/NETID/ngioanni
+```
+
+Fix used:
+
+```bash
+chmod o+x /home/NETID/ngioanni
+```
+
+After that, the static assets were reachable:
+
+```bash
+curl -I https://cytocv2.uwb.edu/static/assets/UWBSTEM.ico
+curl -I https://cytocv2.uwb.edu/static/assets/UWBSTEM.png
+```
+
+Observed result:
+
+```text
+HTTP/1.1 200 OK
+```
+
+## 21. `/favicon.ico` Also Needed Explicit Handling
+
+Browsers still requested `/favicon.ico` even after `/static/assets/UWBSTEM.ico` was working.
+
+The favicon file was copied into the collected static root:
+
+```bash
+cp /home/NETID/ngioanni/CytoCV/cytocv/staticfiles/assets/UWBSTEM.ico /home/NETID/ngioanni/CytoCV/cytocv/staticfiles/favicon.ico
+```
+
+And Nginx added:
+
+```nginx
+location = /favicon.ico {
+    alias /home/NETID/ngioanni/CytoCV/cytocv/staticfiles/favicon.ico;
+}
+```
+
+The remaining favicon problem turned out to be largely asset/browser-behavior related rather than a deployment outage. The browser tab icon was later switched to the PNG path in the template for more reliable display.
+
+## 22. Email and SMTP Remained Incomplete
+
+This redeploy did not receive the production SMTP/account details needed to finish email-backed account flows.
+
+Practical implication:
+
+- OAuth sign-in was the working path
+- email sign-up, email verification, and email recovery should still be treated as incomplete until the UW IT SMTP details are provided
+
+## 23. Final Verification Commands Used
+
+These commands were used to verify the final deployed state:
+
+```bash
+curl -I https://cytocv2.uwb.edu
+sudo systemctl status cytocv --no-pager
+sudo systemctl status nginx --no-pager
+sudo ss -ltnp | grep 8000
+python -c "import tensorflow as tf; print(tf.__version__)"
+curl -I https://cytocv2.uwb.edu/static/assets/UWBSTEM.ico
+curl -I https://cytocv2.uwb.edu/static/assets/UWBSTEM.png
+```
+
+Important observed successful state:
+
+- `https://cytocv2.uwb.edu` returned `HTTP/1.1 200 OK`
+- `cytocv.service` was active and listening on `127.0.0.1:8000`
+- `nginx.service` was active
+- TensorFlow printed version `2.15.1`
+- static favicon/logo assets returned `200 OK`
+
+## 24. Differences From the First UWB VM
+
+Compared with the first March 2026 rollout at `cytocv.uwb.edu`, the replacement `cytocv2` rollout differed in these important ways:
+
+- the replacement VM exposed `AVX`, so TensorFlow could run
+- Ubuntu `24.04.4` required building Python `3.11.5` from source because the expected `python3.11` apt packages were unavailable
+- the same migration-tracking problem still existed and required local recovery again
+- additional Linux runtime issues surfaced and were fixed:
+  - missing `libGL.so.1` dependencies for OpenCV
+  - wrong runtime weights path
+  - case-sensitive import failure for `analysis.py`
+  - production staticfiles setup and permission problems
+- the stack ultimately reached a stronger final state than the first VM because the analysis runtime itself was able to execute on this host
+
+## 25. One-Paragraph Summary
+
+CytoCV was successfully redeployed on the replacement UWB VM at `https://cytocv2.uwb.edu` with PostgreSQL, Gunicorn under `systemd`, Nginx, HTTPS, working staticfiles, and a TensorFlow-capable CPU environment. The deployment required building Python `3.11.5` from source on Ubuntu `24.04.4`, recovering the database schema again from the repository migration problem, fixing missing OpenCV libraries, correcting the runtime Mask R-CNN weights path, renaming `Analysis.py` to `analysis.py` for Linux compatibility, opening UFW for Certbot validation, and explicitly configuring collected static files and directory traversal permissions for Nginx. The result was a working replacement deployment in which the analysis pipeline could run, although email/SMTP-backed account flows remained incomplete pending final production SMTP details.


### PR DESCRIPTION
Add a second historical deployment record for the cytocv2 replacement VM.

Extend the VM deployment guide with Ubuntu 24.04 Python 3.11.5 setup, OpenCV runtime fixes, weights-path requirements, Gunicorn/systemd notes, UFW and Certbot troubleshooting, and production staticfiles guidance.

Add a dedicated local installation and troubleshooting guide covering Python setup, SQLite defaults, weights placement, migration recovery, Linux-specific issues, and first-run validation.

Update root and docs indexes plus related guides so the new deployment and local-installation documentation is discoverable.

Include the updated favicon-related template and static asset changes used during the deployment follow-up.