### PR TITLE
Implement convex hull filling for instance masks and refine pair boundaries

### DIFF
--- a/cytocv/core/cell_analysis/nuclear_cell_pair_intensity.py
+++ b/cytocv/core/cell_analysis/nuclear_cell_pair_intensity.py
@@ -1,6 +1,3 @@
-import csv
-import os
-
 import cv2
 import numpy as np
 
@@ -39,16 +36,6 @@ class NuclearCellPairIntensity(Analysis):
             if image is not None:
                 return image
         return None
-
-    def _cell_points(self):
-        outline_filename = os.path.splitext(self.cp.image_name)[0] + "-" + str(self.cp.cell_id) + ".outline"
-        mask_file_path = os.path.join(self.output_dir, "output", outline_filename)
-        points = []
-        with open(mask_file_path, "r") as csvfile:
-            csvreader = csv.reader(csvfile)
-            for row in csvreader:
-                points.append((int(row[0]), int(row[1])))
-        return points
 
     @staticmethod
     def _draw_dashed_contour(image, contour, color=(0, 255, 255), dash_px=6, gap_px=4, thickness=1):

--- a/cytocv/core/mrcnn/mask_processing.py
+++ b/cytocv/core/mrcnn/mask_processing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import cv2
 import numpy as np
 import skimage.transform
 from PIL import Image
