### PR TITLE
Make CEN dot signal proximity radius configurable and unify blue-channel measurements

### DIFF
--- a/cytocv/accounts/preferences.py
+++ b/cytocv/accounts/preferences.py
@@ -32,12 +32,14 @@ DEFAULT_USER_PREFERENCES: dict[str, Any] = {
         "puncta_line_width": 1,
         "cen_dot_distance": 37,
         "cen_dot_collinearity_threshold": 66,
+        "cen_dot_proximity_radius": 13,
         "puncta_line_mode": DEFAULT_PUNCTA_LINE_MODE,
         "nuclear_cell_pair_mode": "green_nucleus",
         "green_contour_filter_enabled": False,
         "alternate_red_detection": False,
         "puncta_line_width_unit": "px",
         "cen_dot_distance_unit": "px",
+        "cen_dot_proximity_radius_unit": "px",
         "microns_per_pixel": DEFAULT_MICRONS_PER_PIXEL,
         "use_metadata_scale": True,
     },
@@ -201,6 +203,15 @@ def normalize_preferences_payload(raw_payload: Any) -> dict[str, Any]:
             defaults_payload.get("gfp_threshold"),
         ),
         default=66,
+        minimum=0,
+    )
+    normalized["experiment_defaults"]["cen_dot_proximity_radius_unit"] = _normalize_unit(
+        defaults_payload.get("cen_dot_proximity_radius_unit"),
+        default="px",
+    )
+    normalized["experiment_defaults"]["cen_dot_proximity_radius"] = _as_float(
+        defaults_payload.get("cen_dot_proximity_radius"),
+        default=13,
         minimum=0,
     )
     normalized["experiment_defaults"]["puncta_line_mode"] = normalize_puncta_line_mode(

--- a/cytocv/core/cell_analysis/analysis.py
+++ b/cytocv/core/cell_analysis/analysis.py
@@ -32,5 +32,6 @@ class Analysis:
         puncta_line_width_input,
         cen_dot_distance,
         cen_dot_collinearity_threshold,
+        cen_dot_proximity_radius=13,
     ):
         pass

--- a/cytocv/core/cell_analysis/blue_nucleus_intensity.py
+++ b/cytocv/core/cell_analysis/blue_nucleus_intensity.py
@@ -1,11 +1,15 @@
-from .analysis import Analysis
-import numpy as np
-import cv2, os, csv
 import logging
-from core.models import Contour
+
+import numpy as np
 from cv2_rolling_ball import subtract_background_rolling_ball
 
 from core.image_processing import calculate_intensity_mask
+from core.services.canonical_contours import (
+    CELL_MASK_KEY,
+    get_canonical_blue_slots,
+    load_cell_mask,
+)
+from .analysis import Analysis
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +28,14 @@ class BlueNucleusIntensity(Analysis):
         cen_dot_collinearity_threshold=66,
         cen_dot_proximity_radius=13,
     ):
+        """Calculate blue-channel intensity within the nucleus and cell regions."""
+
         gray_blue = self.preprocessed_images.get_image("gray_blue")
-        gray_blue_no_bg, background = subtract_background_rolling_ball(
+        if gray_blue is None:
+            self._set_defaults()
+            return
+
+        gray_blue_no_bg, _background = subtract_background_rolling_ball(
             gray_blue,
             50,
             light_background=False,
@@ -33,33 +43,36 @@ class BlueNucleusIntensity(Analysis):
             do_presmooth=True,
         )
 
-        mask_contour = np.zeros(gray_blue.shape, np.uint8)
-        cv2.fillPoly(mask_contour, [best_contours["Blue"]], 255)
-        pts_contour = np.transpose(np.nonzero(mask_contour))
+        shape = gray_blue_no_bg.shape[:2]
 
-        outline_filename = os.path.splitext(self.cp.image_name)[0] + '-' + str(self.cp.cell_id) + '.outline'
-        mask_file_path = os.path.join(self.output_dir, 'output', outline_filename)
+        blue_slots = get_canonical_blue_slots(contours_data, shape, limit=1)
+        if not blue_slots:
+            self._set_defaults()
+            return
 
-        with open(mask_file_path, 'r') as csvfile:
-            csvreader = csv.reader(csvfile)
-            border_cells = []
-            for row in csvreader:
-                border_cells.append([int(row[0]), int(row[1])])
+        nucleus_mask = blue_slots[0].mask
 
-        intensity_sum = 0
-        for p in pts_contour:
-            intensity_sum += gray_blue_no_bg[p[0]][p[1]]
-        logger.debug("Blue nucleus intensity sum for cell %s: %s", self.cp.cell_id, intensity_sum)
-        self.cp.nucleus_intensity_sum_blue = float(intensity_sum)
+        cell_mask = contours_data.get(CELL_MASK_KEY)
+        if cell_mask is None or cell_mask.shape[:2] != shape or not np.any(cell_mask):
+            cell_mask = load_cell_mask(
+                self.cp.image_name, self.cp.cell_id, self.output_dir, shape,
+            )
 
-        cell_intensity_sum = 0
-        for p in border_cells:
-             cell_intensity_sum += gray_blue_no_bg[p[0]][p[1]]
+        nucleus_intensity = float(calculate_intensity_mask(gray_blue_no_bg, nucleus_mask))
+        cell_intensity = float(calculate_intensity_mask(gray_blue_no_bg, cell_mask))
+
+        logger.debug("Blue nucleus intensity sum for cell %s: %s", self.cp.cell_id, nucleus_intensity)
         logger.debug(
             "Blue cellular intensity sum for cell %s: %s",
             self.cp.cell_id,
-            cell_intensity_sum,
+            cell_intensity,
         )
 
-        self.cp.cell_pair_intensity_sum_blue = float(cell_intensity_sum)
-        self.cp.cytoplasmic_intensity_blue = float(cell_intensity_sum) - float(intensity_sum)
+        self.cp.nucleus_intensity_sum_blue = nucleus_intensity
+        self.cp.cell_pair_intensity_sum_blue = cell_intensity
+        self.cp.cytoplasmic_intensity_blue = cell_intensity - nucleus_intensity
+
+    def _set_defaults(self):
+        self.cp.nucleus_intensity_sum_blue = 0.0
+        self.cp.cell_pair_intensity_sum_blue = 0.0
+        self.cp.cytoplasmic_intensity_blue = 0.0

--- a/cytocv/core/cell_analysis/blue_nucleus_intensity.py
+++ b/cytocv/core/cell_analysis/blue_nucleus_intensity.py
@@ -22,6 +22,7 @@ class BlueNucleusIntensity(Analysis):
         puncta_line_width_input=None,
         cen_dot_distance=0,
         cen_dot_collinearity_threshold=66,
+        cen_dot_proximity_radius=13,
     ):
         gray_blue = self.preprocessed_images.get_image("gray_blue")
         gray_blue_no_bg, background = subtract_background_rolling_ball(

--- a/cytocv/core/cell_analysis/cen_dot.py
+++ b/cytocv/core/cell_analysis/cen_dot.py
@@ -68,6 +68,27 @@ class CENDot(Analysis):
     def is_close(self, green_center_1, green_center_2):
         return math.dist(green_center_1, green_center_2) <= 8
 
+    def _get_proximity_radius_unit(self) -> str:
+        properties = getattr(self.cp, "properties", {}) or {}
+        return normalize_length_unit(properties.get("stats_cen_dot_proximity_radius_unit"), default="px")
+
+    def _proximity_radius_in_pixels(self, proximity_radius: float) -> float:
+        proximity_radius_unit = self._get_proximity_radius_unit()
+        if proximity_radius_unit == "um":
+            properties = getattr(self.cp, "properties", {}) or {}
+            um_per_px = properties.get(
+                "scale_effective_um_per_px",
+                properties.get("scale_x_um_per_px", 0.1),
+            )
+            try:
+                um_per_px = float(um_per_px)
+            except (TypeError, ValueError):
+                um_per_px = 0.1
+            if um_per_px <= 0:
+                um_per_px = 0.1
+            return proximity_radius / um_per_px
+        return proximity_radius
+
     def calculate_statistics(
         self,
         best_contours,
@@ -77,8 +98,9 @@ class CENDot(Analysis):
         puncta_line_width_input,
         cen_dot_distance=37,
         cen_dot_collinearity_threshold=66,
+        cen_dot_proximity_radius=13,
     ):
-        prox_radius = 13
+        prox_radius = self._proximity_radius_in_pixels(cen_dot_proximity_radius)
         cen_dot_distance = cen_dot_distance if (cen_dot_distance >= 0) else 37
         red_shape = None
         green_shape = None

--- a/cytocv/core/cell_analysis/green_red_intensity.py
+++ b/cytocv/core/cell_analysis/green_red_intensity.py
@@ -32,6 +32,7 @@ class GreenRedIntensity(Analysis):
         puncta_line_width_input,
         cen_dot_distance,
         cen_dot_collinearity_threshold,
+        cen_dot_proximity_radius=13,
     ):
         red_gray = self.preprocessed_images.get_image("red_no_bg")
         if red_gray is None:

--- a/cytocv/core/cell_analysis/nuclear_cell_pair_intensity.py
+++ b/cytocv/core/cell_analysis/nuclear_cell_pair_intensity.py
@@ -94,6 +94,7 @@ class NuclearCellPairIntensity(Analysis):
         puncta_line_width_input=None,
         cen_dot_distance=0,
         cen_dot_collinearity_threshold=0,
