### PR TITLE
dev: add smart Windows local installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 db.sqlite3
 media/
 cytocv_venv/
+cyto_cv/
+.cytocv-local-install/
 
 # Neural network
 deepretina_final.h5

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ git clone https://github.com/BrentLagesse/CytoCV.git
 cd CytoCV
 ```
 
+On native Windows with Git Bash, you can use the rerunnable local installer:
+
+```bash
+bash scripts/local-install-windows.sh
+```
+
 ### 2. Create and Activate the Python Environment
 
 CytoCV expects Python `3.11.5`.
@@ -167,6 +173,7 @@ Primary entry points:
 - User documentation: [docs/user/getting-started.md](docs/user/getting-started.md)
 - Developer architecture: [docs/developer/architecture-overview.md](docs/developer/architecture-overview.md)
 - Local installation and troubleshooting: [docs/developer/local-installation-and-troubleshooting.md](docs/developer/local-installation-and-troubleshooting.md)
+- Windows installer design: [docs/developer/windows-local-installer-design.md](docs/developer/windows-local-installer-design.md)
 - Developer codebase map: [docs/developer/codebase-map.md](docs/developer/codebase-map.md)
 - Operations deployment guide: [docs/ops/deployment-guide.md](docs/ops/deployment-guide.md)
 - Operations environment reference: [docs/ops/environment-reference.md](docs/ops/environment-reference.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ This directory is the canonical documentation home for CytoCV. The root `README.
 - [`developer/architecture-overview.md`](developer/architecture-overview.md)
 - [`developer/codebase-map.md`](developer/codebase-map.md)
 - [`developer/local-installation-and-troubleshooting.md`](developer/local-installation-and-troubleshooting.md)
+- [`developer/windows-local-installer-design.md`](developer/windows-local-installer-design.md)
 - [`developer/request-flows.md`](developer/request-flows.md)
 - [`developer/data-flow-and-artifacts.md`](developer/data-flow-and-artifacts.md)
 - [`developer/extending-analysis.md`](developer/extending-analysis.md)

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -53,5 +53,6 @@ Documentation must be updated when any of these change:
 ## Related Documents
 
 - [`local-installation-and-troubleshooting.md`](local-installation-and-troubleshooting.md)
+- [`windows-local-installer-design.md`](windows-local-installer-design.md)
 - [`testing-guide.md`](testing-guide.md)
 - [`../templates/document-style-guide.md`](../templates/document-style-guide.md)

--- a/docs/developer/local-installation-and-troubleshooting.md
+++ b/docs/developer/local-installation-and-troubleshooting.md
@@ -22,6 +22,40 @@ Use this as the default local configuration:
 
 SQLite is the intended local-development database. PostgreSQL should be treated as an explicit local validation path, not the default local setup.
 
+## Smart Windows Installer
+
+For native Windows development, the repo now includes a rerunnable Git Bash installer:
+
+```bash
+bash scripts/local-install-windows.sh
+```
+
+What it does:
+
+- requires Git Bash on a native Windows checkout
+- checks for exact Python `3.11.5`
+- bootstraps Python `3.11.5` with `winget` if it is missing
+- creates `cyto_cv/` only if a valid `3.11.5` environment is not already present
+- installs dependencies only when the venv or `requirements.txt` state requires it
+- creates `.env` if missing and patches only missing local-safe keys
+- auto-downloads `cytocv/core/weights/deepretina_final.h5` if needed
+- runs `python manage.py migrate` and `python manage.py check`
+- validates `cv2` and `tensorflow` imports at the end
+
+What it does not do:
+
+- it does not support WSL
+- it does not configure local PostgreSQL in v1
+- it does not auto-repair tracked migration files if Django migrations fail
+
+Installer state:
+
+- rerun-safe logs and step summaries are written under `.cytocv-local-install/`
+- reruns use real checks instead of trusting checkpoints blindly
+- steps are skipped only when the current environment still validates
+
+If the script stops on a migration failure, fix the issue manually using the documented recovery path in this guide and then rerun the same installer command.
+
 ## Fresh Local Install
 
 ### 1. Create and activate a virtual environment
