### PR TITLE
Refactor main-image URL resolver and improve sidebar layout

### DIFF
--- a/cytocv/accounts/views/profile.py
+++ b/cytocv/accounts/views/profile.py
@@ -47,6 +47,7 @@ from core.services.artifact_storage import (
     sweep_user_run_artifacts,
 )
 from core.services.cell_statistics_payload import serialize_cell_statistics_payload
+from core.services.main_image_urls import build_main_image_paths
 from core.services.overlay_rendering import build_overlay_image_url, overlay_render_config_exists
 from core.services.puncta_line_mode import (
     DEFAULT_PUNCTA_LINE_MODE,
@@ -715,6 +716,12 @@ def _build_dashboard_payload(user: Any) -> dict[str, Any]:
                 "The statistics table is still available when data exists."
             )
 
+        main_image_paths = build_main_image_paths(
+            uuid=uuid,
+            image_name=image_name,
+            channel_config=channel_config,
+            available_frames=output_frames,
+        )
         default_frame_idx = channel_config.get(
             CHANNEL_ROLE_RED,
             DEFAULT_CHANNEL_CONFIG.get(CHANNEL_ROLE_RED, 0),
@@ -728,6 +735,7 @@ def _build_dashboard_payload(user: Any) -> dict[str, Any]:
 
         files_data[uuid] = {
             "MainImagePath": main_image_url or "",
+            "MainImagePaths": main_image_paths,
             "NumberOfCells": number_of_cells,
             "CellPairImages": cell_images,
             "Image_Name": image_name,

--- a/cytocv/core/services/main_image_urls.py
+++ b/cytocv/core/services/main_image_urls.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+from django.conf import settings
+
+from core.channel_roles import (
+    CHANNEL_ROLE_BLUE,
+    CHANNEL_ROLE_DIC,
+    CHANNEL_ROLE_GREEN,
+    CHANNEL_ROLE_RED,
+    channel_slug,
+)
+from core.config import DEFAULT_CHANNEL_CONFIG
+
+MAIN_IMAGE_CHANNEL_ROLES: tuple[str, ...] = (
+    CHANNEL_ROLE_DIC,
+    CHANNEL_ROLE_BLUE,
+    CHANNEL_ROLE_RED,
+    CHANNEL_ROLE_GREEN,
+)
+
+
+def resolve_main_image_url(
+    *,
+    uuid: str,
+    image_name: str,
+    channel_role: str,
+    channel_config: Mapping[str, int],
+    available_frames: Mapping[int, str],
+) -> str:
+    fallback_frame_idx = int(DEFAULT_CHANNEL_CONFIG.get(channel_role, 0))
+    configured_frame_idx = int(channel_config.get(channel_role, fallback_frame_idx))
+    resolved = available_frames.get(configured_frame_idx)
+    if not resolved:
+        resolved = available_frames.get(fallback_frame_idx)
+    if not resolved and available_frames:
+        first_idx = sorted(available_frames.keys())[0]
+        resolved = available_frames[first_idx]
+    if resolved:
+        return resolved
+
+    image_stem = Path(str(image_name or "")).stem
+    image_file_name = f"{image_stem}_frame_{fallback_frame_idx}"
+    return f"{settings.MEDIA_URL}{uuid}/output/{image_file_name}.png"
+
+
+def build_main_image_paths(
+    *,
+    uuid: str,
+    image_name: str,
+    channel_config: Mapping[str, int],
+    available_frames: Mapping[int, str],
+) -> dict[str, str]:
+    return {
+        channel_slug(channel_role): resolve_main_image_url(
+            uuid=uuid,
+            image_name=image_name,
+            channel_role=channel_role,
+            channel_config=channel_config,
+            available_frames=available_frames,
+        )
+        for channel_role in MAIN_IMAGE_CHANNEL_ROLES
+    }

--- a/cytocv/core/tests/test_core_app.py
+++ b/cytocv/core/tests/test_core_app.py
@@ -133,6 +133,28 @@ class RouteSurfaceRefactorTests(TestCase):
         return channel_pixels
 
     @staticmethod
+    def _write_output_frame_assets(
+        media_root: Path,
+        uuid_value: str,
+        image_stem: str,
+        *,
+        frame_indices: tuple[int, ...] = (0, 1, 2, 3),
+    ) -> None:
+        output_dir = media_root / uuid_value / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        frame_colors = {
+            0: (120, 120, 120),
+            1: (30, 30, 220),
+            2: (30, 220, 30),
+            3: (220, 30, 30),
+        }
+        for frame_index in frame_indices:
+            color = frame_colors.get(frame_index, (200, 200, 200))
+            Image.fromarray(
+                np.full((8, 8, 3), color, dtype=np.uint8)
+            ).save(output_dir / f"{image_stem}_frame_{frame_index}.png")
+
+    @staticmethod
     def _write_overlay_config(uuid_value: str, image_stem: str) -> dict[str, object]:
         render_config = build_overlay_render_config(
             image_stem=image_stem,
@@ -334,6 +356,134 @@ class RouteSurfaceRefactorTests(TestCase):
             html=False,
         )
         self._assert_removed_paths(response)
+
+    def test_display_payload_includes_main_image_paths_for_all_channels(self):
+        uuid_value = str(uuid4())
+        with temporary_media_root() as media_root:
+            self._write_channel_config(media_root, uuid_value)
+            self._create_uploaded_image(uuid_value, name="display-main-paths")
+            self._create_segmented_image(uuid_value, name="display-main-paths")
+            self._write_output_frame_assets(media_root, uuid_value, "display-main-paths")
+
+            response = self.client.get(reverse("display", args=[uuid_value]))
+
+        self.assertEqual(response.status_code, 200)
+        files_data = json.loads(response.context["files_data"])
+        payload = files_data[uuid_value]
+        self.assertEqual(
+            set(payload["MainImagePaths"].keys()),
+            {"dic", "blue", "red", "green"},
+        )
+        self.assertEqual(
+            payload["MainImagePaths"]["dic"],
+            f"/media/{uuid_value}/output/display-main-paths_frame_0.png",
+        )
+        self.assertEqual(
+            payload["MainImagePaths"]["blue"],
+            f"/media/{uuid_value}/output/display-main-paths_frame_1.png",
+        )
+        self.assertEqual(
+            payload["MainImagePaths"]["green"],
+            f"/media/{uuid_value}/output/display-main-paths_frame_2.png",
+        )
+        self.assertEqual(
+            payload["MainImagePaths"]["red"],
+            f"/media/{uuid_value}/output/display-main-paths_frame_3.png",
+        )
+
+    def test_dashboard_payload_includes_main_image_paths_for_all_channels(self):
+        uuid_value = str(uuid4())
+        with temporary_media_root() as media_root:
+            self._write_channel_config(media_root, uuid_value)
+            self._create_uploaded_image(uuid_value, name="dashboard-main-paths")
+            segmented = self._create_segmented_image(uuid_value, name="dashboard-main-paths")
+            segmented.user = self.user
+            segmented.save(update_fields=["user"])
+            self._write_output_frame_assets(media_root, uuid_value, "dashboard-main-paths")
+
+            response = self.client.get(reverse("dashboard"))
+
+        self.assertEqual(response.status_code, 200)
+        files_data = json.loads(response.context["files_data_json"])
+        payload = files_data[uuid_value]
+        self.assertEqual(
+            set(payload["MainImagePaths"].keys()),
+            {"dic", "blue", "red", "green"},
+        )
+        self.assertEqual(
+            payload["MainImagePaths"]["red"],
+            f"/media/{uuid_value}/output/dashboard-main-paths_frame_3.png",
+        )
+
+    def test_viewers_use_payload_backed_main_image_warmup(self):
+        uuid_value = str(uuid4())
+        with temporary_media_root() as media_root:
+            self._write_channel_config(media_root, uuid_value)
+            self._create_uploaded_image(uuid_value, name="viewer-main-warmup")
+            segmented = self._create_segmented_image(uuid_value, name="viewer-main-warmup")
+            segmented.user = self.user
+            segmented.save(update_fields=["user"])
+
+            display_response = self.client.get(reverse("display", args=[uuid_value]))
+            dashboard_response = self.client.get(reverse("dashboard"))
+
+        self.assertContains(display_response, "scheduleMainImageWarmup(fileUUID, fileData, inferred);", html=False)
+        self.assertContains(display_response, "const imageUrl = await warmMainImageChannel(fileUUID, fileData, channel);", html=False)
+        self.assertContains(display_response, "fileData.MainImagePaths = {};", html=False)
+        self.assertContains(dashboard_response, "scheduleMainImageWarmup(fileUUID, fileData, inferred);", html=False)
+        self.assertContains(dashboard_response, "const imageUrl = await warmMainImageChannel(fileUUID, fileData, channel);", html=False)
+
+    def test_main_image_channel_matches_display_and_dashboard_payload_paths(self):
+        uuid_value = str(uuid4())
+        with temporary_media_root() as media_root:
+            self._write_channel_config(media_root, uuid_value)
+            self._create_uploaded_image(uuid_value, name="main-channel-match")
+            segmented = self._create_segmented_image(uuid_value, name="main-channel-match")
+            segmented.user = self.user
+            segmented.save(update_fields=["user"])
+            self._write_output_frame_assets(media_root, uuid_value, "main-channel-match")
+
+            display_response = self.client.get(reverse("display", args=[uuid_value]))
+            dashboard_response = self.client.get(reverse("dashboard"))
+
+            display_payload = json.loads(display_response.context["files_data"])[uuid_value]
+            dashboard_payload = json.loads(dashboard_response.context["files_data_json"])[uuid_value]
+
+            for channel in ("dic", "blue", "red", "green"):
+                response = self.client.get(
+                    reverse("main_image_channel", args=[uuid_value]),
+                    {"channel": channel},
+                )
+                self.assertEqual(response.status_code, 200)
+                payload = response.json()
+                self.assertEqual(payload["image_url"], display_payload["MainImagePaths"][channel])
+                self.assertEqual(payload["image_url"], dashboard_payload["MainImagePaths"][channel])
+
+    def test_main_image_channel_and_payload_fall_back_to_first_available_frame(self):
+        uuid_value = str(uuid4())
+        with temporary_media_root() as media_root:
+            self._write_channel_config(media_root, uuid_value)
+            self._create_uploaded_image(uuid_value, name="main-channel-fallback")
+            self._create_segmented_image(uuid_value, name="main-channel-fallback")
+            self._write_output_frame_assets(
+                media_root,
+                uuid_value,
+                "main-channel-fallback",
+                frame_indices=(0,),
+            )
+
+            display_response = self.client.get(reverse("display", args=[uuid_value]))
+            display_payload = json.loads(display_response.context["files_data"])[uuid_value]
+
+            response = self.client.get(
+                reverse("main_image_channel", args=[uuid_value]),
+                {"channel": "green"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        expected_url = f"/media/{uuid_value}/output/main-channel-fallback_frame_0.png"
+        self.assertEqual(display_payload["MainImagePaths"]["green"], expected_url)
+        self.assertEqual(response.json()["image_url"], expected_url)
 
     def test_display_uses_overlay_endpoint_for_fluorescence_contour_on_images(self):
         uuid_value = str(uuid4())
@@ -554,7 +704,7 @@ class RouteSurfaceRefactorTests(TestCase):
         self.assertContains(response, "return 'N/A';", html=False)
         self.assertContains(
             response,
-            "distance: formatStatValue(cellStats ? cellStats.puncta_distance : null),",
+            "distance: formatFieldValue('puncta_distance', cellStats ? cellStats.puncta_distance : null, cellStats, scaleContext),",
             html=False,
         )
         self.assertContains(
@@ -604,17 +754,12 @@ class RouteSurfaceRefactorTests(TestCase):
         )
         self.assertContains(
             response,
-            "'Measurement/Contour Ratio 1 (Green/Red)': 'measurement_contour_ratio_1'",
+            "'measurement_contour_ratio_1',",
             html=False,
         )
         self.assertContains(
             response,
-            "'Measurement/Contour Ratio 1 (Red/Green)': 'measurement_contour_ratio_1'",
-            html=False,
-        )
-        self.assertContains(
-            response,
-            "'Measurement/Contour Ratio 3 (Red/Green)': 'measurement_contour_ratio_3'",
+            "'measurement_contour_ratio_3',",
             html=False,
         )
 
@@ -630,7 +775,7 @@ class RouteSurfaceRefactorTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response,
-            "distance: formatStatValue(cellStats ? cellStats.puncta_distance : null),",
+            "distance: formatFieldValue('puncta_distance', cellStats ? cellStats.puncta_distance : null, cellStats, scaleContext),",
             html=False,
         )
         self.assertContains(
@@ -680,17 +825,12 @@ class RouteSurfaceRefactorTests(TestCase):
         )
         self.assertContains(
             response,
-            "'Measurement/Contour Ratio 1 (Green/Red)': 'measurement_contour_ratio_1'",
+            "'measurement_contour_ratio_1',",
             html=False,
         )
         self.assertContains(
             response,
-            "'Measurement/Contour Ratio 1 (Red/Green)': 'measurement_contour_ratio_1'",
-            html=False,
-        )
-        self.assertContains(
-            response,
-            "'Measurement/Contour Ratio 3 (Red/Green)': 'measurement_contour_ratio_3'",
+            "'measurement_contour_ratio_3',",
             html=False,
         )
 
@@ -847,7 +987,7 @@ class RouteSurfaceRefactorTests(TestCase):
         )
         self.assertLess(
             list(header_row).index("Measurement/Contour Ratio 3 (Red/Green)"),
-            list(header_row).index("Distance of Green from Red 1"),
+            list(header_row).index("Distance of Green from Red 1 (px)"),
         )
         self.assertEqual(csv_rows[0]["Measurement/Contour Ratio 1 (Red/Green)"], "0.500")
         self.assertEqual(csv_rows[0]["Measurement/Contour Ratio 2 (Red/Green)"], "2.000")

--- a/cytocv/core/views/display.py
+++ b/cytocv/core/views/display.py
@@ -19,7 +19,7 @@ from core.channel_roles import (
     channel_role_from_slug,
     channel_slug,
 )
-from core.config import DEFAULT_CHANNEL_CONFIG, get_channel_config_for_uuid
+from core.config import get_channel_config_for_uuid
 from core.models import (
     UploadedImage,
     SegmentedImage,
@@ -34,6 +34,7 @@ from core.services.artifact_storage import (
     sweep_user_run_artifacts,
 )
 from core.services.cell_statistics_payload import serialize_cell_statistics_payload
+from core.services.main_image_urls import build_main_image_paths
 from core.services.overlay_rendering import build_overlay_image_url, overlay_render_config_exists
 from core.services.puncta_line_mode import VALID_PUNCTA_LINE_MODES
 from core.scale import (
@@ -262,6 +263,13 @@ def display(request, uuids):
                     image_index = channel_config.get(CHANNEL_ROLE_BLUE, 1)
             image_file_name = image_name_stem + "_frame_" + str(image_index)
             full_outlined = f"{MEDIA_URL}{uuid}/output/{image_file_name}.png"
+            available_frames = _scan_output_frames(str(uuid))
+            main_image_paths = build_main_image_paths(
+                uuid=str(uuid),
+                image_name=image_name,
+                channel_config=channel_config,
+                available_frames=available_frames,
+            )
             has_overlay_render_config = overlay_render_config_exists(uuid)
 
             # Build the images for each cell based on the dynamic channel configuration
@@ -341,6 +349,7 @@ def display(request, uuids):
             # Store all image details and statistics for this UUID
             all_files_data[str(uuid)] = {
                 'MainImagePath': full_outlined,
+                'MainImagePaths': main_image_paths,
                 'NumberOfCells': number_of_cells,
                 'CellPairImages': images,
                 'Image_Name': image_name,
@@ -704,27 +713,14 @@ def main_image_channel(request, uuid):
         return JsonResponse({'error': 'Unauthorized'}, status=401)
 
     channel_config = get_channel_config_for_uuid(str(uuid))
-    fallback_frame_map = {
-        channel_slug(role): DEFAULT_CHANNEL_CONFIG.get(role, 0)
-        for role in (
-            CHANNEL_ROLE_RED,
-            CHANNEL_ROLE_GREEN,
-            CHANNEL_ROLE_BLUE,
-            CHANNEL_ROLE_DIC,
-        )
-    }
-    configured_frame_idx = channel_config.get(channel_role, fallback_frame_map[channel])
     available_frames = _scan_output_frames(str(uuid))
-    full_outlined = available_frames.get(configured_frame_idx)
-    if not full_outlined:
-        full_outlined = available_frames.get(fallback_frame_map[channel])
-    if not full_outlined and available_frames:
-        first_idx = sorted(available_frames.keys())[0]
-        full_outlined = available_frames[first_idx]
-    if not full_outlined:
-        image_name_stem = Path(uploaded_image.name).stem
-        image_file_name = f"{image_name_stem}_frame_{fallback_frame_map[channel]}"
-        full_outlined = f"{MEDIA_URL}{uuid}/output/{image_file_name}.png"
+    main_image_paths = build_main_image_paths(
+        uuid=str(uuid),
+        image_name=uploaded_image.name,
+        channel_config=channel_config,
+        available_frames=available_frames,
+    )
+    full_outlined = main_image_paths.get(channel) or ""
 
     return JsonResponse({
         'image_url': full_outlined,

--- a/cytocv/templates/dashboard.html
+++ b/cytocv/templates/dashboard.html
@@ -2224,6 +2224,7 @@
         let activeFileLoadToken = 0;
         let activeCellRenderToken = 0;
         let hasInitializedDashboardFile = false;
+        const mainImageWarmStateByFile = new Map();
         const overlayWarmCoordinator = window.CytoCVOverlayPrefetch
             ? window.CytoCVOverlayPrefetch.createWarmCoordinator({
                 resolveUrl: ({ fileKey, cellNumber }) => {
@@ -2569,73 +2570,6 @@
             return Promise.all([...imageUpdates, ...textUpdates]);
         }
 
-        window.onload = function () {
-            if (filesDataParseError) {
-                showChannelError('Saved file preview data could not be loaded. Refresh and try again.');
-                return;
-            }
-            if (dashboardHasFiles && fileUUIDs.length === 0) {
-                showChannelError('Saved files were found, but preview payload is unavailable.');
-                return;
-            }
-            if (fileUUIDs.length > 0) {
-                syncFileNavigationState();
-                loadFile(currentFileIndex);
-                toggleContourOverlays();
-            }
-        };
-
-        function loadFile(fileIndex) {
-            const fileUUID = fileUUIDs[fileIndex];
-            const fileData = filesData[fileUUID];
-            if (!fileData) {
-                return;
-            }
-            document.getElementById("mainImage").src = fileData.MainImagePath || noCellPlaceholder;
-            document.getElementById("imageTitle").textContent = fileData.Image_Name;
-            updateFileContextSummary(fileUUID, fileData);
-            maxCells = Number(fileData.NumberOfCells || 0);
-            if (!Number.isFinite(maxCells) || maxCells < 0) {
-                maxCells = 0;
-            }
-            currentCellNumber = 1;
-            updateCellImages(fileData.CellPairImages, fileData.Statistics);
-            applyContourToggleState();
-            if (fileData.NoCellsWarning) {
-                showChannelError(fileData.NoCellsWarning);
-            }
-            updateTableState(fileUUID, fileData);
-            updateSidebarActive();
-            syncFileNavigationState();
-            const inferred = inferChannelFromMainImage(fileData.MainImagePath, fileData);
-            if (inferred) {
-                setActiveChannel(inferred);
-            }
-        }
-
-        function updateFileContextSummary(fileUUID, fileData) {
-            const metaLine = document.getElementById('fileContextMetaLine');
-            const scaleLine = document.getElementById('fileContextScaleLine');
-            if (!metaLine || !scaleLine) {
-                return;
-            }
-
-            const fileItem = Array.from(document.querySelectorAll('.file-item')).find(
-                (item) => item.dataset.uuid === fileUUID
-            );
-            const metaText = fileItem?.querySelector('.file-meta')?.textContent?.trim() || '';
-            const scaleValue = fileItem?.querySelector('.file-scale-line span:first-child')?.textContent?.trim() || '';
-            const scaleSource = fileItem?.querySelector('.file-scale-source')?.textContent?.trim() || '';
-            const cellsFallback = Number(fileData?.NumberOfCells || 0);
-
-            metaLine.textContent = metaText || `${cellsFallback} cells`;
-            if (scaleValue || scaleSource) {
-                scaleLine.textContent = scaleSource ? `${scaleValue} · ${scaleSource}` : scaleValue;
-            } else {
-                scaleLine.textContent = 'Scale metadata unavailable.';
-            }
-        }
-
         function ensureChannelMessageContainer() {
             let container = document.querySelector('.message-container.channel-switch');
             if (container) return container;
@@ -2667,45 +2601,6 @@
             msg.appendChild(close);
             container.appendChild(msg);
             setTimeout(() => msg.remove(), 8000);
-        }
-
-        function preloadImage(url) {
-            return new Promise((resolve, reject) => {
-                const img = new Image();
-                img.onload = () => resolve();
-                img.onerror = () => reject(new Error('Image failed to load'));
-                img.src = url;
-            });
-        }
-
-        async function switchMainChannel(channel) {
-            const mainImage = document.getElementById('mainImage');
-            if (!mainImage) return;
-            const fileUUID = fileUUIDs[currentFileIndex];
-            if (!fileUUID) return;
-            const requestId = ++activeChannelRequest;
-            try {
-                const response = await fetch(`/experiment/${fileUUID}/main-channel/?channel=${encodeURIComponent(channel)}`, {
-                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
-                    credentials: 'same-origin',
-                });
-                if (!response.ok) {
-                    throw new Error(`Channel request failed (${response.status})`);
-                }
-                const data = await response.json();
-                if (!data || !data.image_url) {
-                    throw new Error('Missing image URL');
-                }
-                await preloadImage(data.image_url);
-                if (requestId !== activeChannelRequest) {
-                    return;
-                }
-                mainImage.src = data.image_url;
-                setActiveChannel(channel);
-            } catch (error) {
-                if (error && error.name === 'AbortError') return;
-                showChannelError('Unable to load that channel image. Please try again.');
-            }
         }
 
         function resolveChannelIndexMap(fileData = null) {
@@ -3056,67 +2951,6 @@
             });
         }
 
-        function updateCellImages(cellPairImages, statistics) {
-            const safeCellPairImages = cellPairImages || {};
-            const safeStatistics = statistics || {};
-            const imageUrls = safeCellPairImages[currentCellNumber] || safeCellPairImages[String(currentCellNumber)];
-            if (!imageUrls) {
-                document.getElementById("cellImage1").src = noCellPlaceholder;
-                document.getElementById("cellImage2").src = noCellPlaceholder;
-                document.getElementById("cellImage3").src = noCellPlaceholder;
-                document.getElementById("cellImage4").src = noCellPlaceholder;
-                document.getElementById("cellID").textContent = maxCells > 0 ? currentCellNumber : 0;
-                BLEND_METRIC_IDS.forEach((metricId) => {
-                    document.getElementById(metricId).textContent = "N/A";
-                });
-                document.getElementById("nucleusIntensityLabel").textContent = "Measured Nuclear Intensity";
-                document.getElementById("cellularIntensityLabel").textContent = "Measured Cellular Intensity";
-                return;
-            }
-
-            document.getElementById("cellImage1").src = imageUrls[0] || noCellPlaceholder;
-            document.getElementById("cellImage2").src = imageUrls[2] || noCellPlaceholder;
-            document.getElementById("cellImage3").src = imageUrls[4] || noCellPlaceholder;
-            document.getElementById("cellImage4").src = imageUrls[6] || noCellPlaceholder;
-            document.getElementById("cellID").textContent = currentCellNumber;
-
-            const cellStats = safeStatistics[currentCellNumber] || safeStatistics[String(currentCellNumber)] || null;
-            const category = cellStats ? (cellStats.category_cen_dot_label || 'N/A') : 'N/A';
-            const nuclearUnavailable = hasNoNucleusContour(cellStats);
-            document.getElementById("distance").textContent = formatStatValue(cellStats ? cellStats.puncta_distance : null);
-            document.getElementById("punctaLineIntensity").textContent = formatStatValue(cellStats ? cellStats.puncta_line_intensity : null);
-            document.getElementById("measurementContourRatioFormula").textContent = cellStats ? (cellStats.measurement_contour_ratio_display_text || "N/A") : "N/A";
-            document.getElementById("measurementContourRatio1").textContent = formatStatValue(cellStats ? cellStats.measurement_contour_ratio_1 : null);
-            document.getElementById("measurementContourRatio2").textContent = formatStatValue(cellStats ? cellStats.measurement_contour_ratio_2 : null);
-            document.getElementById("measurementContourRatio3").textContent = formatStatValue(cellStats ? cellStats.measurement_contour_ratio_3 : null);
-            document.getElementById("redInRedIntensity1").textContent = formatStatValue(cellStats ? cellStats.red_intensity_1 : null);
-            document.getElementById("redInRedIntensity2").textContent = formatStatValue(cellStats ? cellStats.red_intensity_2 : null);
-            document.getElementById("redInRedIntensity3").textContent = formatStatValue(cellStats ? cellStats.red_intensity_3 : null);
-            document.getElementById("greenInRedIntensity1").textContent = formatStatValue(cellStats ? cellStats.green_intensity_1 : null);
-            document.getElementById("greenInRedIntensity2").textContent = formatStatValue(cellStats ? cellStats.green_intensity_2 : null);
-            document.getElementById("greenInRedIntensity3").textContent = formatStatValue(cellStats ? cellStats.green_intensity_3 : null);
-            document.getElementById("redInGreenIntensity1").textContent = formatStatValue(cellStats ? cellStats.red_in_green_intensity_1 : null);
-            document.getElementById("redInGreenIntensity2").textContent = formatStatValue(cellStats ? cellStats.red_in_green_intensity_2 : null);
-            document.getElementById("redInGreenIntensity3").textContent = formatStatValue(cellStats ? cellStats.red_in_green_intensity_3 : null);
-            document.getElementById("greenInGreenIntensity1").textContent = formatStatValue(cellStats ? cellStats.green_in_green_intensity_1 : null);
-            document.getElementById("greenInGreenIntensity2").textContent = formatStatValue(cellStats ? cellStats.green_in_green_intensity_2 : null);
-            document.getElementById("greenInGreenIntensity3").textContent = formatStatValue(cellStats ? cellStats.green_in_green_intensity_3 : null);
-            document.getElementById("nucleusIntensitySum").textContent = (!cellStats || nuclearUnavailable) ? "N/A" : formatStatValue(cellStats.nucleus_intensity_sum);
-            document.getElementById("cellPairIntensitySum").textContent = (!cellStats || nuclearUnavailable) ? "N/A" : formatStatValue(cellStats.cell_pair_intensity_sum);
-            document.getElementById("cytoplasmicIntensity").textContent = (!cellStats || nuclearUnavailable) ? "N/A" : formatStatValue(cellStats.cytoplasmic_intensity);
-            document.getElementById("cenDot").textContent = category;
-            document.getElementById("biorientation").textContent = formatStatValue(cellStats ? cellStats.biorientation : null);
-            document.getElementById("distanceLabel").textContent = cellStats ? (cellStats.puncta_distance_label || "Distance between Red Puncta") : "Distance between Red Puncta";
-            document.getElementById("lineIntensityLabel").textContent = cellStats ? (cellStats.puncta_line_intensity_label || "Green Intensity over Red Line") : "Green Intensity over Red Line";
-            const mode = cellStats ? cellStats.nuclear_cell_pair_mode : null;
-            const labels = getNuclearLabelPair(mode);
-            document.getElementById("nucleusIntensityLabel").textContent = labels.nuclear;
-            document.getElementById("cellularIntensityLabel").textContent = labels.cellular;
-            document.getElementById("nucleusContourChannel").textContent = cellStats ? (cellStats.nuclear_cell_pair_contour_channel || labels.contour) : labels.contour;
-            document.getElementById("measurementChannel").textContent = cellStats ? (cellStats.nuclear_cell_pair_measurement_channel || labels.measurement) : labels.measurement;
-            document.getElementById("nuclearStatus").textContent = cellStats ? (cellStats.nuclear_cell_pair_status || "unknown") : "N/A";
-        }
-
         function getCurrentCellImageUrls() {
             const fileData = filesData[fileUUIDs[currentFileIndex]];
             if (!fileData) {
@@ -3166,46 +3000,6 @@
                 document.getElementById("cellImage3").src = imageUrls[5] || noCellPlaceholder;
                 document.getElementById("cellImage4").src = imageUrls[7] || noCellPlaceholder;
             }
-        }
-
-        function nextFile() {
-            if (!hasMultipleFiles()) {
-                syncFileNavigationState();
-                return;
-            }
-            currentFileIndex = (currentFileIndex + 1) % fileUUIDs.length;
-            loadFile(currentFileIndex);
-            applyContourToggleState();
-        }
-
-        function previousFile() {
-            if (!hasMultipleFiles()) {
-                syncFileNavigationState();
-                return;
-            }
-            currentFileIndex = (currentFileIndex - 1 + fileUUIDs.length) % fileUUIDs.length;
-            loadFile(currentFileIndex);
-            applyContourToggleState();
-        }
-
-        function nextCell() {
-            if (maxCells < 1) {
-                return;
-            }
-            currentCellNumber = (currentCellNumber % maxCells) + 1;
-            const fileData = filesData[fileUUIDs[currentFileIndex]];
-            updateCellImages(fileData.CellPairImages, fileData.Statistics);
-            applyContourToggleState();
-        }
-
-        function previousCell() {
-            if (maxCells < 1) {
-                return;
-            }
-            currentCellNumber = (currentCellNumber - 1 > 0) ? (currentCellNumber - 1) : maxCells;
-            const fileData = filesData[fileUUIDs[currentFileIndex]];
-            updateCellImages(fileData.CellPairImages, fileData.Statistics);
-            applyContourToggleState();
         }
 
         window.onload = async function () {
@@ -3292,10 +3086,11 @@
             updateSidebarActive();
             syncFileNavigationState();
 
-            const inferred = inferChannelFromMainImage(mainImagePath, fileData);
+            const inferred = primeMainImageWarmState(fileUUID, fileData, mainImagePath);
             if (inferred) {
                 setActiveChannel(inferred);
             }
+            scheduleMainImageWarmup(fileUUID, fileData, inferred);
             if (showContours) {
                 markCurrentCellWarm(fileUUID, true);
                 scheduleCircularOverlayWarmup('initial');
@@ -3369,29 +3164,124 @@
             return Promise.all(uniqueUrls.map((url) => preloadImage(url)));
         }
 
+        function getMainImageWarmState(fileUUID) {
+            const normalizedFileUUID = String(fileUUID || '');
+            if (!mainImageWarmStateByFile.has(normalizedFileUUID)) {
+                mainImageWarmStateByFile.set(normalizedFileUUID, {
+                    warmed: new Set(),
+                    inFlight: new Map(),
+                });
+            }
+            return mainImageWarmStateByFile.get(normalizedFileUUID);
+        }
+
+        function getMainImagePaths(fileData) {
+            if (!fileData || typeof fileData !== 'object') {
+                return {};
+            }
+            if (!fileData.MainImagePaths || typeof fileData.MainImagePaths !== 'object') {
+                fileData.MainImagePaths = {};
+            }
+            return fileData.MainImagePaths;
+        }
+
+        function markMainImageChannelWarm(fileUUID, fileData, channel, url = '') {
+            if (!fileUUID || !channel) {
+                return;
+            }
+            const mainImagePaths = getMainImagePaths(fileData);
+            if (url && !mainImagePaths[channel]) {
+                mainImagePaths[channel] = url;
+            }
+            getMainImageWarmState(fileUUID).warmed.add(channel);
+        }
+
+        async function fetchMainImageChannelUrl(fileUUID, channel) {
+            const response = await fetch(`/experiment/${fileUUID}/main-channel/?channel=${encodeURIComponent(channel)}`, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                credentials: 'same-origin',
+            });
+            if (!response.ok) {
+                throw new Error(`Channel request failed (${response.status})`);
+            }
+            const data = await response.json();
+            if (!data || !data.image_url) {
+                throw new Error('Missing image URL');
+            }
+            return data.image_url;
+        }
+
+        async function resolveMainImageChannelUrl(fileUUID, fileData, channel) {
+            const mainImagePaths = getMainImagePaths(fileData);
+            const cachedUrl = typeof mainImagePaths[channel] === 'string' ? mainImagePaths[channel] : '';
+            if (cachedUrl) {
+                return cachedUrl;
+            }
+            const resolvedUrl = await fetchMainImageChannelUrl(fileUUID, channel);
+            mainImagePaths[channel] = resolvedUrl;
+            return resolvedUrl;
+        }
+
+        function warmMainImageChannel(fileUUID, fileData, channel) {
+            if (!fileUUID || !fileData || !channel) {
+                return Promise.resolve('');
+            }
+            const state = getMainImageWarmState(fileUUID);
+            if (state.warmed.has(channel)) {
+                return Promise.resolve(getMainImagePaths(fileData)[channel] || '');
+            }
+            if (state.inFlight.has(channel)) {
+                return state.inFlight.get(channel);
+            }
+            const warmPromise = resolveMainImageChannelUrl(fileUUID, fileData, channel)
+                .then(async (imageUrl) => {
+                    await preloadImage(imageUrl);
+                    state.warmed.add(channel);
+                    return imageUrl;
+                })
+                .finally(() => {
+                    state.inFlight.delete(channel);
+                });
+            state.inFlight.set(channel, warmPromise);
+            return warmPromise;
+        }
+
+        function primeMainImageWarmState(fileUUID, fileData, mainImagePath) {
+            const inferredChannel = inferChannelFromMainImage(mainImagePath, fileData);
+            if (!inferredChannel) {
+                return null;
+            }
+            markMainImageChannelWarm(fileUUID, fileData, inferredChannel, mainImagePath);
+            return inferredChannel;
+        }
+
+        function scheduleMainImageWarmup(fileUUID, fileData, activeChannel = null) {
+            if (!fileUUID || !fileData) {
+                return;
+            }
+            channels
+                .filter((channel) => channel !== activeChannel)
+                .forEach((channel) => {
+                    void warmMainImageChannel(fileUUID, fileData, channel).catch(() => {});
+                });
+        }
+
         async function switchMainChannel(channel) {
             const mainImage = document.getElementById('mainImage');
             if (!mainImage) return;
             const fileUUID = fileUUIDs[currentFileIndex];
-            if (!fileUUID) return;
+            const fileData = fileUUID ? filesData[fileUUID] : null;
+            if (!fileUUID || !fileData) return;
             const requestId = ++activeChannelRequest;
             try {
-                const response = await fetch(`/experiment/${fileUUID}/main-channel/?channel=${encodeURIComponent(channel)}`, {
-                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
-                    credentials: 'same-origin',
-                });
-                if (!response.ok) {
-                    throw new Error(`Channel request failed (${response.status})`);
-                }
-                const data = await response.json();
-                if (!data || !data.image_url) {
+                const imageUrl = await warmMainImageChannel(fileUUID, fileData, channel);
+                if (!imageUrl) {
                     throw new Error('Missing image URL');
                 }
-                await preloadImage(data.image_url);
                 if (requestId !== activeChannelRequest) {
                     return;
                 }
-                await setImageWithBlend(mainImage, data.image_url, {
+                await setImageWithBlend(mainImage, imageUrl, {
                     duration: FILE_BLEND_IMAGE_MS,
                     blend: hasInitializedDashboardFile,
                 });

--- a/cytocv/templates/dashboard.html
+++ b/cytocv/templates/dashboard.html
@@ -515,7 +515,7 @@
             border: 1px solid var(--panel-border);
             border-radius: 8px;
             background: var(--surface-muted-alt);
-            padding: 4px 4px 4px 10px;
+            padding: 2px 4px 2px 10px;
         }
         .sidebar-unit-label {
             font-size: 12px;
@@ -559,7 +559,7 @@
             font-size: 12px;
             font-weight: 600;
             line-height: 1;
-            padding: 8px 16px;
+            padding: 6px 16px;
             text-align: center;
             transition: color 0.25s ease;
         }

--- a/cytocv/templates/display.html
+++ b/cytocv/templates/display.html
@@ -2187,6 +2187,7 @@
         let activeFileLoadToken = 0;
         let activeCellRenderToken = 0;
         let hasInitializedDisplayFile = false;
+        const mainImageWarmStateByFile = new Map();
         const overlayWarmCoordinator = window.CytoCVOverlayPrefetch
             ? window.CytoCVOverlayPrefetch.createWarmCoordinator({
                 resolveUrl: ({ fileKey, cellNumber }) => {
@@ -2613,10 +2614,11 @@
             updateSidebarActive();
             syncFileNavigationState();
 
-            const inferred = inferChannelFromMainImage(mainImagePath, fileData);
+            const inferred = primeMainImageWarmState(fileUUID, fileData, mainImagePath);
             if (inferred) {
                 setActiveChannel(inferred);
             }
+            scheduleMainImageWarmup(fileUUID, fileData, inferred);
             if (showContours) {
                 markCurrentCellWarm(fileUUID, true);
                 scheduleCircularOverlayWarmup('initial');
@@ -2624,29 +2626,6 @@
 
             hasInitializedDisplayFile = true;
             return true;
-        }
-
-        function updateFileContextSummary(fileUUID, fileData) {
-            const metaLine = document.getElementById('fileContextMetaLine');
-            const scaleLine = document.getElementById('fileContextScaleLine');
-            if (!metaLine || !scaleLine) {
-                return;
-            }
-
-            const fileItem = Array.from(document.querySelectorAll('.file-item')).find(
-                (item) => item.dataset.uuid === fileUUID
-            );
-            const metaText = fileItem?.querySelector('.file-meta')?.textContent?.trim() || '';
-            const scaleValue = fileItem?.querySelector('.file-scale-line span:first-child')?.textContent?.trim() || '';
-            const scaleSource = fileItem?.querySelector('.file-scale-source')?.textContent?.trim() || '';
-            const cellsFallback = Number(fileData?.NumberOfCells || 0);
-
-            metaLine.textContent = metaText || `${cellsFallback} cells`;
-            if (scaleValue || scaleSource) {
-                scaleLine.textContent = scaleSource ? `${scaleValue} · ${scaleSource}` : scaleValue;
-            } else {
-                scaleLine.textContent = 'Scale metadata unavailable.';
-            }
         }
 
         function updateFileContextSummary(fileUUID, fileData, { blend = false } = {}) {
@@ -2708,15 +2687,6 @@
         }
 
         function preloadImage(url) {
-            return new Promise((resolve, reject) => {
-                const img = new Image();
-                img.onload = () => resolve();
-                img.onerror = () => reject(new Error('Image failed to load'));
-                img.src = url;
-            });
-        }
-
-        function preloadImage(url) {
             return new Promise((resolve) => {
                 if (!url) {
                     resolve(url);
@@ -2755,59 +2725,124 @@
             return Promise.all(uniqueUrls.map((url) => preloadImage(url)));
         }
 
-        async function switchMainChannel(channel) {
-            const mainImage = document.getElementById('mainImage');
-            if (!mainImage) return;
-            const fileUUID = fileUUIDs[currentFileIndex];
-            if (!fileUUID) return;
-            const requestId = ++activeChannelRequest;
-            try {
-                const response = await fetch(`/experiment/${fileUUID}/main-channel/?channel=${encodeURIComponent(channel)}`, {
-                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
-                    credentials: 'same-origin',
+        function getMainImageWarmState(fileUUID) {
+            const normalizedFileUUID = String(fileUUID || '');
+            if (!mainImageWarmStateByFile.has(normalizedFileUUID)) {
+                mainImageWarmStateByFile.set(normalizedFileUUID, {
+                    warmed: new Set(),
+                    inFlight: new Map(),
                 });
-                if (!response.ok) {
-                    throw new Error(`Channel request failed (${response.status})`);
-                }
-                const data = await response.json();
-                if (!data || !data.image_url) {
-                    throw new Error('Missing image URL');
-                }
-                await preloadImage(data.image_url);
-                if (requestId !== activeChannelRequest) {
-                    return;
-                }
-                mainImage.src = data.image_url;
-                setActiveChannel(channel);
-            } catch (error) {
-                if (error && error.name === 'AbortError') return;
-                showChannelError('Unable to load that channel image. Please try again.');
             }
+            return mainImageWarmStateByFile.get(normalizedFileUUID);
+        }
+
+        function getMainImagePaths(fileData) {
+            if (!fileData || typeof fileData !== 'object') {
+                return {};
+            }
+            if (!fileData.MainImagePaths || typeof fileData.MainImagePaths !== 'object') {
+                fileData.MainImagePaths = {};
+            }
+            return fileData.MainImagePaths;
+        }
+
+        function markMainImageChannelWarm(fileUUID, fileData, channel, url = '') {
+            if (!fileUUID || !channel) {
+                return;
+            }
+            const mainImagePaths = getMainImagePaths(fileData);
+            if (url && !mainImagePaths[channel]) {
+                mainImagePaths[channel] = url;
+            }
+            getMainImageWarmState(fileUUID).warmed.add(channel);
+        }
+
+        async function fetchMainImageChannelUrl(fileUUID, channel) {
+            const response = await fetch(`/experiment/${fileUUID}/main-channel/?channel=${encodeURIComponent(channel)}`, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                credentials: 'same-origin',
+            });
+            if (!response.ok) {
+                throw new Error(`Channel request failed (${response.status})`);
+            }
+            const data = await response.json();
+            if (!data || !data.image_url) {
+                throw new Error('Missing image URL');
+            }
+            return data.image_url;
+        }
+
+        async function resolveMainImageChannelUrl(fileUUID, fileData, channel) {
+            const mainImagePaths = getMainImagePaths(fileData);
+            const cachedUrl = typeof mainImagePaths[channel] === 'string' ? mainImagePaths[channel] : '';
+            if (cachedUrl) {
+                return cachedUrl;
+            }
+            const resolvedUrl = await fetchMainImageChannelUrl(fileUUID, channel);
+            mainImagePaths[channel] = resolvedUrl;
+            return resolvedUrl;
+        }
+
+        function warmMainImageChannel(fileUUID, fileData, channel) {
+            if (!fileUUID || !fileData || !channel) {
+                return Promise.resolve('');
+            }
+            const state = getMainImageWarmState(fileUUID);
+            if (state.warmed.has(channel)) {
+                return Promise.resolve(getMainImagePaths(fileData)[channel] || '');
+            }
+            if (state.inFlight.has(channel)) {
+                return state.inFlight.get(channel);
+            }
+            const warmPromise = resolveMainImageChannelUrl(fileUUID, fileData, channel)
+                .then(async (imageUrl) => {
+                    await preloadImage(imageUrl);
+                    state.warmed.add(channel);
+                    return imageUrl;
+                })
+                .finally(() => {
+                    state.inFlight.delete(channel);
+                });
+            state.inFlight.set(channel, warmPromise);
+            return warmPromise;
+        }
+
+        function primeMainImageWarmState(fileUUID, fileData, mainImagePath) {
+            const inferredChannel = inferChannelFromMainImage(mainImagePath, fileData);
+            if (!inferredChannel) {
+                return null;
+            }
+            markMainImageChannelWarm(fileUUID, fileData, inferredChannel, mainImagePath);
+            return inferredChannel;
+        }
+
+        function scheduleMainImageWarmup(fileUUID, fileData, activeChannel = null) {
+            if (!fileUUID || !fileData) {
+                return;
+            }
+            channels
+                .filter((channel) => channel !== activeChannel)
+                .forEach((channel) => {
+                    void warmMainImageChannel(fileUUID, fileData, channel).catch(() => {});
+                });
         }
 
         async function switchMainChannel(channel) {
             const mainImage = document.getElementById('mainImage');
             if (!mainImage) return;
             const fileUUID = fileUUIDs[currentFileIndex];
-            if (!fileUUID) return;
+            const fileData = fileUUID ? filesData[fileUUID] : null;
+            if (!fileUUID || !fileData) return;
             const requestId = ++activeChannelRequest;
             try {
-                const response = await fetch(`/experiment/${fileUUID}/main-channel/?channel=${encodeURIComponent(channel)}`, {
-                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
-                    credentials: 'same-origin',
-                });
-                if (!response.ok) {
-                    throw new Error(`Channel request failed (${response.status})`);
-                }
-                const data = await response.json();
-                if (!data || !data.image_url) {
+                const imageUrl = await warmMainImageChannel(fileUUID, fileData, channel);
+                if (!imageUrl) {
                     throw new Error('Missing image URL');
                 }
-                await preloadImage(data.image_url);
                 if (requestId !== activeChannelRequest) {
                     return;
                 }
-                await setImageWithBlend(mainImage, data.image_url, {
+                await setImageWithBlend(mainImage, imageUrl, {
                     duration: FILE_BLEND_IMAGE_MS,
                     blend: hasInitializedDisplayFile,
                 });
@@ -3144,69 +3179,6 @@
             });
         }
 
-        function updateCellImages(cellPairImages, statistics) {
-            const imageUrls = cellPairImages[currentCellNumber];
-            if (!imageUrls) {
-                document.getElementById("cellImage1").src = noCellPlaceholder;
-                document.getElementById("cellImage2").src = noCellPlaceholder;
-                document.getElementById("cellImage3").src = noCellPlaceholder;
-                document.getElementById("cellImage4").src = noCellPlaceholder;
-                document.getElementById("cellID").textContent = maxCells > 0 ? currentCellNumber : 0;
-                BLEND_METRIC_IDS.forEach((metricId) => {
-                    document.getElementById(metricId).textContent = "N/A";
-                });
-                document.getElementById("nucleusIntensityLabel").textContent = "Measured Nuclear Intensity";
-                document.getElementById("cellularIntensityLabel").textContent = "Measured Cellular Intensity";
-                return;
-            }
-
-            document.getElementById("cellImage1").src = imageUrls[0];
-            // document.getElementById("cellImage1_2").src = imageUrls[1];
-            document.getElementById("cellImage2").src = imageUrls[2];
-            // document.getElementById("cellImage2_2").src = imageUrls[3];
-            document.getElementById("cellImage3").src = imageUrls[4];
-            // document.getElementById("cellImage3_2").src = imageUrls[5];
-            document.getElementById("cellImage4").src = imageUrls[6];
-            // document.getElementById("cellImage4_2").src = imageUrls[7];
-            document.getElementById("cellID").textContent = currentCellNumber;
-
-            const cellStats = statistics[currentCellNumber];
-            const category = cellStats ? (cellStats.category_cen_dot_label || 'N/A') : 'N/A';
-            const nuclearUnavailable = hasNoNucleusContour(cellStats);
-            document.getElementById("distanceLabel").textContent = cellStats ? (cellStats.puncta_distance_label || "Distance between Red Puncta") : "Distance between Red Puncta";
-            document.getElementById("lineIntensityLabel").textContent = cellStats ? (cellStats.puncta_line_intensity_label || "Green Intensity over Red Line") : "Green Intensity over Red Line";
-            document.getElementById("distance").textContent = formatStatValue(cellStats ? cellStats.puncta_distance : null);
-            document.getElementById("punctaLineIntensity").textContent = formatStatValue(cellStats ? cellStats.puncta_line_intensity : null);
-            document.getElementById("measurementContourRatioFormula").textContent = cellStats ? (cellStats.measurement_contour_ratio_display_text || "N/A") : "N/A";
-            document.getElementById("measurementContourRatio1").textContent = formatStatValue(cellStats ? cellStats.measurement_contour_ratio_1 : null);
-            document.getElementById("measurementContourRatio2").textContent = formatStatValue(cellStats ? cellStats.measurement_contour_ratio_2 : null);
-            document.getElementById("measurementContourRatio3").textContent = formatStatValue(cellStats ? cellStats.measurement_contour_ratio_3 : null);
-            document.getElementById("redInRedIntensity1").textContent = formatStatValue(cellStats ? cellStats.red_intensity_1 : null);
-            document.getElementById("redInRedIntensity2").textContent = formatStatValue(cellStats ? cellStats.red_intensity_2 : null);
-            document.getElementById("redInRedIntensity3").textContent = formatStatValue(cellStats ? cellStats.red_intensity_3 : null);
-            document.getElementById("greenInRedIntensity1").textContent = formatStatValue(cellStats ? cellStats.green_intensity_1 : null);
-            document.getElementById("greenInRedIntensity2").textContent = formatStatValue(cellStats ? cellStats.green_intensity_2 : null);
-            document.getElementById("greenInRedIntensity3").textContent = formatStatValue(cellStats ? cellStats.green_intensity_3 : null);
-            document.getElementById("redInGreenIntensity1").textContent = formatStatValue(cellStats ? cellStats.red_in_green_intensity_1 : null);
-            document.getElementById("redInGreenIntensity2").textContent = formatStatValue(cellStats ? cellStats.red_in_green_intensity_2 : null);
-            document.getElementById("redInGreenIntensity3").textContent = formatStatValue(cellStats ? cellStats.red_in_green_intensity_3 : null);
-            document.getElementById("greenInGreenIntensity1").textContent = formatStatValue(cellStats ? cellStats.green_in_green_intensity_1 : null);
-            document.getElementById("greenInGreenIntensity2").textContent = formatStatValue(cellStats ? cellStats.green_in_green_intensity_2 : null);
-            document.getElementById("greenInGreenIntensity3").textContent = formatStatValue(cellStats ? cellStats.green_in_green_intensity_3 : null);
-            document.getElementById("nucleusIntensitySum").textContent = (!cellStats || nuclearUnavailable) ? "N/A" : formatStatValue(cellStats.nucleus_intensity_sum);
-            document.getElementById("cellPairIntensitySum").textContent = (!cellStats || nuclearUnavailable) ? "N/A" : formatStatValue(cellStats.cell_pair_intensity_sum);
-            document.getElementById("cytoplasmicIntensity").textContent = (!cellStats || nuclearUnavailable) ? "N/A" : formatStatValue(cellStats.cytoplasmic_intensity);
-            document.getElementById("cenDot").textContent = category;
-            document.getElementById("biorientation").textContent = formatStatValue(cellStats ? cellStats.biorientation : null);
-            const mode = cellStats ? cellStats.nuclear_cell_pair_mode : null;
-            const labels = getNuclearLabelPair(mode);
-            document.getElementById("nucleusIntensityLabel").textContent = labels.nuclear;
-            document.getElementById("cellularIntensityLabel").textContent = labels.cellular;
-            document.getElementById("nucleusContourChannel").textContent = cellStats ? (cellStats.nuclear_cell_pair_contour_channel || labels.contour) : labels.contour;
-            document.getElementById("measurementChannel").textContent = cellStats ? (cellStats.nuclear_cell_pair_measurement_channel || labels.measurement) : labels.measurement;
-            document.getElementById("nuclearStatus").textContent = cellStats ? (cellStats.nuclear_cell_pair_status || "unknown") : "N/A";
-        }
-
         function getCurrentCellImageUrls() {
             const fileData = filesData[fileUUIDs[currentFileIndex]];
             if (!fileData) {
@@ -3256,46 +3228,6 @@
                 document.getElementById("cellImage3").src = imageUrls[5] || noCellPlaceholder;
                 document.getElementById("cellImage4").src = imageUrls[7] || noCellPlaceholder;
             }
-        }
-
-        function nextFile() {
-            if (!hasMultipleFiles()) {
-                syncFileNavigationState();
-                return;
-            }
-            currentFileIndex = (currentFileIndex + 1) % fileUUIDs.length;
-            loadFile(currentFileIndex);
-            applyContourToggleState();
-        }
-
-        function previousFile() {
-            if (!hasMultipleFiles()) {
-                syncFileNavigationState();
-                return;
-            }
-            currentFileIndex = (currentFileIndex - 1 + fileUUIDs.length) % fileUUIDs.length;
-            loadFile(currentFileIndex);
-            applyContourToggleState();
-        }
-
-        function nextCell() {
-            if (maxCells < 1) {
-                return;
-            }
-            currentCellNumber = (currentCellNumber % maxCells) + 1;
-            const fileData = filesData[fileUUIDs[currentFileIndex]];
-            updateCellImages(fileData.CellPairImages, fileData.Statistics);
-            applyContourToggleState();
-        }
-
-        function previousCell() {
-            if (maxCells < 1) {
-                return;
-            }
-            currentCellNumber = (currentCellNumber - 1 > 0) ? (currentCellNumber - 1) : maxCells;
-            const fileData = filesData[fileUUIDs[currentFileIndex]];
-            updateCellImages(fileData.CellPairImages, fileData.Statistics);
-            applyContourToggleState();
         }
 
         function getWarmPriorityOffsets(direction = 'initial') {

--- a/cytocv/templates/display.html
+++ b/cytocv/templates/display.html
@@ -308,7 +308,7 @@
             border: 1px solid var(--panel-border);
             border-radius: 8px;
             background: var(--surface-muted-alt);
-            padding: 4px 4px 4px 10px;
+            padding: 2px 4px 2px 10px;
         }
         .sidebar-unit-label {
             font-size: 12px;
@@ -392,7 +392,7 @@
             font-size: 12px;
             font-weight: 600;
             line-height: 1;
-            padding: 8px 16px;
+            padding: 6px 16px;
             text-align: center;
             transition: color 0.25s ease;
         }

--- a/cytocv/templates/pre_process.html
+++ b/cytocv/templates/pre_process.html
@@ -267,7 +267,7 @@
         border: 1px solid var(--panel-border);
         border-radius: 8px;
         background: var(--surface-muted-alt);
-        padding: 4px 4px 4px 10px;
+        padding: 2px 4px 2px 10px;
       }
       .sidebar-unit-label {
         font-size: 12px;
@@ -331,7 +331,7 @@
         font-size: 12px;
         font-weight: 600;
         line-height: 1;
-        padding: 8px 16px;
+        padding: 6px 16px;
         text-align: center;
         transition: color 0.25s ease;
       }


### PR DESCRIPTION
This pull request introduces a new utility for generating main image URLs for all relevant channels and integrates it throughout the backend payloads and tests. It also refactors and simplifies how main image paths are determined and served, adds comprehensive tests for these changes, and makes minor improvements to the dashboard UI and test assertions.

**Main image path generation and integration:**

* Added a new service module `main_image_urls.py` with `build_main_image_paths` and `resolve_main_image_url` functions to consistently generate main image URLs for all channels (`dic`, `blue`, `red`, `green`).
* Updated both the dashboard and display views (`profile.py`, `display.py`) to use `build_main_image_paths`, ensuring the payloads include a `MainImagePaths` dictionary mapping channel slugs to their image URLs. The single-channel path logic is now unified and simplified. [[1]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR50) [[2]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR719-R724) [[3]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR738) [[4]](diffhunk://#diff-961c7d47ecf9274e42ca6b77bdaab255b2d9d045aa810cca4915286780ec77f0L22-R22) [[5]](diffhunk://#diff-961c7d47ecf9274e42ca6b77bdaab255b2d9d045aa810cca4915286780ec77f0R37) [[6]](diffhunk://#diff-961c7d47ecf9274e42ca6b77bdaab255b2d9d045aa810cca4915286780ec77f0R266-R272) [[7]](diffhunk://#diff-961c7d47ecf9274e42ca6b77bdaab255b2d9d045aa810cca4915286780ec77f0R352) [[8]](diffhunk://#diff-961c7d47ecf9274e42ca6b77bdaab255b2d9d045aa810cca4915286780ec77f0L707-R723)

**Testing improvements:**

* Added and expanded tests to verify that all payloads (dashboard, display, and API) include correct `MainImagePaths` for all channels, and that fallback behavior works as expected when frames are missing. Also, added a helper to write output frame assets for tests. [[1]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267R135-R156) [[2]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267R360-R487)
* Updated test assertions to match new payload formats and improved test coverage for main image warmup logic and payload consistency between endpoints.

**Test and UI refinements:**

* Updated test assertions for cell pair card formatting to use the new `formatFieldValue` function and to check for channel-agnostic keys, reflecting recent frontend refactors. [[1]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267L557-R707) [[2]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267L607-R762) [[3]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267L633-R778) [[4]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267L683-R833)
* Fixed a test to match the new CSV export column label for distance (now includes units).
* Minor UI tweaks to dashboard padding for improved appearance. [[1]](diffhunk://#diff-fea3e6a6c8bf668330e0e4ea2c49fb168b3ecfd097762b3da0e5207e1d2736e1L518-R518) [[2]](diffhunk://#diff-fea3e6a6c8bf668330e0e4ea2c49fb168b3ecfd097762b3da0e5207e1d2736e1L562-R562)
* Added a new `mainImageWarmStateByFile` variable to the dashboard JS for improved main image prefetch coordination.