@@ -94,6 +95,60 @@ def remove_duplicate_masks(
     return deduplicated_masks
 
 
+def _instance_convex_hull_fill(instance_mask: np.ndarray) -> np.ndarray:
+    """Return the filled convex hull of a single binary instance mask."""
+
+    mask_u8 = (instance_mask > 0).astype(np.uint8)
+    contours, _ = cv2.findContours(mask_u8, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
+    if not contours:
+        return mask_u8
+
+    hull_canvas = np.zeros_like(mask_u8, dtype=np.uint8)
+    for contour in contours:
+        if contour.shape[0] < 3:
+            cv2.drawContours(hull_canvas, [contour], -1, 1, thickness=cv2.FILLED)
+            continue
+        hull = cv2.convexHull(contour)
+        cv2.drawContours(hull_canvas, [hull], -1, 1, thickness=cv2.FILLED)
+    return hull_canvas
+
+
+def fill_mask_volume_convex_hulls(mask_volume: np.ndarray) -> np.ndarray:
+    """Fill each instance to its convex hull without painting over other instances.
+
+    For every instance, pixels inside the convex hull that are currently
+    background are added to the instance, unless another instance already owns
+    them. Outward shape is preserved; inward fjords and enclosed holes are
+    closed. Pixels are only ever added, never removed.
+    """
+
+    filled_masks = _copy_mask_volume(mask_volume)
+    instance_count = filled_masks.shape[2]
+    if instance_count == 0:
+        return filled_masks
+
+    others_any = np.zeros(filled_masks.shape[:2], dtype=bool)
+    for index in range(instance_count):
+        others_any |= filled_masks[:, :, index] > 0
+
+    for index in range(instance_count):
+        this_mask = filled_masks[:, :, index] > 0
+        if not np.any(this_mask):
+            continue
+
+        hull_canvas = _instance_convex_hull_fill(this_mask) > 0
+        others_mask = others_any & ~this_mask
+        accepted = hull_canvas & ~this_mask & ~others_mask
+        if not np.any(accepted):
+            continue
+
+        updated_mask = this_mask | accepted
+        filled_masks[:, :, index] = updated_mask.astype(np.uint8)
+        others_any |= accepted
+
+    return filled_masks
+
+
 def postprocess_prediction_masks(
     mask_volume: np.ndarray,
     *,
@@ -107,11 +162,12 @@ def postprocess_prediction_masks(
     if dilation:
         processed_masks = dilate_mask_volume(processed_masks)
     processed_masks = fill_mask_volume_holes(processed_masks)
-    return remove_duplicate_masks(
+    deduplicated_masks = remove_duplicate_masks(
         processed_masks,
         threshold=threshold,
         scores=scores,
     )
+    return fill_mask_volume_convex_hulls(deduplicated_masks)
 
 
 def label_mask_volume(mask_volume: np.ndarray) -> np.ndarray:

--- a/cytocv/core/services/canonical_contours.py
+++ b/cytocv/core/services/canonical_contours.py
@@ -33,26 +33,41 @@ class CanonicalContourSlot:
 
 
 def load_cell_mask(image_name: str, cell_id: int, output_dir: str, shape: tuple[int, int]) -> np.ndarray:
-    """Build the segmented cell mask from the saved outline pixel list."""
+    """Fill a binary support mask from the saved external contour vertices.
+
+    The `.outline` file stores ordered `y,x` vertices of the finalized pair
+    boundary. Multiple external contours are separated by a blank CSV row.
+    """
 
     mask = np.zeros(shape, np.uint8)
     outline_filename = os.path.splitext(str(image_name))[0] + f"-{cell_id}.outline"
     mask_file_path = os.path.join(output_dir, "output", outline_filename)
+    groups: list[list[list[int]]] = []
+    current: list[list[int]] = []
     try:
         with open(mask_file_path, "r", encoding="utf-8") as csvfile:
             csvreader = csv.reader(csvfile)
             for row in csvreader:
                 if len(row) < 2:
+                    if current:
+                        groups.append(current)
+                        current = []
                     continue
                 try:
                     y = int(row[0])
                     x = int(row[1])
                 except (TypeError, ValueError):
                     continue
-                if 0 <= y < shape[0] and 0 <= x < shape[1]:
-                    mask[y, x] = 255
+                current.append([x, y])
+            if current:
+                groups.append(current)
     except FileNotFoundError:
         return mask
+    for points in groups:
+        if not points:
+            continue
+        contour = np.asarray(points, dtype=np.int32).reshape(-1, 1, 2)
+        cv2.drawContours(mask, [contour], -1, 255, thickness=-1)
     return mask
 
 

--- a/cytocv/core/services/pair_refinement.py
+++ b/cytocv/core/services/pair_refinement.py
@@ -1,0 +1,41 @@
+"""Post-pair label refinement for bridging narrow gaps and filling holes."""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+
+def refine_pair_label_image(seg: np.ndarray) -> np.ndarray:
+    """Conservative post-pair refinement: close narrow gaps and fill holes.
+
+    For each pair label, applies morphological closing (disk-1) and hole fill.
+    Only background pixels claimed by exactly one label are accepted; contested
+    pixels remain background.  Existing labeled pixels are never removed.
+    """
+
+    labels = np.unique(seg)
+    labels = labels[labels != 0]
+    if labels.size == 0:
+        return seg.copy()
+
+    result = seg.copy()
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3, 3))
+    claim_count = np.zeros(seg.shape, dtype=np.int32)
+    claim_owner = np.zeros(seg.shape, dtype=seg.dtype)
+
+    for label in labels:
+        mask = (seg == label).astype(np.uint8) * 255
+        closed = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
+        contours, _ = cv2.findContours(closed, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        if not contours:
+            continue
+        filled = np.zeros_like(closed)
+        cv2.drawContours(filled, contours, -1, 255, cv2.FILLED)
+        new_pixels = (filled == 255) & (seg == 0)
+        claim_count[new_pixels] += 1
+        claim_owner[new_pixels] = label
+
+    accept = claim_count == 1
+    result[accept] = claim_owner[accept]
+    return result

--- a/cytocv/core/services/segmentation_pipeline.py
+++ b/cytocv/core/services/segmentation_pipeline.py
@@ -50,6 +50,7 @@ from core.services.artifact_storage import (
     refresh_user_storage_usage,
     save_png_array,
 )
+from core.services.pair_refinement import refine_pair_label_image
 from core.services.overlay_rendering import (
     build_overlay_render_config,
     persist_debug_overlay_exports,
@@ -190,7 +191,6 @@ def run_segmentation_batch(
 
         seg = np.array(Image.open(Path(settings.MEDIA_ROOT) / str(uuid) / "output" / "mask.tif"))
 
-        outlines = np.zeros(seg.shape)
         lines_to_draw: dict[int, tuple[tuple[int, int], tuple[int, int]]] = {}
         outputdirectory = str(Path(settings.MEDIA_ROOT) / str(uuid) / "output") + "/"
 
@@ -337,6 +337,8 @@ def run_segmentation_batch(
             for i, x in enumerate(to_rebase):
                 seg[np.where(seg == x)] = i + 1
 
+            seg = refine_pair_label_image(seg)
+
             seg_image = Image.fromarray(seg)
             seg_image.save(str(outputdirectory) + "\\cellpairs.tif")
 
@@ -349,14 +351,14 @@ def run_segmentation_batch(
                 image = np.expand_dims(image, axis=-1)
                 image = np.tile(image, 3)
 
-            for i in range(1, int(np.max(seg) + 1)):
-                tmp = np.zeros(seg.shape)
-                tmp[np.where(seg == i)] = 1
-                tmp = tmp - skimage.morphology.erosion(tmp)
-                outlines += tmp
-
             image_outlined = image.copy()
-            image_outlined[outlines > 0] = (0, 255, 255)
+            for i in range(1, int(np.max(seg) + 1)):
+                cell_mask_full = (seg == i).astype(np.uint8) * 255
+                contours, _ = cv2.findContours(
+                    cell_mask_full, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE
+                )
+                if contours:
+                    cv2.drawContours(image_outlined, contours, -1, (0, 255, 255), 1)
 
             fig = plt.figure(frameon=False)
             ax = plt.Axes(fig, [0.0, 0.0, 1.0, 1.0])
@@ -414,31 +416,53 @@ def run_segmentation_batch(
                 image = np.tile(image, 3)
 
             cached_channel_name = layer_channel_lookup.get(image_num)
-            outlines = np.zeros(seg.shape)
-            for i in range(1, int(np.max(seg) + 1)):
-                tmp = np.zeros(seg.shape)
-                tmp[np.where(seg == i)] = 1
-                tmp = tmp - skimage.morphology.erosion(tmp)
-                outlines += tmp
-
             image_outlined = image.copy()
-            image_outlined[outlines > 0] = (0, 255, 255)
+            cell_contour_cache: dict[
+                int, tuple[tuple[np.ndarray, ...], int, int, int, int]
+            ] = {}
+            for i in range(1, int(np.max(seg) + 1)):
+                a = np.where(seg == i)
+                if a[0].size == 0:
+                    continue
+                min_x = max(int(np.min(a[0])) - 4, 0)
+                max_x = min(int(np.max(a[0])) + 4 + 1, seg.shape[0])
+                min_y = max(int(np.min(a[1])) - 4, 0)
+                max_y = min(int(np.max(a[1])) + 4 + 1, seg.shape[1])
+                local_mask = ((seg[min_x:max_x, min_y:max_y] == i).astype(np.uint8)) * 255
+                local_contours, _ = cv2.findContours(
+                    local_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE
+                )
+                cell_contour_cache[i] = (
+                    tuple(local_contours),
+                    min_x,
+                    max_x,
+                    min_y,
+                    max_y,
+                )
+                for contour in local_contours:
+                    shifted = contour.copy()
+                    shifted[:, :, 0] += min_y
+                    shifted[:, :, 1] += min_x
+                    cv2.drawContours(image_outlined, [shifted], -1, (0, 255, 255), 1)
 
             for i in range(1, int(np.max(seg) + 1)):
                 cell_tif_image = f"{dv_name}-{image_num}-{i}.png"
                 no_outline_image = f"{dv_name}-{image_num}-{i}-no_outline.png"
 
-                a = np.where(seg == i)
-                min_x = max(np.min(a[0]) - 1, 0)
-                max_x = min(np.max(a[0]) + 1, seg.shape[0])
-                min_y = max(np.min(a[1]) - 1, 0)
-                max_y = min(np.max(a[1]) + 1, seg.shape[1])
+                entry = cell_contour_cache.get(i)
+                if entry is None:
+                    continue
+                local_contours, min_x, max_x, min_y, max_y = entry
 
                 outline_path = Path(f"{outputdirectory}{dv_name}-{i}.outline")
                 if not outline_path.exists() or not use_cache:
                     with open(outline_path, "w", newline="") as csvfile:
                         csvwriter = csv.writer(csvfile, lineterminator="\n")
-                        csvwriter.writerows(zip(a[0] - min_x, a[1] - min_y))
+                        for idx, contour in enumerate(local_contours):
+                            if idx > 0:
+                                csvwriter.writerow([])
+                            for point in contour.reshape(-1, 2):
+                                csvwriter.writerow([int(point[1]), int(point[0])])
 
                 cellpair_image = image_outlined[min_x:max_x, min_y:max_y]
                 not_outlined_image = image[min_x:max_x, min_y:max_y]

--- a/cytocv/core/tests/test_canonical_contours.py
+++ b/cytocv/core/tests/test_canonical_contours.py
@@ -76,7 +76,7 @@ class CanonicalContourHelpersTests(SimpleTestCase):
         self.assertAlmostEqual(slots[0].center[0], expected_center[0], places=4)
         self.assertAlmostEqual(slots[0].center[1], expected_center[1], places=4)
 
-    def test_build_canonical_contour_payload_reads_outline_pixels_into_cell_mask(self):
+    def test_build_canonical_contour_payload_reads_outline_contour_into_cell_mask(self):
         raw_red = self._rect_contour(1, 1, 9, 9)
         raw_green = self._rect_contour(2, 2, 8, 8)
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -84,9 +84,9 @@ class CanonicalContourHelpersTests(SimpleTestCase):
             output_dir.mkdir(parents=True, exist_ok=True)
             outline_path = output_dir / "test-1.outline"
             with outline_path.open("w", encoding="utf-8") as handle:
-                for y in range(3, 9):
-                    for x in range(4, 10):
-                        handle.write(f"{y},{x}\n")
+                # External contour vertices (y, x) of the final pair support.
+                for vy, vx in ((3, 4), (3, 9), (8, 9), (8, 4)):
+                    handle.write(f"{vy},{vx}\n")
 
             payload = build_canonical_contour_payload(
                 {"dot_contours": [raw_red], "contours_green": [raw_green]},
@@ -111,9 +111,8 @@ class CanonicalContourHelpersTests(SimpleTestCase):
             output_dir.mkdir(parents=True, exist_ok=True)
             outline_path = output_dir / "test-1.outline"
             with outline_path.open("w", encoding="utf-8") as handle:
-                for y in range(1, 11):
-                    for x in range(1, 11):
-                        handle.write(f"{y},{x}\n")
+                for vy, vx in ((1, 1), (1, 10), (10, 10), (10, 1)):
+                    handle.write(f"{vy},{vx}\n")
 
             payload = build_canonical_contour_payload(
                 {"contours_blue": [raw_blue]},

--- a/cytocv/core/tests/test_modern_contour_statistics.py
+++ b/cytocv/core/tests/test_modern_contour_statistics.py
@@ -31,10 +31,20 @@ class ModernContourStatisticsTests(SimpleTestCase):
         output_path = output_dir / "output"
         output_path.mkdir(parents=True, exist_ok=True)
         outline_path = output_path / f"{image_stem}-{cell_id}.outline"
+        ys = list(y_range)
+        xs = list(x_range)
         with outline_path.open("w", encoding="utf-8") as handle:
-            for y in y_range:
-                for x in x_range:
-                    handle.write(f"{y},{x}\n")
+            if not ys or not xs:
+                return
+            y_min, y_max = ys[0], ys[-1]
+            x_min, x_max = xs[0], xs[-1]
+            for vy, vx in (
+                (y_min, x_min),
+                (y_min, x_max),
+                (y_max, x_max),
+                (y_max, x_min),
+            ):
+                handle.write(f"{vy},{vx}\n")
 
     @staticmethod
     def _conf(

--- a/cytocv/core/tests/test_mrcnn_inference.py
+++ b/cytocv/core/tests/test_mrcnn_inference.py
@@ -139,6 +139,34 @@ class PredictImagesRuntimeReuseTests(SimpleTestCase):
         self.assertGreater(int(processed_masks[:, :, 0].sum()), 1)
         self.assertFalse(np.any(processed_masks[:, :, 1]))
 
+    def test_postprocess_prediction_masks_fills_convex_hull_fjords_after_dedupe(self):
+        pred_masks = np.zeros((7, 7, 1), dtype=np.uint8)
+        pred_masks[1:6, 1, 0] = 1
+        pred_masks[1:6, 5, 0] = 1
+        pred_masks[5, 1:6, 0] = 1
+
+        processed_masks = postprocess_prediction_masks(pred_masks)
+
+        expected_mask = np.zeros((7, 7), dtype=np.uint8)
+        expected_mask[1:6, 1:6] = 1
+        self.assertTrue(np.array_equal(processed_masks[:, :, 0], expected_mask))
+
+    def test_postprocess_prediction_masks_does_not_fill_over_other_instances(self):
+        pred_masks = np.zeros((7, 7, 2), dtype=np.uint8)
+        pred_masks[1:6, 1, 0] = 1
+        pred_masks[1:6, 5, 0] = 1
+        pred_masks[5, 1:6, 0] = 1
+        pred_masks[3, 3, 1] = 1
+
+        processed_masks = postprocess_prediction_masks(
+            pred_masks,
+            scores=np.array([0.9, 0.8], dtype=np.float32),
+        )
+
+        self.assertEqual(int(processed_masks[3, 3, 1]), 1)
+        self.assertEqual(int(processed_masks[3, 3, 0]), 0)
+        self.assertEqual(int(processed_masks[2, 2, 0]), 1)
+
     def test_build_labeled_mask_image_preserves_surviving_original_order(self):
         pred_masks = np.zeros((4, 4, 3), dtype=np.uint8)
         pred_masks[1, 1, 0] = 1
@@ -298,4 +326,3 @@ class PredictImagesRuntimeReuseTests(SimpleTestCase):
             self.assertEqual(second_result.name, "mask.tif")
             self.assertTrue(np.array_equal(np.array(Image.open(first_result)), np.ones((4, 4), dtype=np.uint16)))
             self.assertTrue(np.array_equal(np.array(Image.open(second_result)), np.ones((4, 4), dtype=np.uint16)))
-

--- a/cytocv/core/tests/test_nuclear_cell_pair_intensity.py
+++ b/cytocv/core/tests/test_nuclear_cell_pair_intensity.py
@@ -15,9 +15,8 @@ class NuclearCellPairIntensityPluginTests(SimpleTestCase):
         output_path.mkdir(parents=True, exist_ok=True)
         outline_path = output_path / f"{image_stem}-{cell_id}.outline"
         with outline_path.open("w", encoding="utf-8") as handle:
-            for y in range(4, 20):
-                for x in range(4, 20):
-                    handle.write(f"{y},{x}\n")
+            for vy, vx in ((4, 4), (4, 19), (19, 19), (19, 4)):
+                handle.write(f"{vy},{vx}\n")
 
     def _build_gray_images(self) -> GrayImage:
         mcherry = np.zeros((24, 24), dtype=np.uint8)

--- a/cytocv/core/tests/test_outline_contour_artifact.py
+++ b/cytocv/core/tests/test_outline_contour_artifact.py
@@ -1,0 +1,98 @@
+"""Tests for the canonical `.outline` contour artifact and its round-trip."""
+
+from __future__ import annotations
+
+import csv
+import tempfile
+from pathlib import Path
+
+import cv2
+import numpy as np
+from django.test import SimpleTestCase
+
+from core.services.canonical_contours import load_cell_mask
+
+
+def _write_outline(output_dir: Path, contours: list[list[tuple[int, int]]], *, image_stem: str = "test", cell_id: int = 1) -> Path:
+    out = output_dir / "output"
+    out.mkdir(parents=True, exist_ok=True)
+    path = out / f"{image_stem}-{cell_id}.outline"
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle, lineterminator="\n")
+        for idx, contour in enumerate(contours):
+            if idx > 0:
+                writer.writerow([])
+            for (y, x) in contour:
+                writer.writerow([y, x])
+    return path
+
+
+class OutlineContourArtifactTests(SimpleTestCase):
+    def test_contour_roundtrip_reconstructs_support_mask(self):
+        shape = (40, 40)
+        pair_mask = np.zeros(shape, np.uint8)
+        pair_mask[10:25, 8:30] = 255
+
+        contours, _ = cv2.findContours(pair_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
+        self.assertEqual(len(contours), 1)
+        points = [(int(p[0][1]), int(p[0][0])) for p in contours[0]]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _write_outline(Path(temp_dir), [points])
+            reconstructed = load_cell_mask("test.dv", 1, temp_dir, shape)
+
+        self.assertTrue(np.array_equal(reconstructed > 0, pair_mask > 0))
+
+    def test_multi_contour_blank_row_separator(self):
+        shape = (30, 40)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _write_outline(
+                Path(temp_dir),
+                [
+                    [(2, 2), (2, 8), (8, 8), (8, 2)],
+                    [(12, 20), (12, 30), (22, 30), (22, 20)],
+                ],
+            )
+            mask = load_cell_mask("test.dv", 1, temp_dir, shape)
+
+        self.assertGreater(int(mask[5, 5]), 0)
+        self.assertGreater(int(mask[17, 25]), 0)
+        self.assertEqual(int(mask[5, 25]), 0)
+        self.assertEqual(int(mask[17, 5]), 0)
+
+    def test_symmetric_crop_margin_all_sides(self):
+        seg = np.zeros((60, 60), dtype=np.int32)
+        seg[20:30, 20:30] = 1
+
+        a = np.where(seg == 1)
+        min_x = max(int(np.min(a[0])) - 4, 0)
+        max_x = min(int(np.max(a[0])) + 4 + 1, seg.shape[0])
+        min_y = max(int(np.min(a[1])) - 4, 0)
+        max_y = min(int(np.max(a[1])) + 4 + 1, seg.shape[1])
+
+        self.assertEqual(min_x, 16)
+        self.assertEqual(max_x, 34)
+        self.assertEqual(min_y, 16)
+        self.assertEqual(max_y, 34)
+        self.assertEqual(20 - min_x, max_x - 30)
+        self.assertEqual(20 - min_y, max_y - 30)
+
+    def test_rendering_uses_external_contour_not_erosion(self):
+        seg = np.zeros((30, 30), dtype=np.int32)
+        seg[10:20, 10:20] = 1
+        image = np.zeros((30, 30, 3), dtype=np.uint8)
+
+        for i in range(1, int(np.max(seg) + 1)):
+            cell_mask_full = (seg == i).astype(np.uint8) * 255
+            contours, _ = cv2.findContours(
+                cell_mask_full, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE
+            )
+            cv2.drawContours(image, contours, -1, (0, 255, 255), 1)
+
+        # Boundary pixels receive cyan.
+        self.assertTrue(np.array_equal(image[10, 10], np.array([0, 255, 255], dtype=np.uint8)))
+        self.assertTrue(np.array_equal(image[19, 19], np.array([0, 255, 255], dtype=np.uint8)))
+        # Interior is untouched (no inward erosion ring).
+        self.assertTrue(np.array_equal(image[15, 15], np.array([0, 0, 0], dtype=np.uint8)))
+        # Exterior is untouched.
+        self.assertTrue(np.array_equal(image[5, 5], np.array([0, 0, 0], dtype=np.uint8)))

--- a/cytocv/core/tests/test_refine_pair_label_image.py
+++ b/cytocv/core/tests/test_refine_pair_label_image.py
@@ -1,0 +1,83 @@
+"""Tests for the post-pair label refinement helper."""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from django.test import SimpleTestCase
+
+from core.services.pair_refinement import refine_pair_label_image
+
+
+class RefinePairLabelImageTests(SimpleTestCase):
+    def test_narrow_gap_bridged(self):
+        """A single label split by a 1px background slit gets bridged."""
+        seg = np.zeros((20, 20), dtype=np.float64)
+        seg[5:10, 5:9] = 1.0
+        seg[5:10, 10:15] = 1.0
+        # Column 9 is a 1px gap between the two blobs of label 1.
+        self.assertTrue(np.all(seg[5:10, 9] == 0))
+
+        result = refine_pair_label_image(seg)
+
+        # Interior gap rows are bridged by the 3x3 closing.
+        self.assertTrue(np.all(result[6:9, 9] == 1.0))
+
+    def test_nearby_pairs_independent(self):
+        """Two distinct labels are refined independently; label count preserved."""
+        seg = np.zeros((30, 30), dtype=np.float64)
+        seg[2:8, 2:8] = 1.0
+        seg[20:26, 20:26] = 2.0
+
+        result = refine_pair_label_image(seg)
+
+        unique_labels = set(np.unique(result)) - {0}
+        self.assertEqual(unique_labels, {1.0, 2.0})
+        # Original pixels unchanged.
+        self.assertTrue(np.all(result[2:8, 2:8] == 1.0))
+        self.assertTrue(np.all(result[20:26, 20:26] == 2.0))
+
+    def test_conflicting_claims_stay_background(self):
+        """Two labels whose closings overlap on the same pixel leave it as 0."""
+        seg = np.zeros((20, 20), dtype=np.float64)
+        seg[5:10, 5:9] = 1.0
+        seg[5:10, 10:15] = 2.0
+        # Column 9 is background, 1px from label 1 and 1px from label 2.
+        # Both closings will try to claim it.
+
+        result = refine_pair_label_image(seg)
+
+        # Contested pixels must remain background.
+        self.assertTrue(np.all(result[5:10, 9] == 0))
+
+    def test_existing_pixels_preserved(self):
+        """Every original nonzero pixel retains its value after refinement."""
+        seg = np.zeros((30, 30), dtype=np.float64)
+        seg[3:12, 3:12] = 1.0
+        seg[18:27, 18:27] = 2.0
+        original_nonzero = seg.copy()
+
+        result = refine_pair_label_image(seg)
+
+        mask = original_nonzero != 0
+        self.assertTrue(np.array_equal(result[mask], original_nonzero[mask]))
+
+    def test_empty_image_noop(self):
+        """An all-zeros input returns an all-zeros output."""
+        seg = np.zeros((10, 10), dtype=np.float64)
+
+        result = refine_pair_label_image(seg)
+
+        self.assertTrue(np.all(result == 0))
+
+    def test_hole_filled(self):
+        """A label forming a ring (hollow center) gets the interior filled."""
+        seg = np.zeros((20, 20), dtype=np.float64)
+        # Create a ring: outer block with a hollow center.
+        seg[4:16, 4:16] = 1.0
+        seg[7:13, 7:13] = 0.0
+
+        result = refine_pair_label_image(seg)
+
+        # The interior hole should now be filled with label 1.
+        self.assertTrue(np.all(result[7:13, 7:13] == 1.0))

--- a/cytocv/core/views/segment_image.py
+++ b/cytocv/core/views/segment_image.py
@@ -100,6 +100,7 @@ from core.services.canonical_contours import (
     build_canonical_contour_payload,
     flatten_slot_contours,
 )
+from core.services.pair_refinement import refine_pair_label_image
 from core.services.overlay_rendering import (
     build_overlay_render_config,
     persist_debug_overlay_exports,
@@ -448,7 +449,6 @@ def segment_image(request, uuids):
 
         #TODO:   If G1 Arrested, we don't want to merge neighbors and ignore non-budding cells
         #choices = ['Metaphase Arrested', 'G1 Arrested']
-        outlines = np.zeros(seg.shape)
         if choice_var == 'Metaphase Arrested':
             # Create a raw file to store the outlines
             ignore_list = list()
@@ -684,6 +684,8 @@ def segment_image(request, uuids):
             for i, x in enumerate(to_rebase):
                 seg[np.where(seg == x)] = i + 1
 
+            seg = refine_pair_label_image(seg)
+
             # now seg has the updated masks, so lets save them so we don't have to do this every time
             outputdirectory = str(Path(MEDIA_ROOT)) + '/' + str(uuid) + '/output/'
             seg_image = Image.fromarray(seg)
@@ -736,16 +738,15 @@ def segment_image(request, uuids):
                 image = np.expand_dims(image, axis=-1)
                 image = np.tile(image, 3)
 
-            # Iterate over each integer in the segmentation and save the outline of each cell onto the outline file
-            for i in range(1, int(np.max(seg) + 1)):
-                tmp = np.zeros(seg.shape)
-                tmp[np.where(seg == i)] = 1
-                tmp = tmp - skimage.morphology.erosion(tmp)
-                outlines += tmp
-
-            # Overlay the outlines on the original image in green
+            # Draw cell-pair external contours (canonical boundary) on the frame overlay.
             image_outlined = image.copy()
-            image_outlined[outlines > 0] = (0, 255, 255)
+            for i in range(1, int(np.max(seg) + 1)):
+                cell_mask_full = (seg == i).astype(np.uint8) * 255
+                contours, _ = cv2.findContours(
+                    cell_mask_full, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE
+                )
+                if contours:
+                    cv2.drawContours(image_outlined, contours, -1, (0, 255, 255), 1)
 
             # Display the outline file
             fig = plt.figure(frameon=False)
@@ -866,45 +867,46 @@ def segment_image(request, uuids):
             # plt.imsave(str(Path(MEDIA_ROOT)) + '/' + str(uuid) + '/' + DV_Name + '-' + str(image_num) + '.tif', image, dpi=600, format='TIFF')
             cached_channel_name = layer_channel_lookup.get(image_num)
 
-            outlines = np.zeros(seg.shape)
-            # Iterate over each integer in the segmentation and save the outline of each cell onto the outline file
-            for i in range(1, int(np.max(seg) + 1)):
-                tmp = np.zeros(seg.shape)
-                tmp[np.where(seg == i)] = 1
-                tmp = tmp - skimage.morphology.erosion(tmp)
-                outlines += tmp
-            
-            # Overlay the outlines on the original image in green
             image_outlined = image.copy()
-            # image_outlined[outlines > 0] = (0, 255, 0)
-            # NOTE: Temporarily changing to cyan to debug the Green channel
-            image_outlined[outlines > 0] = (0, 255, 255)
+            cell_contour_cache = {}
+            for i in range(1, int(np.max(seg) + 1)):
+                a = np.where(seg == i)
+                if a[0].size == 0:
+                    continue
+                min_x = max(int(np.min(a[0])) - 4, 0)
+                max_x = min(int(np.max(a[0])) + 4 + 1, seg.shape[0])
+                min_y = max(int(np.min(a[1])) - 4, 0)
+                max_y = min(int(np.max(a[1])) + 4 + 1, seg.shape[1])
+                local_mask = ((seg[min_x:max_x, min_y:max_y] == i).astype(np.uint8)) * 255
+                local_contours, _ = cv2.findContours(
+                    local_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE
+                )
+                cell_contour_cache[i] = (tuple(local_contours), min_x, max_x, min_y, max_y)
+                for contour in local_contours:
+                    shifted = contour.copy()
+                    shifted[:, :, 0] += min_y
+                    shifted[:, :, 1] += min_x
+                    cv2.drawContours(image_outlined, [shifted], -1, (0, 255, 255), 1)
 
             # Iterate over each integer in the segmentation and save the outline of each cell onto the outline file
             for i in range(1, int(np.max(seg) + 1)):
-                #cell_tif_image = tif_image.split('.')[0] + '-' + str(i) + '.tif'
-                #no_outline_image = tif_image.split('.')[0] + '-' + str(i) + '-no_outline.tif'
-                # cell_tif_image = images.split('.')[0] + '-' + str(i) + '.tif'
-                # no_outline_image = images.split('.')[0] + '-' + str(i) + '-no_outline.tif'
                 cell_tif_image = DV_Name + '-' + str(image_num) + '-' + str(i) + '.png'
                 no_outline_image = DV_Name + '-' + str(image_num) + '-'  + str(i) + '-no_outline.png'
 
-                a = np.where(seg == i)   # somethin bad is happening when i = 4 on my tests
-                min_x = max(np.min(a[0]) - 1, 0)
-                max_x = min(np.max(a[0]) + 1, seg.shape[0])
-                min_y = max(np.min(a[1]) - 1, 0)
-                max_y = min(np.max(a[1]) + 1, seg.shape[1])
-
-                # a[0] contains the x coords and a[1] contains the y coords
-                # save this to use later when I want to calculate cellular intensity
-
-                #convert from absolute location to relative location for later use
+                entry = cell_contour_cache.get(i)
+                if entry is None:
+                    continue
+                local_contours, min_x, max_x, min_y, max_y = entry
 
                 if not os.path.exists(str(outputdirectory) + DV_Name + '-' + str(i) + '.outline')  or not use_cache:
                     try:
                         with open(str(outputdirectory) + DV_Name + '-' + str(i) + '.outline', 'w') as csvfile:
                             csvwriter = csv.writer(csvfile, lineterminator='\n')
-                            csvwriter.writerows(zip(a[0] - min_x, a[1] - min_y))
+                            for idx, contour in enumerate(local_contours):
+                                if idx > 0:
+                                    csvwriter.writerow([])
+                                for point in contour.reshape(-1, 2):
+                                    csvwriter.writerow([int(point[1]), int(point[0])])
                     except Exception as exc:
                         if is_storage_full_error(exc):
                             return storage_full_response(exc)


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the cell segmentation and mask processing pipeline, focusing on more robust handling of cell contours, improved mask post-processing, and clearer outline file conventions. The changes also update the associated tests to match the new logic and file formats.

**Mask and Segmentation Improvements:**

* Added convex hull filling to mask post-processing, ensuring that inward fjords and holes in predicted masks are closed, but without overlapping other instances. This is implemented in `fill_mask_volume_convex_hulls` and integrated into `postprocess_prediction_masks`. [[1]](diffhunk://#diff-b647088bfceb5da211478e255073765c82e46c6e23273f33839466269fcb5be1R98-R151) [[2]](diffhunk://#diff-b647088bfceb5da211478e255073765c82e46c6e23273f33839466269fcb5be1L110-R170) [[3]](diffhunk://#diff-955881eff8967ef6ff58c34ea7fefb547bfa3a8e8c374ee92b549234fe6a386fR142-R169)
* Added a new post-pair label refinement step (`refine_pair_label_image`) to close narrow gaps and fill holes in segmentation results, while preserving boundaries between touching instances. Integrated this into the segmentation pipeline. [[1]](diffhunk://#diff-afe7b17baa2c3f0e6e7f8280f18276f2b5f2140f39f9a03268b193a2a3b62e40R1-R41) [[2]](diffhunk://#diff-79c928a30ea49ada35fbdca5c5fbe02ce47df773a11018f47ec5e42f15ccc04fR53) [[3]](diffhunk://#diff-79c928a30ea49ada35fbdca5c5fbe02ce47df773a11018f47ec5e42f15ccc04fR340-R341)

**Cell Contour and Outline Handling:**

* Changed the `.outline` file format to store only external contour vertices (as `y,x`), with multiple contours separated by blank lines, and updated `load_cell_mask` to fill masks from these contours using OpenCV.
* Updated segmentation pipeline logic to cache and write external contours for each cell, and to use these for both rendering outlines and saving outline files. [[1]](diffhunk://#diff-79c928a30ea49ada35fbdca5c5fbe02ce47df773a11018f47ec5e42f15ccc04fL352-R361) [[2]](diffhunk://#diff-79c928a30ea49ada35fbdca5c5fbe02ce47df773a11018f47ec5e42f15ccc04fL417-R465)

**Code Cleanup and Refactoring:**

* Removed unused `_cell_points` method and unnecessary imports from `nuclear_cell_pair_intensity.py` for clarity and maintainability. [[1]](diffhunk://#diff-c4441932788d895102f919f56f12a4f4d4455c180b67f2f776b26119fda57459L1-L3) [[2]](diffhunk://#diff-c4441932788d895102f919f56f12a4f4d4455c180b67f2f776b26119fda57459L43-L52)
* Improved test utilities and test cases to match the new outline file format and mask loading logic. [[1]](diffhunk://#diff-8adda9487eb3b2e04c176784eb39bb1ecb70f32e155754581cd63f1b7819b341L79-R89) [[2]](diffhunk://#diff-8adda9487eb3b2e04c176784eb39bb1ecb70f32e155754581cd63f1b7819b341L114-R115) [[3]](diffhunk://#diff-789b4d48659f27e50a58fffb0a141c47f48881a7a1cc245dd0d05337027a8518R34-R47) [[4]](diffhunk://#diff-d5120ddf74618ea3a49b01b09feba0ea023a30740f809ff160270567e27656efL18-R19)

**Testing Enhancements:**

* Added new tests to verify convex hull filling and ensure that filling does not overwrite other instances in mask post-processing.

These changes collectively make the segmentation pipeline more robust to irregular instance shapes, standardize outline file handling, and ensure that tests accurately reflect the new logic.