### PR TITLE
Fix frozen spatial unit toggle and update controls on dashboard

### DIFF
--- a/cytocv/templates/dashboard.html
+++ b/cytocv/templates/dashboard.html
@@ -2101,6 +2101,12 @@
     <div id="selectionInfoTooltip" class="info-tooltip" role="tooltip" hidden></div>
 
     <script>
+        function getCsrfToken() {
+            const match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]*)/);
+            return match ? decodeURIComponent(match[1]) : '';
+        }
+        const csrfToken = getCsrfToken();
+
         // Parse JSON file data
         let filesData = {};
         let filesDataParseError = false;
@@ -2902,6 +2908,7 @@
             if (!fileUUID || !fileData) {
                 return;
             }
+            updateSpatialUnitControls(fileData);
             const nextState = getCellDisplayState(fileData.CellPairImages, fileData.Statistics, {
                 showContours: getContourToggleState(),
                 cellNumber: currentCellNumber,
@@ -2937,13 +2944,16 @@
                     }
                     const previousUnit = getCurrentSpatialUnit();
                     setCurrentSpatialUnit(nextUnit);
+                    updateSpatialUnitControls(filesData[fileUUIDs[currentFileIndex]] || null);
                     rerenderSpatialUnitsForCurrentFile();
                     try {
                         const persistedUnit = await persistSidebarSpatialUnit(nextUnit);
                         setCurrentSpatialUnit(persistedUnit);
+                        updateSpatialUnitControls(filesData[fileUUIDs[currentFileIndex]] || null);
                         rerenderSpatialUnitsForCurrentFile();
                     } catch (error) {
                         setCurrentSpatialUnit(previousUnit);
+                        updateSpatialUnitControls(filesData[fileUUIDs[currentFileIndex]] || null);
                         rerenderSpatialUnitsForCurrentFile();
                         showMessage('Unable to save spatial unit preference right now.');
                     }


### PR DESCRIPTION
This pull request makes improvements to the spatial unit controls and enhances CSRF token handling in the `dashboard.html` template. The most important changes are grouped below.

**Security and Utility Enhancements:**

* Added a `getCsrfToken` utility function to consistently extract the CSRF token from cookies, and defined a `csrfToken` variable for use in client-side scripts.

**Spatial Unit Controls Consistency:**

* Ensured that `updateSpatialUnitControls` is called whenever the current file or spatial unit changes, including after setting or persisting the spatial unit, to keep the UI in sync with the selected file and spatial unit. [[1]](diffhunk://#diff-fea3e6a6c8bf668330e0e4ea2c49fb168b3ecfd097762b3da0e5207e1d2736e1R2911) [[2]](diffhunk://#diff-fea3e6a6c8bf668330e0e4ea2c49fb168b3ecfd097762b3da0e5207e1d2736e1R2947-R2956)