### PR TITLE
Fix hole filling in segmentation masks and update documentation

### DIFF
--- a/cytocv/core/mrcnn/mask_processing.py
+++ b/cytocv/core/mrcnn/mask_processing.py
@@ -47,6 +47,17 @@ def dilate_mask_volume(mask_volume: np.ndarray) -> np.ndarray:
     return dilated_masks
 
 
+def fill_mask_volume_holes(mask_volume: np.ndarray) -> np.ndarray:
+    """Fill enclosed holes inside each instance mask without mutating input."""
+
+    filled_masks = _copy_mask_volume(mask_volume)
+    for index in range(filled_masks.shape[2]):
+        filled_masks[:, :, index] = ndimage.binary_fill_holes(
+            filled_masks[:, :, index] > 0
+        ).astype(np.uint8)
+    return filled_masks
+
+
 def remove_duplicate_masks(
     mask_volume: np.ndarray,
     *,
@@ -95,6 +106,7 @@ def postprocess_prediction_masks(
     processed_masks = _copy_mask_volume(mask_volume)
     if dilation:
         processed_masks = dilate_mask_volume(processed_masks)
+    processed_masks = fill_mask_volume_holes(processed_masks)
     return remove_duplicate_masks(
         processed_masks,
         threshold=threshold,
@@ -117,6 +129,22 @@ def label_mask_volume(mask_volume: np.ndarray) -> np.ndarray:
         current_label += 1
 
     return label_image
+
+
+def fill_label_image_holes(label_image: np.ndarray) -> np.ndarray:
+    """Fill enclosed background holes for each label without overwriting other labels."""
+
+    filled_labels = np.asarray(label_image, dtype=np.uint16).copy()
+    for label in range(1, int(filled_labels.max()) + 1):
+        label_mask = filled_labels == label
+        if not np.any(label_mask):
+            continue
+        hole_pixels = np.logical_and(
+            ndimage.binary_fill_holes(label_mask),
+            filled_labels == 0,
+        )
+        filled_labels[hole_pixels] = label
+    return filled_labels
 
 
 def build_labeled_mask_image(
@@ -146,7 +174,7 @@ def build_labeled_mask_image(
             anti_aliasing=False,
         ).astype(np.uint16)
 
-    return label_image
+    return fill_label_image_holes(label_image)
 
 
 def save_mask_tiff(mask_image: np.ndarray, destination: Path) -> Path:
@@ -157,4 +185,3 @@ def save_mask_tiff(mask_image: np.ndarray, destination: Path) -> Path:
     normalized_mask = np.asarray(mask_image, dtype=np.uint16)
     Image.fromarray(normalized_mask).save(destination, format="TIFF")
     return destination
-

--- a/cytocv/core/tests/test_mrcnn_inference.py
+++ b/cytocv/core/tests/test_mrcnn_inference.py
@@ -6,6 +6,7 @@ from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import cv2
 import numpy as np
 from django.test import SimpleTestCase
 from PIL import Image
@@ -158,6 +159,42 @@ class PredictImagesRuntimeReuseTests(SimpleTestCase):
 
         self.assertEqual(label_image.dtype, np.uint16)
         self.assertTrue(np.array_equal(label_image, np.zeros((4, 4), dtype=np.uint16)))
+
+    def test_build_labeled_mask_image_fills_donut_mask_holes_and_removes_child_contours(self):
+        pred_masks = np.zeros((7, 7, 1), dtype=np.uint8)
+        pred_masks[1:6, 1:6, 0] = 1
+        pred_masks[2:5, 2:5, 0] = 0
+
+        label_image = build_labeled_mask_image(pred_masks)
+
+        self.assertEqual(int(label_image[3, 3]), 1)
+        contour_mask = (label_image == 1).astype(np.uint8)
+        contours, hierarchy = cv2.findContours(
+            contour_mask.copy(),
+            cv2.RETR_CCOMP,
+            cv2.CHAIN_APPROX_SIMPLE,
+        )
+        self.assertEqual(len(contours), 1)
+        self.assertIsNotNone(hierarchy)
+        self.assertFalse(any(node[3] != -1 for node in hierarchy[0]))
+
+    def test_build_labeled_mask_image_preserves_order_when_surviving_instances_have_filled_holes(self):
+        pred_masks = np.zeros((10, 10, 3), dtype=np.uint8)
+        pred_masks[1:5, 1:5, 0] = 1
+        pred_masks[2:4, 2:4, 0] = 0
+        pred_masks[1:5, 1:5, 1] = 1
+        pred_masks[2:4, 2:4, 1] = 0
+        pred_masks[5:9, 5:9, 2] = 1
+        pred_masks[6:8, 6:8, 2] = 0
+
+        label_image = build_labeled_mask_image(
+            pred_masks,
+            scores=np.array([0.1, 0.9, 0.8], dtype=np.float32),
+        )
+
+        self.assertTrue(np.array_equal(np.unique(label_image), np.array([0, 1, 2], dtype=np.uint16)))
+        self.assertEqual(int(label_image[2, 2]), 1)
+        self.assertEqual(int(label_image[6, 6]), 2)
 
     def test_predict_images_writes_blank_mask_when_model_returns_no_detections(self):
         with TemporaryDirectory() as temp_dir:

--- a/docs/developer/data-flow-and-artifacts.md
+++ b/docs/developer/data-flow-and-artifacts.md
@@ -34,6 +34,7 @@ Generated transient or regenerable artifacts may include:
 - preprocess images
 - inference logs
 - `mask.tif`
+  Written from the postprocessed Mask R-CNN output; enclosed interior holes are filled so later DIC outlines and fluorescence contour clipping operate on solid cell regions.
 - generated temporary image assets
 - CSV helper artifacts such as `compressed_masks.csv`
 

--- a/docs/reference/file-format-and-artifact-spec.md
+++ b/docs/reference/file-format-and-artifact-spec.md
@@ -35,6 +35,7 @@ Common artifacts under `MEDIA_ROOT/<uuid>/`:
 - preview PNG files
 - preprocess intermediates
 - `output/mask.tif`
+  Labeled segmentation mask written after mask postprocessing; enclosed interior holes are filled before downstream outlines, crops, and contour clipping use it.
 - `output/*_frame_<n>.png`
 - `segmented/cell_<n>.png`
 - `segmented/*-no_outline.png`


### PR DESCRIPTION
### Overview
This fixes a segmentation-mask bug where some cell masks were saved with enclosed interior holes. Those holes produced false inner contours in the DIC crop and could also cause valid red/green signal to be clipped out, because downstream contour logic treated the hole pixels as outside the cell.

This change makes the saved segmentation masks solid before they are written to mask.tif and consumed by the rest of the pipeline.

**Core mask processing improvements:**

* Added `fill_mask_volume_holes` to fill enclosed holes in each instance mask without mutating the input, and integrated it into the `postprocess_prediction_masks` pipeline to ensure all predicted masks are solid before deduplication. [[1]](diffhunk://#diff-b647088bfceb5da211478e255073765c82e46c6e23273f33839466269fcb5be1R50-R60) [[2]](diffhunk://#diff-b647088bfceb5da211478e255073765c82e46c6e23273f33839466269fcb5be1R109)
* Added `fill_label_image_holes` to fill background holes for each label in labeled mask images and updated `build_labeled_mask_image` to use this function, ensuring labeled outputs have no internal voids. [[1]](diffhunk://#diff-b647088bfceb5da211478e255073765c82e46c6e23273f33839466269fcb5be1R134-R149) [[2]](diffhunk://#diff-b647088bfceb5da211478e255073765c82e46c6e23273f33839466269fcb5be1L149-R177)

**Testing enhancements:**

* Added comprehensive tests to verify that donut-shaped masks have their holes filled and that label ordering and instance preservation are correct after hole filling.
* Updated test imports to include `cv2` for contour analysis in new test cases.

**Documentation updates:**

* Clarified in `data-flow-and-artifacts.md` and `file-format-and-artifact-spec.md` that the output mask artifacts have all enclosed holes filled, ensuring downstream tools operate on solid regions. [[1]](diffhunk://#diff-1cd818760d82b9d798fbec7391068ccb3aa6b1ab016295be62cbdad5e951927eR37) [[2]](diffhunk://#diff-17a9742b82d96407a7daec2735a8a721643937a101eaab642dcff8effe90023cR38)