@@ -49,6 +83,12 @@ Python 3.11.5
 ```
 
 If your default interpreter is not `3.11.5`, stop and fix that first.
+
+Windows Git Bash shortcut:
+
+```bash
+bash scripts/local-install-windows.sh
+```
 
 ### 2. Install dependencies
 
@@ -282,6 +322,7 @@ Important:
 
 - this is a local recovery workaround
 - it does not fix the underlying repository migration-tracking problem
+- the smart Windows installer intentionally stops here and asks you to resolve this manually before rerunning it
 
 ### 6. `no such table: accounts_customuser`
 
@@ -402,9 +443,16 @@ Then verify:
 - one local `.dv` test file can reach preprocess
 - the weights file is found and inference can start
 
+For Windows Git Bash users, the installer can be rerun after any resolved error:
+
+```bash
+bash scripts/local-install-windows.sh
+```
+
 ## Related Documents
 
 - [`contributing.md`](contributing.md)
+- [`windows-local-installer-design.md`](windows-local-installer-design.md)
 - [`testing-guide.md`](testing-guide.md)
 - [`../user/getting-started.md`](../user/getting-started.md)
 - [`../user/troubleshooting.md`](../user/troubleshooting.md)

--- a/docs/developer/windows-local-installer-design.md
+++ b/docs/developer/windows-local-installer-design.md
@@ -1,0 +1,280 @@
+# Windows Local Installer Design
+
+## Purpose
+
+This document explains the design and implementation of the rerunnable Windows local installer:
+
+- [`../../scripts/local-install-windows.sh`](../../scripts/local-install-windows.sh)
+
+It exists to make the standard local SQLite setup reproducible for native Windows development without turning the installer into a risky repair tool.
+
+## Design Goals
+
+The installer was built around these constraints:
+
+- support native Windows development with Git Bash
+- install the standard local SQLite workflow end to end
+- be safe to rerun after partial progress or failure
+- use real environment checks instead of trusting checkpoints blindly
+- preserve existing local secrets and provider credentials in `.env`
+- stop on risky failures instead of mutating tracked files automatically
+
+This means the installer is intentionally conservative. It automates the common path aggressively, but it does not attempt to repair migration history or rewrite repo-tracked Django migration files.
+
+## Scope
+
+Current scope:
+
+- native Windows checkout only
+- Git Bash only
+- exact Python `3.11.5`
+- local SQLite setup only
+- automatic model-weight download
+- Django migration and system-check validation
+- basic runtime validation for `cv2` and `tensorflow`
+
+Current non-goals:
+
+- WSL support
+- Linux/macOS support
+- local PostgreSQL installation or provisioning
+- automatic migration recovery when the repository migration graph is broken
+- automatic server startup after install
+
+## Why Git Bash
+
+Git Bash was chosen because it matches the existing Windows-native development posture in this repository while still allowing a single Bash entrypoint.
+
+The script rejects:
+
+- WSL
+- generic Linux shells
+- non-Git-Bash environments without `cygpath`
+
+That decision keeps path handling predictable for:
+
+- spaces in Windows paths
+- `winget.exe`
+- `py.exe`
+- the venv under `cyto_cv/`
+
+## Why the Installer Is "Smart"
+
+The rerun model is state-aware, but state files are not the source of truth.
+
+The installer uses actual checks before each step:
+
+- Python:
+  - validate that exact `3.11.5` is available
+- Virtual environment:
+  - validate that `cyto_cv/Scripts/python.exe` exists and reports `3.11.5`
+- Dependencies:
+  - compare a stored `requirements.txt` hash
+  - run `pip check`
+- `.env`:
+  - detect whether the file exists
+  - patch only missing keys
+  - stop on conflicting local-mode values
+- Weights:
+  - validate that `cytocv/core/weights/deepretina_final.h5` exists and is large enough
+- Django:
+  - rerun `python manage.py migrate`
+  - rerun `python manage.py check`
+
+The state directory `.cytocv-local-install/` is used for:
+
+- `install.log`
+- `summary.txt`
+- `requirements.sha256`
+
+Those files improve observability, but they do not override live validation.
+
+## Step-By-Step Implementation
+
+### 1. Shell and platform gating
+
+The script verifies:
+
+- `uname -s` starts with `MINGW` or `MSYS`
+- `WSL_DISTRO_NAME` is not set
+- `cygpath` is available
+
+This prevents subtle differences between Git Bash and WSL from leaking into the installer logic.
+
+### 2. Python bootstrapping
+
+The installer requires exact Python `3.11.5`.
+
+Lookup order:
+
+- `py.exe -3.11`
+- `python.exe`
+
+If neither yields exact `3.11.5`, the script attempts:
+
+```bash
+winget.exe install --id Python.Python.3.11 --version 3.11.5 --exact
+```
+
+After bootstrapping, it validates the version again. If the environment still does not expose exact `3.11.5`, the script stops.
+
+This strict version gate aligns with the project's existing documentation and avoids silently drifting onto `3.12.x` or an arbitrary `3.11.x` patch release.
+
+### 3. Virtual environment management
+
+The installer creates:
+
+```text
+cyto_cv/
+```
+
+It does not activate the environment internally. Instead, it calls:
+
+- `cyto_cv/Scripts/python.exe`
+- `cyto_cv/Scripts/pip.exe`
+
+That avoids shell-state bugs and makes the script easier to rerun reliably.
+
+If `cyto_cv/` already exists but is not using Python `3.11.5`, the installer stops and asks for manual cleanup.
+
+### 4. Dependency installation
+
+Dependency installation is skipped only when:
+
+- the venv exists
+- the stored `requirements.txt` hash matches
+- `pip check` passes
+
+Otherwise the installer reruns:
+
+```bash
+python -m pip install --upgrade pip setuptools wheel
+pip install -r requirements.txt --no-cache-dir
+```
+
+This design avoids a false "already installed" result when the environment is partially broken.
+
+### 5. `.env` handling
+
+The installer creates `.env` from `.env.example` if it is missing.
+
+If `.env` already exists:
+
+- missing local-safe keys are appended
+- existing values are preserved
+- conflicting local-mode values stop the script
+
+Conflicts currently treated as hard stops:
+
+- `CYTOCV_DB_BACKEND` is present and not `sqlite`
+- `CYTOCV_DEBUG` is present and not `1`
+
+This prevents the installer from silently converting an intentionally different environment.
+
+### 6. Weights handling
+
+The runtime expects the model weights at:
+
+```text
+cytocv/core/weights/deepretina_final.h5
+```
+
+The installer validates that exact path, not `core/mrcnn/weights/`.
+
+If the file is missing or clearly incomplete, the installer:
+
+- installs `gdown` into the venv if needed
+- downloads the weights automatically from the current Google Drive source
+
+The validation is intentionally simple and practical: it checks existence plus a minimum file size threshold.
+
+### 7. Django setup
+
+The installer always runs:
+
+```bash
+cd cytocv
+python manage.py migrate
+python manage.py check
+```
+
+This is safe because `migrate` is idempotent for successful states and catches broken states early.
+
+If migrations fail, the installer prints the documented manual recovery path and exits.
+
+It does not automatically:
+
+- delete migration files
+- regenerate migrations
+- rewrite tracked repository state
+
+That boundary is deliberate because the repository has known migration-history sensitivity.
+
+### 8. Runtime validation
+
+At the end, the installer performs a light import test:
+
+```bash
+python -c "import cv2, tensorflow as tf; ..."
+```
+
+This catches the most common "setup succeeded but runtime is still broken" cases before the user starts the dev server manually.
+
+## Failure Philosophy
+
+The installer is intentionally opinionated about what it should and should not repair.
+
+It will repair:
+
+- missing Python `3.11.5` via `winget`
+- missing venv
+- missing dependencies
+- missing `.env`
+- missing local-safe `.env` keys
+- missing weights
+
+It will not repair automatically:
+
+- a conflicting existing `.env`
+- a wrong-version existing venv
+- broken Django migration history
+- non-Windows or WSL shell/runtime mismatches
+
+The rule is:
+
+- recover automatically when the fix is local, reversible, and unambiguous
+- stop when the fix would mutate tracked project state or override user intent
+
+## Repo Integration
+
+Supporting repo changes for this installer:
+
+- `.gitignore` now ignores:
+  - `cyto_cv/`
+  - `.cytocv-local-install/`
+- local setup docs now include the installer
+
+This keeps the installer's artifacts out of normal Git status noise.
+
+## Extension Points
+
+Reasonable future extensions:
+
+- optional local PostgreSQL mode that assumes Postgres is already installed
+- an optional `--start-server` flag after validation
+- a companion PowerShell entrypoint that delegates into the Bash installer
+- richer validation for weights integrity
+- structured JSON summary output for automation
+
+Deliberately postponed:
+
+- automatic Postgres installation on Windows
+- automatic migration recovery
+- cross-platform unification into one installer script
+
+## Related Documents
+
+- [`local-installation-and-troubleshooting.md`](local-installation-and-troubleshooting.md)
+- [`contributing.md`](contributing.md)
+- [`../ops/postgres-setup.md`](../ops/postgres-setup.md)
+- [`../vm-deployment-guide/README.md`](../vm-deployment-guide/README.md)

--- a/scripts/local-install-windows.sh
+++ b/scripts/local-install-windows.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly REQUIRED_PYTHON_VERSION="3.11.5"
+readonly WEIGHTS_URL="https://drive.google.com/file/d/1moUKvWFYQoWg0z63F0JcSd3WaEPa4UY7/view?usp=sharing"
+readonly MIN_WEIGHTS_SIZE_BYTES=100000000
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+STATE_DIR="${REPO_ROOT}/.cytocv-local-install"
+LOG_FILE="${STATE_DIR}/install.log"
+SUMMARY_FILE="${STATE_DIR}/summary.txt"
+REQUIREMENTS_HASH_FILE="${STATE_DIR}/requirements.sha256"
+VENV_DIR="${REPO_ROOT}/cyto_cv"
+VENV_PYTHON="${VENV_DIR}/Scripts/python.exe"
+VENV_PIP="${VENV_DIR}/Scripts/pip.exe"
+ENV_FILE="${REPO_ROOT}/.env"
+ENV_EXAMPLE="${REPO_ROOT}/.env.example"
+REQUIREMENTS_FILE="${REPO_ROOT}/requirements.txt"
+DJANGO_DIR="${REPO_ROOT}/cytocv"
+WEIGHTS_PATH="${DJANGO_DIR}/core/weights/deepretina_final.h5"
+
+mkdir -p "${STATE_DIR}"
+: > "${LOG_FILE}"
+: > "${SUMMARY_FILE}"
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+summary() {
+    printf '%s\n' "$*" | tee -a "${SUMMARY_FILE}" >/dev/null
+}
+
+log() {
+    printf '[INFO] %s\n' "$*" >&2
+}
+
+warn() {
+    printf '[WARN] %s\n' "$*" >&2
+}
+
+fail() {
+    printf '[ERROR] %s\n' "$*" >&2
+    summary "[ERROR] $*"
+    exit 1
+}
+
+mark_run() {
+    local message="$1"
+    log "${message}"
+    summary "[RUN] ${message}"
+}
+
+mark_skip() {
+    local message="$1"
+    log "${message}"
+    summary "[SKIP] ${message}"
+}
+
+require_git_bash() {
+    local uname_out
+    uname_out="$(uname -s)"
+    case "${uname_out}" in
+        MINGW*|MSYS*) ;;
+        *)
+            fail "This installer targets Git Bash on native Windows. Detected '${uname_out}'."
+            ;;
+    esac
+
+    if [[ -n "${WSL_DISTRO_NAME:-}" ]]; then
+        fail "This installer does not support WSL. Use Git Bash on a native Windows checkout."
+    fi
+
+    if ! command -v cygpath >/dev/null 2>&1; then
+        fail "cygpath is required. Run this installer from Git Bash."
+    fi
+}
+
+windows_path_to_unix() {
+    cygpath -u "$1"
+}
+
+find_python_3115() {
+    local result version executable unix_executable
+    if command -v py.exe >/dev/null 2>&1; then
+        result="$(py.exe -3.11 -c "import sys; print(sys.version.split()[0]); print(sys.executable)" 2>/dev/null || true)"
+        if [[ -n "${result}" ]]; then
+            version="$(printf '%s\n' "${result}" | sed -n '1p')"
+            executable="$(printf '%s\n' "${result}" | sed -n '2p')"
+            if [[ "${version}" == "${REQUIRED_PYTHON_VERSION}" && -n "${executable}" ]]; then
+                unix_executable="$(windows_path_to_unix "${executable}")"
+                if [[ -x "${unix_executable}" ]]; then
+                    printf '%s\n' "${unix_executable}"
+                    return 0
+                fi
+            fi
+        fi
+    fi
+
+    if command -v python.exe >/dev/null 2>&1; then
+        result="$(python.exe -c "import sys; print(sys.version.split()[0]); print(sys.executable)" 2>/dev/null || true)"
+        if [[ -n "${result}" ]]; then
+            version="$(printf '%s\n' "${result}" | sed -n '1p')"
+            executable="$(printf '%s\n' "${result}" | sed -n '2p')"
+            if [[ "${version}" == "${REQUIRED_PYTHON_VERSION}" && -n "${executable}" ]]; then
+                unix_executable="$(windows_path_to_unix "${executable}")"
+                if [[ -x "${unix_executable}" ]]; then
+                    printf '%s\n' "${unix_executable}"
+                    return 0
+                fi
+            fi
+        fi
+    fi
+
+    return 1
+}
+
+install_python_3115_with_winget() {
+    if ! command -v winget.exe >/dev/null 2>&1; then
+        fail "winget.exe was not found. Install Python ${REQUIRED_PYTHON_VERSION} manually, then rerun this script."
+    fi
+
+    mark_run "Installing Python ${REQUIRED_PYTHON_VERSION} with winget"
+    winget.exe install \
+        --id Python.Python.3.11 \
+        --version "${REQUIRED_PYTHON_VERSION}" \
+        --exact \
+        --accept-package-agreements \
+        --accept-source-agreements \
+        --disable-interactivity \
+        || fail "winget could not install Python ${REQUIRED_PYTHON_VERSION}. Install it manually and rerun."
+}
+
+ensure_python_3115() {
+    local python_path
+    if python_path="$(find_python_3115)"; then
+        mark_skip "Using existing Python ${REQUIRED_PYTHON_VERSION} at ${python_path}"
+        printf '%s\n' "${python_path}"
+        return 0
+    fi
+
+    install_python_3115_with_winget
+
+    if python_path="$(find_python_3115)"; then
+        printf '%s\n' "${python_path}"
+        return 0
+    fi
+
+    fail "Python ${REQUIRED_PYTHON_VERSION} is still not available after winget install. Verify the exact version manually, then rerun."
+}
+
+ensure_venv() {
+    local base_python="$1"
+    local venv_version
+
+    if [[ -x "${VENV_PYTHON}" ]]; then
+        venv_version="$("${VENV_PYTHON}" -c "import sys; print(sys.version.split()[0])" 2>/dev/null || true)"
+        if [[ "${venv_version}" == "${REQUIRED_PYTHON_VERSION}" ]]; then
+            mark_skip "Virtual environment already exists at ${VENV_DIR}"
+            return 0
+        fi
+        fail "Existing virtual environment at ${VENV_DIR} is using Python ${venv_version:-unknown}, not ${REQUIRED_PYTHON_VERSION}. Remove cyto_cv and rerun."
+    fi
+
+    mark_run "Creating virtual environment at ${VENV_DIR}"
+    "${base_python}" -m venv "${VENV_DIR}"
+}
+
+requirements_hash() {
+    sha256sum "${REQUIREMENTS_FILE}" | awk '{print $1}'
+}
+
+ensure_dependencies() {
+    local current_hash stored_hash
+    current_hash="$(requirements_hash)"
+
+    if [[ -x "${VENV_PIP}" && -f "${REQUIREMENTS_HASH_FILE}" ]]; then
+        stored_hash="$(<"${REQUIREMENTS_HASH_FILE}")"
+        if [[ "${stored_hash}" == "${current_hash}" ]] && "${VENV_PIP}" check >/dev/null 2>&1; then
+            mark_skip "Python dependencies already satisfy requirements.txt"
+            return 0
+        fi
+    fi
+
+    mark_run "Installing Python dependencies into ${VENV_DIR}"
+    "${VENV_PYTHON}" -m pip install --upgrade pip setuptools wheel
+    "${VENV_PIP}" install -r "${REQUIREMENTS_FILE}" --no-cache-dir
+    "${VENV_PIP}" check >/dev/null
+    printf '%s\n' "${current_hash}" > "${REQUIREMENTS_HASH_FILE}"
+}
+
+get_env_value() {
+    local key="$1"
+    if [[ ! -f "${ENV_FILE}" ]]; then
+        return 0
+    fi
+    awk -F= -v target="${key}" '
+        $1 == target {
+            sub(/^[[:space:]]+/, "", $2)
+            sub(/[[:space:]]+$/, "", $2)
+            print $2
+            exit
+        }
+    ' "${ENV_FILE}"
+}
+
+append_env_if_missing() {
+    local key="$1"
+    local value="$2"
+    if grep -Eq "^${key}=" "${ENV_FILE}"; then
+        return 0
+    fi
+    printf '%s=%s\n' "${key}" "${value}" >> "${ENV_FILE}"
+}
+
+ensure_env_file() {
+    local current_db current_debug
+
+    if [[ ! -f "${ENV_FILE}" ]]; then
+        mark_run "Creating .env from .env.example"
+        cp "${ENV_EXAMPLE}" "${ENV_FILE}"
+    else
+        mark_skip "Using existing .env at ${ENV_FILE}"
+    fi
+
+    current_db="$(get_env_value "CYTOCV_DB_BACKEND")"
+    current_debug="$(get_env_value "CYTOCV_DEBUG")"
+
+    if [[ -n "${current_db}" && "${current_db}" != "sqlite" ]]; then
+        fail "Existing .env sets CYTOCV_DB_BACKEND=${current_db}. This installer only supports local SQLite. Update .env manually or use a separate environment."
+    fi
+    if [[ -n "${current_debug}" && "${current_debug}" != "1" ]]; then
+        fail "Existing .env sets CYTOCV_DEBUG=${current_debug}. This installer requires CYTOCV_DEBUG=1 for local SQLite."
+    fi
+
+    mark_run "Patching missing local-safe defaults in .env"
+    append_env_if_missing "CYTOCV_SECRET_KEY" "change-me-local"
+    append_env_if_missing "CYTOCV_DEBUG" "1"
+    append_env_if_missing "CYTOCV_ALLOWED_HOSTS" "localhost,127.0.0.1"
+    append_env_if_missing "CYTOCV_DB_BACKEND" "sqlite"
+    append_env_if_missing "CYTOCV_ACCOUNT_EMAIL_VERIFICATION" "none"
+    append_env_if_missing "CYTOCV_RECAPTCHA_ENABLED" "0"
+}
+
+ensure_gdown() {
+    if "${VENV_PYTHON}" -c "import gdown" >/dev/null 2>&1; then
+        mark_skip "gdown is already available in the virtual environment"
+        return 0
+    fi
+
+    mark_run "Installing gdown into the virtual environment"
+    "${VENV_PIP}" install gdown
+}
+
+weights_are_valid() {
+    [[ -f "${WEIGHTS_PATH}" ]] || return 1
+    local size
+    size="$(wc -c < "${WEIGHTS_PATH}")"
+    [[ "${size}" -ge "${MIN_WEIGHTS_SIZE_BYTES}" ]]
+}
+
+ensure_weights() {
+    mkdir -p "$(dirname "${WEIGHTS_PATH}")"
+
+    if weights_are_valid; then
+        mark_skip "Mask R-CNN weights already present at ${WEIGHTS_PATH}"
+        return 0
+    fi
+
+    ensure_gdown
+    mark_run "Downloading Mask R-CNN weights to ${WEIGHTS_PATH}"
+    "${VENV_PYTHON}" -m gdown --fuzzy "${WEIGHTS_URL}" -O "${WEIGHTS_PATH}" \
+        || fail "Failed to download deepretina_final.h5. Resolve the network or Google Drive access issue and rerun."
+
+    if ! weights_are_valid; then
+        fail "Weights file at ${WEIGHTS_PATH} is missing or incomplete after download."
+    fi
+}
+
+print_migration_recovery_guidance() {
+    cat <<'EOF'
+
+Known local migration recovery path:
+
+    cd ..
+    rm -f cytocv/accounts/migrations/0001_initial.py
+    rm -f cytocv/core/migrations/0001_initial.py
+    rm -f cytocv/core/migrations/0007_uploadedimage_scale_info.py
+    cd cytocv
+    python manage.py makemigrations accounts core
+    python manage.py migrate
+    python manage.py check
+
+This installer intentionally stops here instead of rewriting tracked migration files automatically.
+Resolve the migration issue, then rerun scripts/local-install-windows.sh.
+EOF
+}
+
+run_migrations_and_checks() {
+    mark_run "Running Django migrations"
+    if ! (
+        cd "${DJANGO_DIR}" &&
+        "${VENV_PYTHON}" manage.py migrate
+    ); then
+        print_migration_recovery_guidance
+        fail "Django migrations failed."
+    fi
+
+    mark_run "Running Django system checks"
+    (
+        cd "${DJANGO_DIR}" &&
+        "${VENV_PYTHON}" manage.py check
+    ) || fail "python manage.py check failed."
+}
+
+validate_runtime_imports() {
+    mark_run "Validating cv2 and tensorflow imports"
+    "${VENV_PYTHON}" -c "import cv2, tensorflow as tf; print('cv2', cv2.__version__); print('tensorflow', tf.__version__)" \
+        || fail "Runtime import validation failed."
+}
+
+print_success_summary() {
+    summary "[OK] Local installation completed successfully"
+    cat <<EOF
+
+Local installation completed successfully.
+
+State files:
+  Log: ${LOG_FILE}
+  Summary: ${SUMMARY_FILE}
+
+Next steps:
+  1. Open Git Bash in the repo root.
+  2. Start the development server:
+
+     cd "${REPO_ROOT}/cytocv"
+     ../cyto_cv/Scripts/python.exe manage.py runserver
+
+  3. Open http://localhost:8000/
+
+Rerun behavior:
+  - Re-running this script is safe.
+  - Completed steps are skipped only when their current outputs are still valid.
+EOF
+}
+
+main() {
+    local python_3115
+
+    require_git_bash
+    summary "CytoCV smart Windows local installer"
+    summary "Repository root: ${REPO_ROOT}"
+
+    python_3115="$(ensure_python_3115)"
+    ensure_venv "${python_3115}"
+    ensure_dependencies
+    ensure_env_file
+    ensure_weights
+    run_migrations_and_checks
+    validate_runtime_imports
+    print_success_summary
+}
+
+main "$@"


### PR DESCRIPTION
Add a rerunnable Git Bash installer for native Windows local setup.

Bootstrap exact Python 3.11.5 via winget, create or validate cyto_cv, patch .env safely, auto-download weights, and run Django plus runtime validation.

Document the installer workflow in the local install guide and add a dedicated design and implementation document.

Ignore cyto_cv and .cytocv-local-install artifacts to keep local installer state out of git.