+        cen_dot_proximity_radius=13,
     ):
         props = dict(getattr(self.cp, "properties", {}) or {})
         mode = props.get("nuclear_cell_pair_mode", "green_nucleus")

--- a/cytocv/core/cell_analysis/nucleus_intensity.py
+++ b/cytocv/core/cell_analysis/nucleus_intensity.py
@@ -15,6 +15,7 @@ class NucleusIntensity(Analysis):
         puncta_line_width_input=None,
         cen_dot_distance=0,
         cen_dot_collinearity_threshold=0,
+        cen_dot_proximity_radius=13,
     ):
         """
             This function calculate the nucleus intensity within the green image

--- a/cytocv/core/cell_analysis/nucleus_intensity.py
+++ b/cytocv/core/cell_analysis/nucleus_intensity.py
@@ -1,7 +1,14 @@
-import cv2, os, csv
 import numpy as np
+
+from core.image_processing import calculate_intensity_mask
 from core.models import Contour
+from core.services.canonical_contours import (
+    CELL_MASK_KEY,
+    get_canonical_blue_slots,
+    load_cell_mask,
+)
 from .analysis import Analysis
+
 
 class NucleusIntensity(Analysis):
     name = 'Nucleus Intensity'
@@ -17,50 +24,48 @@ class NucleusIntensity(Analysis):
         cen_dot_collinearity_threshold=0,
         cen_dot_proximity_radius=13,
     ):
-        """
-            This function calculate the nucleus intensity within the green image
-        """
+        """Calculate green-channel intensity within the nucleus and cell regions."""
+
         gray_green = self.preprocessed_images.get_image('green')
         gray_green_no_bg = self.preprocessed_images.get_image('green_no_bg')
+        if gray_green_no_bg is None:
+            gray_green_no_bg = gray_green
 
-        mask_contour = np.zeros(gray_green.shape, np.uint8)
-        cv2.fillPoly(mask_contour, [best_contours['Blue']], 255)
-        pts_contour = np.transpose(np.nonzero(mask_contour))
+        if gray_green_no_bg is None:
+            self._set_defaults()
+            return
 
-        # Build the expected outline filename:
-        # cp.image_name is set (in the get_or_create for CellStatistics) as DV_Name + '.dv',
-        # so taking os.path.splitext(cp.image_name)[0] gives the full DV name (e.g. "M3850_001_PRJ")
-        outline_filename = os.path.splitext(self.cp.image_name)[0] + '-' + str(self.cp.cell_id) + '.outline'
+        shape = gray_green_no_bg.shape[:2]
 
-        # The outline files are stored in the "output" folder (not in a "masks" folder)
-        mask_file_path = os.path.join(self.output_dir, 'output', outline_filename)
+        blue_slots = get_canonical_blue_slots(contours_data, shape, limit=1)
+        if not blue_slots:
+            self._set_defaults()
+            return
 
-        with open(mask_file_path, 'r') as csvfile:
-            csvreader = csv.reader(csvfile)
-            border_cells = []
-            for row in csvreader:
-                border_cells.append([int(row[0]), int(row[1])])
+        nucleus_mask = blue_slots[0].mask
 
-        # Calculate nucleus intensity inside the best_contour
-        intensity_sum = 0
-        for p in pts_contour:
-            intensity_sum += gray_green_no_bg[p[0]][p[1]]
+        cell_mask = contours_data.get(CELL_MASK_KEY)
+        if cell_mask is None or cell_mask.shape[:2] != shape or not np.any(cell_mask):
+            cell_mask = load_cell_mask(
+                self.cp.image_name, self.cp.cell_id, self.output_dir, shape,
+            )
 
-        # Cast to Python int before saving into the JSON field
-        self.cp.nucleus_intensity[Contour.CONTOUR.name] = int(intensity_sum)
-        self.cp.nucleus_total_points = len(pts_contour)  # This is usually a Python int already
+        nucleus_intensity = float(calculate_intensity_mask(gray_green_no_bg, nucleus_mask))
+        cell_intensity = float(calculate_intensity_mask(gray_green_no_bg, cell_mask))
 
-        self.cp.nucleus_intensity_sum = float(intensity_sum)
+        self.cp.nucleus_intensity[Contour.CONTOUR.name] = int(nucleus_intensity)
+        self.cp.nucleus_total_points = int(np.count_nonzero(nucleus_mask))
+        self.cp.nucleus_intensity_sum = nucleus_intensity
+        self.cp.cell_intensity = int(cell_intensity)
+        self.cp.cell_total_points = int(np.count_nonzero(cell_mask))
+        self.cp.cell_pair_intensity_sum = cell_intensity
+        self.cp.cytoplasmic_intensity = cell_intensity - nucleus_intensity
 
-        # Calculate cell intensity from the "border_cells" list
-        cell_intensity_sum = 0
-        for p in border_cells:
-            cell_intensity_sum += gray_green_no_bg[p[0]][p[1]]
-
-        # Ensure that the JSON field gets a Python int
-        self.cp.cell_intensity = int(cell_intensity_sum)
-        self.cp.cell_total_points = len(border_cells)
-
-        self.cp.cell_pair_intensity_sum = float(cell_intensity_sum)
-
-        self.cp.cytoplasmic_intensity = float(cell_intensity_sum) - float(intensity_sum)
+    def _set_defaults(self):
+        self.cp.nucleus_intensity[Contour.CONTOUR.name] = 0
+        self.cp.nucleus_total_points = 0
+        self.cp.nucleus_intensity_sum = 0.0
+        self.cp.cell_intensity = 0
+        self.cp.cell_total_points = 0
+        self.cp.cell_pair_intensity_sum = 0.0
+        self.cp.cytoplasmic_intensity = 0.0

--- a/cytocv/core/cell_analysis/puncta_distance.py
+++ b/cytocv/core/cell_analysis/puncta_distance.py
@@ -38,6 +38,7 @@ class PunctaDistance(Analysis):
         puncta_line_width_input,
         cen_dot_distance,
         cen_dot_collinearity_threshold,
+        cen_dot_proximity_radius=13,
     ):
         puncta_line_points = []
         properties = dict(getattr(self.cp, "properties", {}) or {})

--- a/cytocv/core/cell_analysis/red_blue_intensity.py
+++ b/cytocv/core/cell_analysis/red_blue_intensity.py
@@ -14,6 +14,7 @@ class RedBlueIntensity(Analysis):
         puncta_line_width_input,
         cen_dot_distance,
         cen_dot_collinearity_threshold,
+        cen_dot_proximity_radius=13,
     ):
         """
         """

--- a/cytocv/core/services/canonical_contours.py
+++ b/cytocv/core/services/canonical_contours.py
@@ -1,4 +1,4 @@
-"""Canonical contour-slot helpers for modern Red/Green measurements."""
+"""Canonical contour-slot helpers for modern Red/Green/Blue measurements."""
 
 from __future__ import annotations
 
@@ -14,6 +14,7 @@ import numpy as np
 CELL_MASK_KEY = "cell_mask"
 CANONICAL_RED_SLOTS_KEY = "canonical_red_slots"
 CANONICAL_GREEN_SLOTS_KEY = "canonical_green_slots"
+CANONICAL_BLUE_SLOTS_KEY = "canonical_blue_slots"
 
 
 @dataclass(slots=True)
@@ -127,6 +128,25 @@ def build_canonical_contour_slots(
     return slots[:limit]
 
 
+def _select_raw_blue_contours(contours_data: dict, shape: tuple[int, int]) -> list:
+    """Select and area-filter blue contours, preferring the 3-channel source."""
+
+    image_area = float(shape[0] * shape[1])
+    min_area = max(10.0, image_area * 0.002)
+    max_area = image_area * 0.95
+
+    for key in ("contours_blue_3", "contours_blue"):
+        source = contours_data.get(key, [])
+        valid = [
+            c for c in source
+            if c is not None and len(c) >= 3
+            and min_area <= cv2.contourArea(c) <= max_area
+        ]
+        if valid:
+            return valid
+    return []
+
+
 def build_canonical_contour_payload(
     contours_data: dict,
     *,
@@ -153,6 +173,12 @@ def build_canonical_contour_payload(
         cell_mask,
         height_width,
         limit=limit,
+    )
+    payload[CANONICAL_BLUE_SLOTS_KEY] = build_canonical_contour_slots(
+        _select_raw_blue_contours(payload, height_width),
+        cell_mask,
+        height_width,
+        limit=1,
     )
     return payload
 
@@ -197,6 +223,26 @@ def get_canonical_green_slots(
         return list(slots)[:limit]
     return build_canonical_contour_slots(
         contours_data.get("contours_green", contours_data.get("contours_gfp", [])),
+        _resolve_cell_mask(contours_data, shape),
+        shape,
+        limit=limit,
+    )
+
+
+def get_canonical_blue_slots(
+    contours_data: dict,
+    shape: tuple[int, int] | Iterable[int],
+    *,
+    limit: int = 1,
+) -> list[CanonicalContourSlot]:
+    """Return canonical Blue contour slots, deriving them locally when absent."""
+
+    slots = contours_data.get(CANONICAL_BLUE_SLOTS_KEY)
+    if slots is not None:
+        return list(slots)[:limit]
+    height_width = _shape_tuple(shape)
+    return build_canonical_contour_slots(
+        _select_raw_blue_contours(contours_data, height_width),
         _resolve_cell_mask(contours_data, shape),
         shape,
         limit=limit,

--- a/cytocv/core/services/overlay_rendering.py
+++ b/cytocv/core/services/overlay_rendering.py
@@ -144,6 +144,8 @@ def build_overlay_render_config(
     alternate_red_detection: bool,
     puncta_line_width_unit: str | None = None,
     cen_dot_distance_unit: str | None = None,
+    cen_dot_proximity_radius: float | None = None,
+    cen_dot_proximity_radius_unit: str | None = None,
 ) -> dict[str, object]:
     render_config: dict[str, object] = {
         "schema_version": OVERLAY_RENDER_SCHEMA_VERSION,
@@ -170,6 +172,10 @@ def build_overlay_render_config(
         render_config["stats_puncta_line_width_unit"] = str(puncta_line_width_unit)
     if cen_dot_distance_unit:
         render_config["stats_cen_dot_distance_unit"] = str(cen_dot_distance_unit)
+    if cen_dot_proximity_radius is not None:
+        render_config["cen_dot_proximity_radius"] = float(cen_dot_proximity_radius)
+    if cen_dot_proximity_radius_unit:
+        render_config["stats_cen_dot_proximity_radius_unit"] = str(cen_dot_proximity_radius_unit)
     return render_config
 
 
@@ -318,6 +324,7 @@ def render_overlay_images_for_cell(
         int(render_config.get("puncta_line_width_px", 1)),
         float(render_config.get("cen_dot_distance_value_used", 37.0)),
         int(render_config.get("cen_dot_collinearity_threshold", 66)),
+        float(render_config.get("cen_dot_proximity_radius", 13)),
         bool(render_config.get("green_contour_filter_enabled", False)),
         bool(render_config.get("alternate_red_detection", False)),
         cached_images=images_to_use,

--- a/cytocv/core/services/segmentation_pipeline.py
+++ b/cytocv/core/services/segmentation_pipeline.py
@@ -567,6 +567,39 @@ def run_segmentation_batch(
             cen_dot_collinearity_threshold = 66
         if cen_dot_collinearity_threshold < 0:
             cen_dot_collinearity_threshold = 66
+        raw_cen_dot_proximity_radius = config_snapshot.get(
+            "stats_cen_dot_proximity_radius_value",
+            config_snapshot.get("cenDotProximityRadius", 13),
+        )
+        cen_dot_proximity_radius_unit = normalize_length_unit(
+            str(config_snapshot.get("stats_cen_dot_proximity_radius_unit", "px")),
+            default="px",
+        )
+        if cen_dot_proximity_radius_unit == "um":
+            try:
+                cen_dot_proximity_radius = float(raw_cen_dot_proximity_radius)
+            except (TypeError, ValueError):
+                cen_dot_proximity_radius = 13.0
+            if not math.isfinite(cen_dot_proximity_radius) or cen_dot_proximity_radius < 0:
+                cen_dot_proximity_radius = 13.0
+            cen_dot_proximity_radius_px_equivalent = convert_length_to_pixels(
+                cen_dot_proximity_radius,
+                "um",
+                minimum_px=0,
+                fallback_px=13,
+                um_per_px=line_width_proxy_um_per_px,
+            )
+        else:
+            cen_dot_proximity_radius = float(
+                convert_length_to_pixels(
+                    raw_cen_dot_proximity_radius,
+                    cen_dot_proximity_radius_unit,
+                    minimum_px=0,
+                    fallback_px=13,
+                    um_per_px=effective_um_per_px,
+                )
+            )
+            cen_dot_proximity_radius_px_equivalent = int(cen_dot_proximity_radius)
         green_contour_filter_enabled = config_snapshot.get(
             "greenContourFilterEnabled",
             config_snapshot.get("gfpFilterEnabled", False),
@@ -627,6 +660,8 @@ def run_segmentation_batch(
                 alternate_red_detection=bool(alternate_red_detection),
                 puncta_line_width_unit=puncta_line_width_unit,
                 cen_dot_distance_unit=cen_dot_distance_unit,
+                cen_dot_proximity_radius=cen_dot_proximity_radius,
+                cen_dot_proximity_radius_unit=cen_dot_proximity_radius_unit,
             ),
         )
 
@@ -685,6 +720,9 @@ def run_segmentation_batch(
             cp.properties["stats_cen_dot_distance_mode"] = cen_dot_distance_mode
             cp.properties["stats_puncta_line_width_unit"] = puncta_line_width_unit
             cp.properties["stats_cen_dot_distance_unit"] = cen_dot_distance_unit
+            cp.properties["stats_cen_dot_proximity_radius_px"] = cen_dot_proximity_radius_px_equivalent
+            cp.properties["stats_cen_dot_proximity_radius_value"] = cen_dot_proximity_radius
+            cp.properties["stats_cen_dot_proximity_radius_unit"] = cen_dot_proximity_radius_unit
 
             debug_red, debug_green, debug_blue = get_stats(
                 cp,
@@ -693,6 +731,7 @@ def run_segmentation_batch(
                 puncta_line_width,
                 cen_dot_distance,
                 cen_dot_collinearity_threshold,
+                cen_dot_proximity_radius,
                 green_contour_filter_enabled,
                 alternate_red_detection,
                 cached_images=cell_image_cache.get(cell_number),

--- a/cytocv/core/stats_plugins.py
+++ b/cytocv/core/stats_plugins.py
@@ -95,7 +95,12 @@ PLUGIN_DEFINITIONS: dict[str, StatsPluginDefinition] = {
     "CENDot": StatsPluginDefinition(
         plugin_id="CENDot",
         label="CEN dot Classification",
-        description="Classifies CEN-dot category and biorientation relative to paired red puncta.",
+        description=(
+            "Classifies CEN-dot category and biorientation relative to paired red puncta. "
+            "Minimum signal distance sets the threshold between the two red signals for "
+            "category vs. biorientation mode. Signal proximity radius controls how close "
+            "a green signal must be to a red signal to count as co-localized."
+        ),
         module_name="core.cell_analysis.cen_dot",
         class_name="CENDot",
         required_channels=frozenset({CHANNEL_ROLE_RED, CHANNEL_ROLE_GREEN}),

--- a/cytocv/core/tests/test_canonical_contours.py
+++ b/cytocv/core/tests/test_canonical_contours.py
@@ -6,11 +6,13 @@ import numpy as np
 from django.test import SimpleTestCase
 
 from core.services.canonical_contours import (
+    CANONICAL_BLUE_SLOTS_KEY,
     CANONICAL_GREEN_SLOTS_KEY,
     CANONICAL_RED_SLOTS_KEY,
     CELL_MASK_KEY,
     build_canonical_contour_payload,
     build_canonical_contour_slots,
+    get_canonical_blue_slots,
 )
 
 
@@ -100,3 +102,61 @@ class CanonicalContourHelpersTests(SimpleTestCase):
         self.assertEqual(int(cell_mask[1, 1]), 0)
         self.assertEqual(len(payload[CANONICAL_RED_SLOTS_KEY]), 1)
         self.assertEqual(len(payload[CANONICAL_GREEN_SLOTS_KEY]), 1)
+        self.assertIn(CANONICAL_BLUE_SLOTS_KEY, payload)
+
+    def test_build_canonical_contour_payload_includes_blue_slots(self):
+        raw_blue = self._rect_contour(2, 2, 8, 8)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            outline_path = output_dir / "test-1.outline"
+            with outline_path.open("w", encoding="utf-8") as handle:
+                for y in range(1, 11):
+                    for x in range(1, 11):
+                        handle.write(f"{y},{x}\n")
+
+            payload = build_canonical_contour_payload(
+                {"contours_blue": [raw_blue]},
+                image_name="test.dv",
+                cell_id=1,
+                output_dir=temp_dir,
+                shape=(12, 12),
+            )
+
+        blue_slots = payload[CANONICAL_BLUE_SLOTS_KEY]
+        self.assertEqual(len(blue_slots), 1)
+        clipped_mask = blue_slots[0].mask
+        cell_mask = payload[CELL_MASK_KEY]
+        self.assertEqual(int(np.count_nonzero(clipped_mask[cell_mask == 0])), 0)
+
+    def test_blue_slots_default_limit_is_one(self):
+        shape = (20, 20)
+        cell_mask = np.full(shape, 255, np.uint8)
+        contours = [
+            self._rect_contour(1, 1, 8, 8),
+            self._rect_contour(10, 10, 18, 18),
+        ]
+        contours_data = {"contours_blue": contours, "cell_mask": cell_mask}
+
+        slots = get_canonical_blue_slots(contours_data, shape)
+
+        self.assertEqual(len(slots), 1)
+
+    def test_get_canonical_blue_slots_returns_empty_when_no_blue_contours(self):
+        shape = (12, 12)
+        cell_mask = np.full(shape, 255, np.uint8)
+        contours_data = {"cell_mask": cell_mask}
+
+        slots = get_canonical_blue_slots(contours_data, shape)
+
+        self.assertEqual(slots, [])
+
+    def test_canonical_blue_slots_area_filter_excludes_tiny_contours(self):
+        shape = (200, 200)
+        cell_mask = np.full(shape, 255, np.uint8)
+        tiny_contour = self._rect_contour(1, 1, 2, 2)
+        contours_data = {"contours_blue": [tiny_contour], "cell_mask": cell_mask}
+
+        slots = get_canonical_blue_slots(contours_data, shape)
+
+        self.assertEqual(slots, [])

--- a/cytocv/core/views/experiment.py
+++ b/cytocv/core/views/experiment.py
@@ -289,6 +289,10 @@ def experiment(request):
             request.POST.get("stats_cen_dot_distance_unit", request.POST.get("stats_gfp_distance_unit")),
             default="px",
         )
+        cen_dot_proximity_radius_unit = _normalize_length_unit(
+            request.POST.get("stats_cen_dot_proximity_radius_unit"),
+            default="px",
+        )
 
         # Backward compatibility: if raw-value fields are absent, treat submitted
         # legacy width/distance fields as already pixel-normalized.
@@ -301,8 +305,10 @@ def experiment(request):
             "stats_cen_dot_distance_value" in request.POST
             or "stats_gfp_distance_value" in request.POST
         )
+        has_raw_cen_dot_proximity_radius = "stats_cen_dot_proximity_radius_value" in request.POST
         puncta_line_source_unit = puncta_line_width_unit if has_raw_puncta_line_width else "px"
         cen_dot_source_unit = cen_dot_distance_unit if has_raw_cen_dot_distance else "px"
+        cen_dot_proximity_radius_source_unit = cen_dot_proximity_radius_unit if has_raw_cen_dot_proximity_radius else "px"
 
         puncta_line_width_value = _parse_positive_float(
             request.POST.get(
@@ -323,6 +329,14 @@ def experiment(request):
             default=37,
             minimum=0,
         )
+        cen_dot_proximity_radius_value = _parse_positive_float(
+            request.POST.get(
+                "stats_cen_dot_proximity_radius_value",
+                request.POST.get("cenDotProximityRadius", "13"),
+            ),
+            default=13,
+            minimum=0,
+        )
 
         puncta_line_width = _convert_length_to_pixels(
             puncta_line_width_value,
@@ -336,6 +350,13 @@ def experiment(request):
             cen_dot_source_unit,
             minimum_px=0,
             fallback_px=37,
+            microns_per_pixel=posted_microns_per_pixel,
+        )
+        cen_dot_proximity_radius = _convert_length_to_pixels(
+            cen_dot_proximity_radius_value,
+            cen_dot_proximity_radius_source_unit,
+            minimum_px=0,
+            fallback_px=13,
             microns_per_pixel=posted_microns_per_pixel,
         )
 
@@ -364,12 +385,15 @@ def experiment(request):
         request.session["punctaLineWidth"] = puncta_line_width
         request.session["cenDotDistance"] = cen_dot_distance
         request.session["cenDotCollinearityThreshold"] = cen_dot_collinearity_threshold
+        request.session["cenDotProximityRadius"] = cen_dot_proximity_radius
         request.session["stats_puncta_line_width_unit"] = puncta_line_width_unit
         request.session["stats_cen_dot_distance_unit"] = cen_dot_distance_unit
+        request.session["stats_cen_dot_proximity_radius_unit"] = cen_dot_proximity_radius_unit
         request.session["stats_microns_per_pixel"] = posted_microns_per_pixel
         request.session["stats_use_metadata_scale"] = stats_use_metadata_scale
         request.session["stats_puncta_line_width_value"] = puncta_line_width_value
         request.session["stats_cen_dot_distance_value"] = cen_dot_distance_value
+        request.session["stats_cen_dot_proximity_radius_value"] = cen_dot_proximity_radius_value
         request.session["puncta_line_mode"] = _parse_puncta_line_mode(
             request.POST.get("puncta_line_mode"),
             default=DEFAULT_PUNCTA_LINE_MODE,

--- a/cytocv/core/views/segment_image.py
+++ b/cytocv/core/views/segment_image.py
@@ -183,6 +183,7 @@ def get_stats(
     puncta_line_width,
     cen_dot_distance,
     cen_dot_collinearity_threshold,
+    cen_dot_proximity_radius=13,
     green_contour_filter_enabled=False,
     alternate_red_detection=False,
     cached_images=None,
@@ -335,6 +336,7 @@ def get_stats(
             puncta_line_width,
             cen_dot_distance,
             cen_dot_collinearity_threshold,
+            cen_dot_proximity_radius,
         )
 
     # Convert BGR back to RGB so PIL shows correct colors
@@ -1090,6 +1092,39 @@ def segment_image(request, uuids):
             cen_dot_collinearity_threshold = 66
         if cen_dot_collinearity_threshold < 0:
             cen_dot_collinearity_threshold = 66
+        raw_cen_dot_proximity_radius = request.session.get(
+            'stats_cen_dot_proximity_radius_value',
+            request.session.get('cenDotProximityRadius', 13),
+        )
+        cen_dot_proximity_radius_unit = normalize_length_unit(
+            request.session.get('stats_cen_dot_proximity_radius_unit', 'px'),
+            default="px",
+        )
+        if cen_dot_proximity_radius_unit == "um":
+            try:
+                cen_dot_proximity_radius = float(raw_cen_dot_proximity_radius)
+            except (TypeError, ValueError):
+                cen_dot_proximity_radius = 13.0
+            if not math.isfinite(cen_dot_proximity_radius) or cen_dot_proximity_radius < 0:
+                cen_dot_proximity_radius = 13.0
+            cen_dot_proximity_radius_px_equivalent = convert_length_to_pixels(
+                cen_dot_proximity_radius,
+                "um",
+                minimum_px=0,
+                fallback_px=13,
+                um_per_px=line_width_proxy_um_per_px,
+            )
+        else:
+            cen_dot_proximity_radius = float(
+                convert_length_to_pixels(
+                    raw_cen_dot_proximity_radius,
+                    cen_dot_proximity_radius_unit,
+                    minimum_px=0,
+                    fallback_px=13,
+                    um_per_px=effective_um_per_px,
+                )
+            )
+            cen_dot_proximity_radius_px_equivalent = int(cen_dot_proximity_radius)
         green_contour_filter_enabled = request.session.get(
             'greenContourFilterEnabled',
             request.session.get('gfpFilterEnabled', 'False'),
@@ -1159,6 +1194,8 @@ def segment_image(request, uuids):
                 ),
                 puncta_line_width_unit=puncta_line_width_unit,
                 cen_dot_distance_unit=cen_dot_distance_unit,
+                cen_dot_proximity_radius=cen_dot_proximity_radius,
+                cen_dot_proximity_radius_unit=cen_dot_proximity_radius_unit,
             ),
         )
 
@@ -1229,6 +1266,9 @@ def segment_image(request, uuids):
             cp.properties["stats_cen_dot_distance_mode"] = cen_dot_distance_mode
             cp.properties["stats_puncta_line_width_unit"] = puncta_line_width_unit
             cp.properties["stats_cen_dot_distance_unit"] = cen_dot_distance_unit
+            cp.properties["stats_cen_dot_proximity_radius_px"] = cen_dot_proximity_radius_px_equivalent
+            cp.properties["stats_cen_dot_proximity_radius_value"] = cen_dot_proximity_radius
+            cp.properties["stats_cen_dot_proximity_radius_unit"] = cen_dot_proximity_radius_unit
             # Call get_stats to do the real work
             debug_red, debug_green, debug_blue = get_stats(
                 cp,
@@ -1237,6 +1277,7 @@ def segment_image(request, uuids):
                 puncta_line_width,
                 cen_dot_distance,
                 cen_dot_collinearity_threshold,
+                cen_dot_proximity_radius,
                 green_contour_filter_enabled,
                 alternate_red_detection,
                 cached_images=cell_image_cache.get(cell_number),

--- a/cytocv/core/views/segment_image.py
+++ b/cytocv/core/views/segment_image.py
@@ -96,6 +96,7 @@ from core.services.artifact_storage import (
     save_png_array,
 )
 from core.services.canonical_contours import (
+    CANONICAL_BLUE_SLOTS_KEY,
     build_canonical_contour_payload,
     flatten_slot_contours,
 )
@@ -262,74 +263,28 @@ def get_stats(
     canonical_red_contours = flatten_slot_contours(contours_data.get("canonical_red_slots", []))
     canonical_green_contours = flatten_slot_contours(contours_data.get("canonical_green_slots", []))
 
-    best_contour_data = {}
-    best_contour_blue = None
-    best_blue_area = None
-    blue_gray = preprocessed_images.get_image("gray_blue")
-    if blue_gray is not None:
-        image_area = float(blue_gray.shape[0] * blue_gray.shape[1])
-        min_blue_area = max(10.0, image_area * 0.002)
-        max_blue_area = image_area * 0.95
-
-        def _pick_first_valid(contours, indices):
-            for idx in indices:
-                if idx >= len(contours):
-                    continue
-                cnt = contours[idx]
-                area = cv2.contourArea(cnt)
-                if min_blue_area <= area <= max_blue_area:
-                    return cnt, area
-            return None, None
-
-        best_contour_blue, best_blue_area = _pick_first_valid(
-            contours_data.get("contours_blue_3", []),
-            contours_data.get("best_contours_blue_3", []),
-        )
-
-        if best_contour_blue is None:
-            best_contour_blue, best_blue_area = _pick_first_valid(
-                contours_data.get("contours_blue", []),
-                contours_data.get("best_contours_blue", []),
-            )
-
-        if best_contour_blue is None and contours_data.get("contours_blue"):
-            valid_blue = []
-            for cnt in contours_data["contours_blue"]:
-                area = cv2.contourArea(cnt)
-                if min_blue_area <= area <= max_blue_area:
-                    valid_blue.append((area, cnt))
-            if valid_blue:
-                valid_blue.sort(key=lambda item: item[0], reverse=True)
-                best_blue_area, best_contour_blue = valid_blue[0]
-
-    if best_contour_blue is not None:
-        best_contour_data["Blue"] = best_contour_blue
-        cp.blue_contour_size = float(best_blue_area)
-    else:
-        cp.blue_contour_size = 0.0
+    canonical_blue_slots = contours_data.get(CANONICAL_BLUE_SLOTS_KEY, [])
+    canonical_blue_contours = flatten_slot_contours(canonical_blue_slots)
+    cp.blue_contour_size = float(canonical_blue_slots[0].area) if canonical_blue_slots else 0.0
 
     if canonical_red_contours:
         cv2.drawContours(edit_red_img, canonical_red_contours, -1, (0, 0, 255), 1)
         cv2.drawContours(edit_green_img, canonical_red_contours, -1, (0, 0, 255), 1)
         cv2.drawContours(edit_blue_img, canonical_red_contours, -1, (0, 0, 255), 1)
 
-    if best_contour_blue is not None:
-        cv2.drawContours(edit_green_img, [best_contour_blue], 0, (255, 0, 0), 1)
-        cv2.drawContours(edit_blue_img, [best_contour_blue], 0, (255, 0, 0), 1)
+    if canonical_blue_contours:
+        cv2.drawContours(edit_green_img, canonical_blue_contours, -1, (255, 0, 0), 1)
+        cv2.drawContours(edit_blue_img, canonical_blue_contours, -1, (255, 0, 0), 1)
 
     if canonical_green_contours:
         cv2.drawContours(edit_red_img, canonical_green_contours, -1, (0, 255, 0), 1)
         cv2.drawContours(edit_green_img, canonical_green_contours, -1, (0, 255, 0), 1)
         cv2.drawContours(edit_blue_img, canonical_green_contours, -1, (0, 255, 0), 1)
 
-    blue_contour_required_plugins = {"NucleusIntensity", "BlueNucleusIntensity"}
     for analysis in execution_plan.analyses:
-        analysis_name = analysis.__class__.__name__
-        if analysis_name in blue_contour_required_plugins and "Blue" not in best_contour_data:
-            continue
         analysis.setting_up(cp, preprocessed_images, output_dir)
         analysis.calculate_statistics(
-            best_contour_data,
+            {},
             contours_data,
             edit_red_img,
             edit_green_img,

--- a/cytocv/templates/form/experiment.html
+++ b/cytocv/templates/form/experiment.html
@@ -1865,6 +1865,7 @@
     const initializedKey = 'cytocv.selected_analyses_initialized.v3';
     const widthKey = 'cytocv.puncta_line_width.v3';
     const distanceKey = 'cytocv.cen_dot_distance.v2';
+    const proximityRadiusKey = 'cytocv.cen_dot_proximity_radius.v1';
     const thresholdKey = 'cytocv.cen_dot_collinearity_threshold.v2';
     const advancedKey = 'cytocv.advanced_validation.v3';
     const punctaModeKey = 'cytocv.puncta_line_mode.v1';
@@ -1872,6 +1873,7 @@
     const legacyLengthUnitKey = 'cytocv.stats_length_unit.v2';
     const punctaLineWidthUnitKey = 'cytocv.puncta_line_width_unit.v3';
     const cenDotDistanceUnitKey = 'cytocv.cen_dot_distance_unit.v2';
+    const cenDotProximityRadiusUnitKey = 'cytocv.cen_dot_proximity_radius_unit.v1';
     const micronsPerPixelKey = 'cytocv.stats_microns_per_pixel.v2';
     const useMetadataScaleKey = 'cytocv.use_metadata_scale.v2';
     const DEFAULT_MICRONS_PER_PIXEL = 0.1;
@@ -1904,6 +1906,7 @@
         manualRequiredChannels: new Set(),
         punctaLineWidth: 1,
         cenDotDistance: 37,
+        cenDotProximityRadius: 13,
         cenDotCollinearityThreshold: 66,
         punctaLineMode: 'red_puncta',
         nuclearCellPairMode: 'green_nucleus',
@@ -1911,6 +1914,7 @@
         alternateRedDetection: false,
         punctaLineWidthUnit: 'px',
         cenDotDistanceUnit: 'px',
+        cenDotProximityRadiusUnit: 'px',
         micronsPerPixel: DEFAULT_MICRONS_PER_PIXEL,
         useMetadataScale: true,
     };
@@ -1923,6 +1927,7 @@
     let punctaLineWidthRow = null;
     let cenDotDistanceInput = null;
     let cenDotDistanceRow = null;
+    let cenDotProximityRadiusInput = null;
     let cenDotCollinearityThresholdInput = null;
     let micronsPerPixelInput = null;
     let useMetadataScaleInput = null;
@@ -1964,16 +1969,20 @@
 
         const widthUnit = (serverPreferenceDefaults.puncta_line_width_unit === 'um') ? 'um' : 'px';
         const distanceUnit = (serverPreferenceDefaults.cen_dot_distance_unit === 'um') ? 'um' : 'px';
+        const proximityRadiusUnit = (serverPreferenceDefaults.cen_dot_proximity_radius_unit === 'um') ? 'um' : 'px';
         localStorage.setItem(punctaLineWidthUnitKey, widthUnit);
         localStorage.setItem(cenDotDistanceUnitKey, distanceUnit);
+        localStorage.setItem(cenDotProximityRadiusUnitKey, proximityRadiusUnit);
         localStorage.setItem(legacyLengthUnitKey, widthUnit === distanceUnit ? widthUnit : 'mixed');
 
         const width = Number(serverPreferenceDefaults.puncta_line_width);
         const distance = Number(serverPreferenceDefaults.cen_dot_distance);
+        const proximityRadius = Number(serverPreferenceDefaults.cen_dot_proximity_radius);
         const threshold = Number(serverPreferenceDefaults.cen_dot_collinearity_threshold);
         const micronsPerPixel = Number(serverPreferenceDefaults.microns_per_pixel);
         localStorage.setItem(widthKey, Number.isFinite(width) ? String(width) : '1');
         localStorage.setItem(distanceKey, Number.isFinite(distance) ? String(distance) : '37');
+        localStorage.setItem(proximityRadiusKey, Number.isFinite(proximityRadius) ? String(proximityRadius) : '13');
         localStorage.setItem(thresholdKey, Number.isFinite(threshold) ? String(Math.max(0, Math.round(threshold))) : '66');
         localStorage.setItem(
             micronsPerPixelKey,
@@ -2457,9 +2466,16 @@
             : 37;
     }
 
+    function defaultProximityRadiusForUnit(unit) {
+        return unit === 'um'
+            ? 13 * sanitizeMicronsPerPixel(statsState.micronsPerPixel)
+            : 13;
+    }
+
     function getLengthUnitForField(field) {
         if (field === 'punctaLineWidth') return statsState.punctaLineWidthUnit;
         if (field === 'cenDotDistance') return statsState.cenDotDistanceUnit;
+        if (field === 'cenDotProximityRadius') return statsState.cenDotProximityRadiusUnit;
         return 'px';
     }
 
@@ -2471,12 +2487,17 @@
         }
         if (field === 'cenDotDistance') {
             statsState.cenDotDistanceUnit = normalized;
+            return;
+        }
+        if (field === 'cenDotProximityRadius') {
+            statsState.cenDotProximityRadiusUnit = normalized;
         }
     }
 
     function getLengthValueForField(field) {
         if (field === 'punctaLineWidth') return statsState.punctaLineWidth;
         if (field === 'cenDotDistance') return statsState.cenDotDistance;
+        if (field === 'cenDotProximityRadius') return statsState.cenDotProximityRadius;
         return 0;
     }
 
@@ -2487,6 +2508,10 @@
         }
         if (field === 'cenDotDistance') {
             statsState.cenDotDistance = value;
+            return;
+        }
+        if (field === 'cenDotProximityRadius') {
+            statsState.cenDotProximityRadius = value;
         }
     }
 
@@ -2505,6 +2530,7 @@
     function persistLengthUnitSettings() {
         localStorage.setItem(punctaLineWidthUnitKey, statsState.punctaLineWidthUnit);
         localStorage.setItem(cenDotDistanceUnitKey, statsState.cenDotDistanceUnit);
+        localStorage.setItem(cenDotProximityRadiusUnitKey, statsState.cenDotProximityRadiusUnit);
         localStorage.setItem(micronsPerPixelKey, String(statsState.micronsPerPixel));
         localStorage.setItem(useMetadataScaleKey, String(!!statsState.useMetadataScale));
     }
@@ -2553,9 +2579,9 @@
         const currentValue = getLengthValueForField(field);
         let converted = convertLengthValueToUnit(currentValue, currentUnit, normalizedNext);
         if (!Number.isFinite(converted)) {
-            converted = field === 'punctaLineWidth'
-                ? defaultWidthForUnit(normalizedNext)
-                : defaultDistanceForUnit(normalizedNext);
+            if (field === 'punctaLineWidth') converted = defaultWidthForUnit(normalizedNext);
+            else if (field === 'cenDotProximityRadius') converted = defaultProximityRadiusForUnit(normalizedNext);
+            else converted = defaultDistanceForUnit(normalizedNext);
         }
 
         if (field === 'punctaLineWidth') {
@@ -2566,9 +2592,12 @@
             if (normalizedNext === 'px') {
                 converted = Math.round(converted);
             }
-        } else if (field === 'cenDotDistance') {
+        } else if (field === 'cenDotDistance' || field === 'cenDotProximityRadius') {
+            const fallback = field === 'cenDotProximityRadius'
+                ? defaultProximityRadiusForUnit(normalizedNext)
+                : defaultDistanceForUnit(normalizedNext);
             if (converted < 0) {
-                converted = defaultDistanceForUnit(normalizedNext);
+                converted = fallback;
             }
             if (normalizedNext === 'px') {
                 converted = Math.round(converted);
@@ -2582,6 +2611,8 @@
             localStorage.setItem(widthKey, String(statsState.punctaLineWidth));
         } else if (field === 'cenDotDistance') {
             localStorage.setItem(distanceKey, String(statsState.cenDotDistance));
+        } else if (field === 'cenDotProximityRadius') {
+            localStorage.setItem(proximityRadiusKey, String(statsState.cenDotProximityRadius));
         }
         syncStatsUI();
     }
@@ -2713,6 +2744,9 @@
         if (statsState.cenDotDistanceUnit === 'px') {
             statsState.cenDotDistance = Math.max(0, Math.round(Number(statsState.cenDotDistance) || 0));
         }
+        if (statsState.cenDotProximityRadiusUnit === 'px') {
+            statsState.cenDotProximityRadius = Math.max(0, Math.round(Number(statsState.cenDotProximityRadius) || 0));
+        }
         lengthUnitSelectElements.forEach((control) => {
             control.setUnit(getLengthUnitForField(control.field));
         });
@@ -2738,6 +2772,17 @@
             }
             cenDotDistanceInput.value = formatNumericInputValue(statsState.cenDotDistance);
         }
+
+        if (cenDotProximityRadiusInput) {
+            if (statsState.cenDotProximityRadiusUnit === 'um') {
+                cenDotProximityRadiusInput.step = '0.01';
+                cenDotProximityRadiusInput.min = '0';
+            } else {
+                cenDotProximityRadiusInput.step = '1';
+                cenDotProximityRadiusInput.min = '0';
+            }
+            cenDotProximityRadiusInput.value = formatNumericInputValue(statsState.cenDotProximityRadius);
+        }
     }
 
     function initializeStatsSettings() {
@@ -2749,6 +2794,7 @@
         loadStoredUseMetadataScale();
         loadStoredWidth();
         loadStoredDistance();
+        loadStoredProximityRadius();
         loadStoredThreshold();
         loadStoredPunctaMode();
         loadStoredNuclearMode();
@@ -2802,6 +2848,7 @@
         punctaLineWidthRow = null;
         cenDotDistanceInput = null;
         cenDotDistanceRow = null;
+        cenDotProximityRadiusInput = null;
         cenDotCollinearityThresholdInput = null;
         micronsPerPixelInput = null;
         punctaLineModeRow = null;
@@ -2975,6 +3022,30 @@
                 });
                 distanceLine.appendChild(distanceGroup.controls);
                 distanceRow.appendChild(distanceLine);
+
+                const proximityRadiusLine = document.createElement('div');
+                proximityRadiusLine.className = 'stats-distance-line';
+                const proximityRadiusLabel = document.createElement('label');
+                proximityRadiusLabel.setAttribute('for', 'cenDotProximityRadiusInput');
+                proximityRadiusLabel.textContent = 'Signal proximity radius:';
+                proximityRadiusLine.appendChild(proximityRadiusLabel);
+
+                const proximityRadiusGroup = buildLengthInputGroup({
+                    field: 'cenDotProximityRadius',
+                    inputId: 'cenDotProximityRadiusInput',
+                    minValue: 0,
+                    defaultValue: 13,
+                    onChange: () => {
+                        const fallback = defaultProximityRadiusForUnit(statsState.cenDotProximityRadiusUnit);
+                        statsState.cenDotProximityRadius = parseLengthValue(proximityRadiusGroup.input.value, statsState.cenDotProximityRadiusUnit, fallback, 0);
+                        proximityRadiusGroup.input.value = formatNumericInputValue(statsState.cenDotProximityRadius);
+                        localStorage.setItem(proximityRadiusKey, String(statsState.cenDotProximityRadius));
+                        updateMeasurementScaleHints();
+                    },
+                });
+                proximityRadiusLine.appendChild(proximityRadiusGroup.controls);
+                distanceRow.appendChild(proximityRadiusLine);
+                cenDotProximityRadiusInput = proximityRadiusGroup.input;
 
                 const thresholdLine = document.createElement('div');
                 thresholdLine.className = 'stats-distance-line stats-threshold-line';
@@ -3214,6 +3285,12 @@
                 `Minimum signal distance ${formatNumericInputValue(statsState.cenDotDistance, 3)} µm -> ${pxValue} px`
             );
         }
+        if (statsState.cenDotProximityRadiusUnit === 'um') {
+            const pxValue = convertLengthToPixels(statsState.cenDotProximityRadius, statsState.cenDotProximityRadiusUnit, 0, 13);
+            examples.push(
+                `Signal proximity radius ${formatNumericInputValue(statsState.cenDotProximityRadius, 3)} µm -> ${pxValue} px`
+            );
+        }
 
         setSmoothText(
             measurementScaleExampleHint,
@@ -3397,8 +3474,10 @@
         const legacyUnit = normalizeLengthUnit(localStorage.getItem(legacyLengthUnitKey));
         const storedWidthUnit = localStorage.getItem(punctaLineWidthUnitKey);
         const storedDistanceUnit = localStorage.getItem(cenDotDistanceUnitKey);
+        const storedProximityRadiusUnit = localStorage.getItem(cenDotProximityRadiusUnitKey);
         statsState.punctaLineWidthUnit = normalizeLengthUnit(storedWidthUnit || legacyUnit);
         statsState.cenDotDistanceUnit = normalizeLengthUnit(storedDistanceUnit || legacyUnit);
+        statsState.cenDotProximityRadiusUnit = normalizeLengthUnit(storedProximityRadiusUnit || legacyUnit);
     }
 
     function loadStoredMicronsPerPixel() {
@@ -3426,6 +3505,12 @@
         const raw = localStorage.getItem(distanceKey);
         const fallback = defaultDistanceForUnit(statsState.cenDotDistanceUnit);
         statsState.cenDotDistance = parseLengthValue(raw, statsState.cenDotDistanceUnit, fallback, 0);
+    }
+
+    function loadStoredProximityRadius() {
+        const raw = localStorage.getItem(proximityRadiusKey);
+        const fallback = defaultProximityRadiusForUnit(statsState.cenDotProximityRadiusUnit);
+        statsState.cenDotProximityRadius = parseLengthValue(raw, statsState.cenDotProximityRadiusUnit, fallback, 0);
     }
 
     function loadStoredThreshold() {
@@ -3565,6 +3650,9 @@
         }
         if (cenDotDistanceInput) {
             cenDotDistanceInput.value = formatNumericInputValue(statsState.cenDotDistance);
+        }
+        if (cenDotProximityRadiusInput) {
+            cenDotProximityRadiusInput.value = formatNumericInputValue(statsState.cenDotProximityRadius);
         }
         if (cenDotDistanceRow) {
             cenDotDistanceRow.classList.toggle('visible', statsState.selectedPlugins.has('CENDot'));
@@ -3768,6 +3856,7 @@
             manualRequiredChannels: [...statsState.manualRequiredChannels].sort(),
             punctaLineWidth: Number.isFinite(Number(statsState.punctaLineWidth)) ? Number(statsState.punctaLineWidth) : 1,
             cenDotDistance: Number.isFinite(Number(statsState.cenDotDistance)) ? Number(statsState.cenDotDistance) : 37,
+            cenDotProximityRadius: Number.isFinite(Number(statsState.cenDotProximityRadius)) ? Number(statsState.cenDotProximityRadius) : 13,
             cenDotCollinearityThreshold: Number.isFinite(Number(statsState.cenDotCollinearityThreshold)) ? Number(statsState.cenDotCollinearityThreshold) : 66,
             punctaLineMode: statsState.punctaLineMode === 'green_puncta' ? 'green_puncta' : 'red_puncta',
             nuclearCellPairMode: statsState.nuclearCellPairMode === 'red_nucleus' ? 'red_nucleus' : 'green_nucleus',
@@ -3775,6 +3864,7 @@
             alternateRedDetection: !!statsState.alternateRedDetection,
             punctaLineWidthUnit: normalizeLengthUnit(statsState.punctaLineWidthUnit),
             cenDotDistanceUnit: normalizeLengthUnit(statsState.cenDotDistanceUnit),
+            cenDotProximityRadiusUnit: normalizeLengthUnit(statsState.cenDotProximityRadiusUnit),
             micronsPerPixel: sanitizeMicronsPerPixel(statsState.micronsPerPixel),
             useMetadataScale: !!statsState.useMetadataScale,
         });
@@ -3803,6 +3893,7 @@
             );
             statsState.punctaLineWidthUnit = normalizeLengthUnit(snapshot.punctaLineWidthUnit);
             statsState.cenDotDistanceUnit = normalizeLengthUnit(snapshot.cenDotDistanceUnit);
+            statsState.cenDotProximityRadiusUnit = normalizeLengthUnit(snapshot.cenDotProximityRadiusUnit);
             statsState.micronsPerPixel = sanitizeMicronsPerPixel(snapshot.micronsPerPixel);
             statsState.useMetadataScale = !!snapshot.useMetadataScale;
             const widthMinimum = statsState.punctaLineWidthUnit === 'um' ? 0.01 : 1;
@@ -3810,6 +3901,8 @@
             statsState.punctaLineWidth = parseLengthValue(snapshot.punctaLineWidth, statsState.punctaLineWidthUnit, widthFallback, widthMinimum);
             const distanceFallback = defaultDistanceForUnit(statsState.cenDotDistanceUnit);
             statsState.cenDotDistance = parseLengthValue(snapshot.cenDotDistance, statsState.cenDotDistanceUnit, distanceFallback, 0);
+            const proximityRadiusFallback = defaultProximityRadiusForUnit(statsState.cenDotProximityRadiusUnit);
+            statsState.cenDotProximityRadius = parseLengthValue(snapshot.cenDotProximityRadius, statsState.cenDotProximityRadiusUnit, proximityRadiusFallback, 0);
             const parsedThreshold = parseInt(String(snapshot.cenDotCollinearityThreshold ?? 66), 10);
             statsState.cenDotCollinearityThreshold = Number.isFinite(parsedThreshold) && parsedThreshold >= 0 ? parsedThreshold : 66;
             statsState.punctaLineMode = snapshot.punctaLineMode === 'green_puncta' ? 'green_puncta' : 'red_puncta';
@@ -3828,6 +3921,7 @@
             persistAdvancedSettings();
             localStorage.setItem(widthKey, String(statsState.punctaLineWidth));
             localStorage.setItem(distanceKey, String(statsState.cenDotDistance));
+            localStorage.setItem(proximityRadiusKey, String(statsState.cenDotProximityRadius));
             localStorage.setItem(thresholdKey, String(statsState.cenDotCollinearityThreshold));
             localStorage.setItem(punctaModeKey, statsState.punctaLineMode);
             localStorage.setItem(nuclearModeKey, statsState.nuclearCellPairMode);
@@ -4555,6 +4649,12 @@
                 cenDotDistanceInput.value = formatNumericInputValue(statsState.cenDotDistance);
                 localStorage.setItem(distanceKey, String(statsState.cenDotDistance));
             }
+            if (cenDotProximityRadiusInput) {
+                const fallback = defaultProximityRadiusForUnit(statsState.cenDotProximityRadiusUnit);
+                statsState.cenDotProximityRadius = parseLengthValue(cenDotProximityRadiusInput.value, statsState.cenDotProximityRadiusUnit, fallback, 0);
+                cenDotProximityRadiusInput.value = formatNumericInputValue(statsState.cenDotProximityRadius);
+                localStorage.setItem(proximityRadiusKey, String(statsState.cenDotProximityRadius));
+            }
             if (cenDotCollinearityThresholdInput) {
                 const parsed = parseInt(cenDotCollinearityThresholdInput.value, 10);
                 statsState.cenDotCollinearityThreshold = Number.isFinite(parsed) && parsed >= 0 ? parsed : 66;
@@ -4569,7 +4669,7 @@
                 statsState.nuclearCellPairMode = nuclearModeSelect.value === 'red_nucleus' ? 'red_nucleus' : 'green_nucleus';
             }
             localStorage.setItem(nuclearModeKey, statsState.nuclearCellPairMode);
-            const usingMicrometers = statsState.punctaLineWidthUnit === 'um' || statsState.cenDotDistanceUnit === 'um';
+            const usingMicrometers = statsState.punctaLineWidthUnit === 'um' || statsState.cenDotDistanceUnit === 'um' || statsState.cenDotProximityRadiusUnit === 'um';
             if (usingMicrometers && !(Number.isFinite(statsState.micronsPerPixel) && statsState.micronsPerPixel > 0)) {
                 showErrors([
                     'Micrometers-per-pixel must be greater than 0 when using micrometer input.',
@@ -4579,6 +4679,7 @@
 
             const punctaLineWidthPixels = convertLengthToPixels(statsState.punctaLineWidth, statsState.punctaLineWidthUnit, 1, 1);
             const cenDotDistancePixels = convertLengthToPixels(statsState.cenDotDistance, statsState.cenDotDistanceUnit, 0, 37);
+            const cenDotProximityRadiusPixels = convertLengthToPixels(statsState.cenDotProximityRadius, statsState.cenDotProximityRadiusUnit, 0, 13);
 
             const submitBtn = document.getElementById('uploadSubmit');
             const btnText = submitBtn.querySelector('.btn-text');
@@ -4661,19 +4762,24 @@
             [...statsState.selectedPlugins].forEach((pluginId) => formData.append('selected_analysis', pluginId));
             formData.append('stats_puncta_line_width_value', String(statsState.punctaLineWidth));
             formData.append('stats_cen_dot_distance_value', String(statsState.cenDotDistance));
+            formData.append('stats_cen_dot_proximity_radius_value', String(statsState.cenDotProximityRadius));
             formData.append('punctaLineWidth', String(punctaLineWidthPixels));
             formData.append('cenDotDistance', String(cenDotDistancePixels));
+            formData.append('cenDotProximityRadius', String(cenDotProximityRadiusPixels));
             formData.append('cenDotCollinearityThreshold', String(statsState.cenDotCollinearityThreshold));
             formData.append('puncta_line_mode', statsState.punctaLineMode);
             formData.append('nuclear_cell_pair_mode', statsState.nuclearCellPairMode);
             formData.append('greenContourFilterEnabled', String(statsState.greenContourFilterEnabled));
             formData.append('alternateRedDetection', String(statsState.alternateRedDetection));
-            const sharedLengthUnit = statsState.punctaLineWidthUnit === statsState.cenDotDistanceUnit
+            const allUnitsMatch = statsState.punctaLineWidthUnit === statsState.cenDotDistanceUnit
+                && statsState.cenDotDistanceUnit === statsState.cenDotProximityRadiusUnit;
+            const sharedLengthUnit = allUnitsMatch
                 ? statsState.punctaLineWidthUnit
                 : 'mixed';
             formData.append('stats_length_unit', sharedLengthUnit);
             formData.append('stats_puncta_line_width_unit', statsState.punctaLineWidthUnit);
             formData.append('stats_cen_dot_distance_unit', statsState.cenDotDistanceUnit);
+            formData.append('stats_cen_dot_proximity_radius_unit', statsState.cenDotProximityRadiusUnit);
             formData.append('stats_microns_per_pixel', String(statsState.micronsPerPixel));
             formData.append('stats_use_metadata_scale', statsState.useMetadataScale ? '1' : '0');
 

--- a/cytocv/templates/workflow_defaults.html
+++ b/cytocv/templates/workflow_defaults.html
@@ -1069,6 +1069,13 @@ main.main > section.panel {
                   </div>
                 </div>
                 <div class="plugin-measure-line">
+                  <label for="cen_dot_proximity_radius">Signal proximity radius:</label>
+                  <div class="length-input-group plugin-measure-right">
+                    <input type="number" step="0.01" min="0" id="cen_dot_proximity_radius" name="cen_dot_proximity_radius" value="{{ preferences.experiment_defaults.cen_dot_proximity_radius }}">
+                    <select id="cen_dot_proximity_radius_unit" name="cen_dot_proximity_radius_unit"><option value="px" {% if preferences.experiment_defaults.cen_dot_proximity_radius_unit == 'px' %}selected{% endif %}>px</option><option value="um" {% if preferences.experiment_defaults.cen_dot_proximity_radius_unit == 'um' %}selected{% endif %}>µm</option></select>
+                  </div>
+                </div>
+                <div class="plugin-measure-line">
                   <label for="cen_dot_collinearity_threshold">Biorientation collinearity threshold:</label>
                   <div class="boxed-number-group plugin-measure-right">
                     <input type="number" min="0" id="cen_dot_collinearity_threshold" name="cen_dot_collinearity_threshold" value="{{ preferences.experiment_defaults.cen_dot_collinearity_threshold }}">
@@ -2038,6 +2045,8 @@ main.main > section.panel {
   const redWidthUnit = document.getElementById('puncta_line_width_unit');
   const cenDotDistanceInput = document.getElementById('cen_dot_distance');
   const cenDotDistanceUnit = document.getElementById('cen_dot_distance_unit');
+  const cenDotProximityRadiusInput = document.getElementById('cen_dot_proximity_radius');
+  const cenDotProximityRadiusUnit = document.getElementById('cen_dot_proximity_radius_unit');
   const cenDotCollinearityThresholdInput = document.getElementById('cen_dot_collinearity_threshold');
   const punctaLineModeInput = document.getElementById('puncta_line_mode');
   const nuclearCellPairModeInput = document.getElementById('nuclear_cell_pair_mode');
@@ -2199,6 +2208,12 @@ main.main > section.panel {
         examples.push(`Minimum signal distance ${formatNumeric(cenDotDistanceInput.value, 3)} µm -> ${px} px`);
       }
     }
+    if (cenDotProximityRadiusUnit && cenDotProximityRadiusInput && cenDotProximityRadiusUnit.value === 'um') {
+      const px = convertUmToPixels(cenDotProximityRadiusInput.value, umPerPx);
+      if (px > 0) {
+        examples.push(`Signal proximity radius ${formatNumeric(cenDotProximityRadiusInput.value, 3)} µm -> ${px} px`);
+      }
+    }
     prefsScaleExample.textContent = examples.length
       ? `Live conversion: ${examples.join(' | ')}`
       : 'Set a plugin length unit to µm to preview its pixel conversion here.';
@@ -2218,6 +2233,8 @@ main.main > section.panel {
     redWidthUnit: normalizeLengthUnit(valueOrEmpty(redWidthUnit)),
     cenDotDistance: captureNumericField(cenDotDistanceInput),
     cenDotDistanceUnit: normalizeLengthUnit(valueOrEmpty(cenDotDistanceUnit)),
+    cenDotProximityRadius: captureNumericField(cenDotProximityRadiusInput),
+    cenDotProximityRadiusUnit: normalizeLengthUnit(valueOrEmpty(cenDotProximityRadiusUnit)),
     cenDotCollinearityThreshold: captureNumericField(cenDotCollinearityThresholdInput),
     punctaLineMode: valueOrEmpty(punctaLineModeInput) || 'red_puncta',
     nuclearCellPairMode: valueOrEmpty(nuclearCellPairModeInput) || 'green_nucleus',
@@ -2280,6 +2297,14 @@ main.main > section.panel {
     ) {
       changes.push(
         `Minimum signal distance: ${numericDisplay(fromSnapshot.cenDotDistance)} ${formatLengthUnitLabel(fromSnapshot.cenDotDistanceUnit)} -> ${numericDisplay(toSnapshot.cenDotDistance)} ${formatLengthUnitLabel(toSnapshot.cenDotDistanceUnit)}`
+      );
+    }
+    if (
+      fromSnapshot.cenDotProximityRadius.normalized !== toSnapshot.cenDotProximityRadius.normalized ||
+      fromSnapshot.cenDotProximityRadiusUnit !== toSnapshot.cenDotProximityRadiusUnit
+    ) {
+      changes.push(
+        `Signal proximity radius: ${numericDisplay(fromSnapshot.cenDotProximityRadius)} ${formatLengthUnitLabel(fromSnapshot.cenDotProximityRadiusUnit)} -> ${numericDisplay(toSnapshot.cenDotProximityRadius)} ${formatLengthUnitLabel(toSnapshot.cenDotProximityRadiusUnit)}`
       );
     }
     if (fromSnapshot.cenDotCollinearityThreshold.normalized !== toSnapshot.cenDotCollinearityThreshold.normalized) {
@@ -2468,6 +2493,12 @@ main.main > section.panel {
       cenDotDistanceUnit.dataset.prevUnit = snapshot.cenDotDistanceUnit;
       syncLengthInputConstraints(cenDotDistanceInput, snapshot.cenDotDistanceUnit, 0, 0);
     }
+    if (cenDotProximityRadiusInput) cenDotProximityRadiusInput.value = snapshot.cenDotProximityRadius.raw;
+    if (cenDotProximityRadiusUnit) {
+      cenDotProximityRadiusUnit.value = snapshot.cenDotProximityRadiusUnit;
+      cenDotProximityRadiusUnit.dataset.prevUnit = snapshot.cenDotProximityRadiusUnit;
+      syncLengthInputConstraints(cenDotProximityRadiusInput, snapshot.cenDotProximityRadiusUnit, 0, 0);
+    }
     if (cenDotCollinearityThresholdInput) cenDotCollinearityThresholdInput.value = snapshot.cenDotCollinearityThreshold.raw;
     if (punctaLineModeInput) punctaLineModeInput.value = snapshot.punctaLineMode === 'green_puncta' ? 'green_puncta' : 'red_puncta';
     if (nuclearCellPairModeInput) nuclearCellPairModeInput.value = snapshot.nuclearCellPairMode;
@@ -2653,6 +2684,20 @@ main.main > section.panel {
         minimumPx: 0,
         minimumUm: 0,
         defaultForUnit: (unit, umPerPx) => (normalizeLengthUnit(unit) === 'um' ? 37 * umPerPx : 37),
+        minimumForUnit: () => 0,
+      });
+      updateMeasurementScaleHelp();
+    });
+  }
+
+  if (cenDotProximityRadiusInput && cenDotProximityRadiusUnit) {
+    cenDotProximityRadiusUnit.dataset.prevUnit = normalizeLengthUnit(cenDotProximityRadiusUnit.value);
+    syncLengthInputConstraints(cenDotProximityRadiusInput, cenDotProximityRadiusUnit.value, 0, 0);
+    cenDotProximityRadiusUnit.addEventListener('change', () => {
+      applyUnitConversion(cenDotProximityRadiusInput, cenDotProximityRadiusUnit, {
+        minimumPx: 0,
+        minimumUm: 0,
+        defaultForUnit: (unit, umPerPx) => (normalizeLengthUnit(unit) === 'um' ? 13 * umPerPx : 13),
         minimumForUnit: () => 0,
       });
       updateMeasurementScaleHelp();


### PR DESCRIPTION
This pull request introduces support for a new "blue" (nucleus) contour slot and improves how nucleus and cell intensities are calculated for both blue and green channels. It also adds configuration and consistent handling for the "cen dot proximity radius" parameter throughout the codebase, including units and pixel conversion. Several analysis modules are refactored to use new, more robust contour and mask selection logic.

**Blue contour slot support and intensity calculation improvements:**

* Added support for canonical blue contour slots (`CANONICAL_BLUE_SLOTS_KEY`) and helper functions such as `get_canonical_blue_slots` and `_select_raw_blue_contours` in `canonical_contours.py`, enabling consistent selection and use of blue contours for nucleus intensity calculations. [[1]](diffhunk://#diff-da501fff9a8398a1a7334ac5ec3abaa7d05a9955b5804e9fc1bcb47ff5ecf7b6R17) [[2]](diffhunk://#diff-da501fff9a8398a1a7334ac5ec3abaa7d05a9955b5804e9fc1bcb47ff5ecf7b6R131-R149) [[3]](diffhunk://#diff-da501fff9a8398a1a7334ac5ec3abaa7d05a9955b5804e9fc1bcb47ff5ecf7b6R177-R182) [[4]](diffhunk://#diff-da501fff9a8398a1a7334ac5ec3abaa7d05a9955b5804e9fc1bcb47ff5ecf7b6R232-R251)
* Refactored `blue_nucleus_intensity.py` and `nucleus_intensity.py` to use the new blue slot and cell mask logic, replacing manual mask construction and file reading with `get_canonical_blue_slots` and `load_cell_mask`, improving robustness and maintainability. [[1]](diffhunk://#diff-d0a1c4ca49b01411a245caab8df664d30021289edda38b7ff13c3f2a7b3b1dd9R29-R78) [[2]](diffhunk://#diff-a9b8433d6f01288f53e5ea56d2ba7d38c453e436a1d9b99ddae5dd4234cd4c50R25-R71)

**Cen dot proximity radius parameterization and unit handling:**

* Added `cen_dot_proximity_radius` and `cen_dot_proximity_radius_unit` to preferences, normalization, and overlay rendering, ensuring this parameter is consistently configurable and converted to pixels as needed. [[1]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379R35-R42) [[2]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379R208-R216) [[3]](diffhunk://#diff-fef90c7f659bbbec01c491c55a19fe49407cecef117e02858bb1d4ec7daff174R147-R148) [[4]](diffhunk://#diff-fef90c7f659bbbec01c491c55a19fe49407cecef117e02858bb1d4ec7daff174R175-R178) [[5]](diffhunk://#diff-79c928a30ea49ada35fbdca5c5fbe02ce47df773a11018f47ec5e42f15ccc04fR570-R602)
* Updated all relevant `calculate_statistics` methods across analysis modules to accept and use the new `cen_dot_proximity_radius` parameter, defaulting to 13. [[1]](diffhunk://#diff-1f1a5afc1de63e9dee4541b5f5a9d9a5c67c025ccd957f4564125e553caa5c3aR35) [[2]](diffhunk://#diff-d0a1c4ca49b01411a245caab8df664d30021289edda38b7ff13c3f2a7b3b1dd9R29-R78) [[3]](diffhunk://#diff-673c37dbbdbce7d31a4eba7f822196e3a16220570c6d1463058aa610f3c3440bR101-R103) [[4]](diffhunk://#diff-0c861ad0138f6c820b2e820502b3d32b441a5805272a41eb15d3bcb84918ceaaR35) [[5]](diffhunk://#diff-c4441932788d895102f919f56f12a4f4d4455c180b67f2f776b26119fda57459R97) [[6]](diffhunk://#diff-b869d1a3c9f05ddb6601fe191467c5853f861670dcb319bc49fc16807008e00bR41) [[7]](diffhunk://#diff-ec6bd6d9b9554b525bfa4068b10144d937b3d8d8aeadd6475771a1d2dfb423adR17)
* Implemented unit-aware conversion for proximity radius in `cen_dot.py`, ensuring correct pixel values regardless of input units. [[1]](diffhunk://#diff-673c37dbbdbce7d31a4eba7f822196e3a16220570c6d1463058aa610f3c3440bR71-R91) [[2]](diffhunk://#diff-673c37dbbdbce7d31a4eba7f822196e3a16220570c6d1463058aa610f3c3440bR101-R103)

**Code cleanup and minor improvements:**

* Cleaned up unused imports and improved docstrings for clarity in several analysis modules. [[1]](diffhunk://#diff-d0a1c4ca49b01411a245caab8df664d30021289edda38b7ff13c3f2a7b3b1dd9L1-R12) [[2]](diffhunk://#diff-a9b8433d6f01288f53e5ea56d2ba7d38c453e436a1d9b99ddae5dd4234cd4c50L1-R12) [[3]](diffhunk://#diff-a9b8433d6f01288f53e5ea56d2ba7d38c453e436a1d9b99ddae5dd4234cd4c50R25-R71)
* Updated overlay rendering configuration and segmentation pipeline to pass and use the new proximity radius and its unit, ensuring overlays and batch segmentation are consistent with analysis logic. [[1]](diffhunk://#diff-fef90c7f659bbbec01c491c55a19fe49407cecef117e02858bb1d4ec7daff174R327) [[2]](diffhunk://#diff-79c928a30ea49ada35fbdca5c5fbe02ce47df773a11018f47ec5e42f15ccc04fR570-R602)

These changes enhance the accuracy, configurability, and maintainability of cell intensity analysis, especially for blue (nucleus) channel measurements.