### PR TITLE
Add neck split geometry module and optimize artifact storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,15 @@
 __pycache__/
 db.sqlite3
 media/
-cytocv_venv/
 cyto_cv/
 .cytocv-local-install/
+
+# Local Python virtual environments
+.venv/
+venv/
+env/
+ENV/
+cytocv_venv*/
 
 # Neural network
 deepretina_final.h5

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ For operational deployment material, use these documents:
 
 - General deployment guide: [docs/ops/deployment-guide.md](docs/ops/deployment-guide.md)
 - PostgreSQL setup: [docs/ops/postgres-setup.md](docs/ops/postgres-setup.md)
+- Example `systemd` units: [deploy/systemd/README.md](deploy/systemd/README.md)
 - March 2026 VM step-by-step guide: [docs/vm-deployment-guide/README.md](docs/vm-deployment-guide/README.md)
 - March 2026 VM rollout record: [docs/vm-deployment-record/README.md](docs/vm-deployment-record/README.md)
 - Replacement `cytocv2.uwb.edu` VM rollout record: [docs/vm-deployment-record-cytocv2/README.md](docs/vm-deployment-record-cytocv2/README.md)
@@ -245,4 +246,3 @@ License reference:
 
 - [docs/license/README.md](docs/license/README.md)
 - <https://creativecommons.org/licenses/by-nc-sa/4.0/>
-

--- a/cytocv/core/artifact_constants.py
+++ b/cytocv/core/artifact_constants.py
@@ -2,3 +2,7 @@
 
 PRE_PROCESS_FOLDER_NAME = "preprocessed_images"
 PREVIEW_FOLDER_NAME = "preview_images"
+
+# Sidecar artifact written next to the per-cell `.outline` file. Stores the
+# two internal neck-split endpoints (see core.services.neck_split).
+NECK_SPLIT_SUFFIX = ".neck_split"

--- a/cytocv/core/artifact_constants.py
+++ b/cytocv/core/artifact_constants.py
@@ -2,7 +2,9 @@
 
 PRE_PROCESS_FOLDER_NAME = "preprocessed_images"
 PREVIEW_FOLDER_NAME = "preview_images"
+PAIR_GEOMETRY_FILENAME = "pair-geometry.json"
 
 # Sidecar artifact written next to the per-cell `.outline` file. Stores the
-# two internal neck-split endpoints (see core.services.neck_split).
+# two internal neck-split endpoints for legacy runs
+# (see core.services.neck_split).
 NECK_SPLIT_SUFFIX = ".neck_split"

--- a/cytocv/core/cell_analysis/cen_dot.py
+++ b/cytocv/core/cell_analysis/cen_dot.py
@@ -1,16 +1,34 @@
 import logging
 import math
+
+import cv2
 import numpy as np
 
 from core.services.canonical_contours import (
+    CanonicalContourSlot,
     get_canonical_green_slots,
     get_canonical_red_slots,
+    get_neck_split,
+    get_side_masks,
 )
 from core.scale import convert_pixel_delta_to_microns, normalize_length_unit
 
 from .analysis import Analysis
 
 logger = logging.getLogger(__name__)
+
+
+CEN_DOT_SCHEMA_VERSION = 2
+
+_CATEGORY_BOTH = 1
+_CATEGORY_MOTHER_ONLY = 2
+_CATEGORY_DAUGHTER_ONLY = 3
+_CATEGORY_NA = 4
+
+_SIDE_MOTHER = "mother"
+_SIDE_DAUGHTER = "daughter"
+
+_MAX_RED_SLOTS_FOR_CLASSIFICATION = 3
 
 
 class CENDot(Analysis):
@@ -39,7 +57,7 @@ class CENDot(Analysis):
             )
         return float(math.dist(center_1, center_2))
 
-    def _is_distance_above_threshold(self, center_1, center_2, threshold_value) -> bool:
+    def _distance_meets_threshold(self, center_1, center_2, threshold_value) -> tuple[bool, float, float]:
         threshold_unit = self._get_distance_threshold_unit()
         distance = self._distance_between_centers(
             center_1,
@@ -50,7 +68,7 @@ class CENDot(Analysis):
             threshold = float(threshold_value)
         except (TypeError, ValueError):
             threshold = 0.0
-        return distance > threshold
+        return distance >= threshold, distance, threshold
 
     def point_is_between(self, point, endpoint1, endpoint2, eps):
         point = np.array(point)
@@ -64,9 +82,6 @@ class CENDot(Analysis):
         dot = (point[0] - endpoint1[0]) * (endpoint2[0] - endpoint1[0]) + (point[1] - endpoint1[1]) * (endpoint2[1] - endpoint1[1])
         squared_dist = math.dist(endpoint1, endpoint2) * math.dist(endpoint1, endpoint2)
         return not (dot < 0 or dot > squared_dist)
-
-    def is_close(self, green_center_1, green_center_2):
-        return math.dist(green_center_1, green_center_2) <= 8
 
     def _get_proximity_radius_unit(self) -> str:
         properties = getattr(self.cp, "properties", {}) or {}
@@ -89,6 +104,62 @@ class CENDot(Analysis):
             return proximity_radius / um_per_px
         return proximity_radius
 
+    @staticmethod
+    def _deduplicate_slots(
+        slots: list[CanonicalContourSlot],
+        min_center_distance: float = 8.0,
+    ) -> list[CanonicalContourSlot]:
+        """Drop slots whose center lies within ``min_center_distance`` of a kept slot."""
+
+        kept: list[CanonicalContourSlot] = []
+        for slot in slots:
+            keep = True
+            for existing in kept:
+                if math.dist(slot.center, existing.center) <= min_center_distance:
+                    keep = False
+                    break
+            if keep:
+                kept.append(slot)
+        return kept
+
+    @staticmethod
+    def _assign_slot_side(
+        slot: CanonicalContourSlot,
+        mother_mask: np.ndarray | None,
+        daughter_mask: np.ndarray | None,
+    ) -> str | None:
+        """Return ``mother``/``daughter`` based on which side mask overlaps most."""
+
+        if mother_mask is None or daughter_mask is None:
+            return None
+        slot_mask = slot.mask
+        if slot_mask is None or not np.any(slot_mask):
+            return None
+        mother_overlap = int(np.count_nonzero(cv2.bitwise_and(slot_mask, mother_mask)))
+        daughter_overlap = int(np.count_nonzero(cv2.bitwise_and(slot_mask, daughter_mask)))
+        if mother_overlap == 0 and daughter_overlap == 0:
+            return None
+        return _SIDE_MOTHER if mother_overlap >= daughter_overlap else _SIDE_DAUGHTER
+
+    @staticmethod
+    def _green_slot_inside_pair_mask(
+        slot: CanonicalContourSlot,
+        cell_mask: np.ndarray | None,
+    ) -> bool:
+        """Require a non-empty green footprint inside the DIC pair mask."""
+
+        if cell_mask is None or slot.mask is None:
+            return False
+        clipped = cv2.bitwise_and(slot.mask, cell_mask)
+        return bool(np.any(clipped))
+
+    @staticmethod
+    def _set_location_properties(cp, payload: dict) -> None:
+        properties = dict(getattr(cp, "properties", {}) or {})
+        properties["cen_dot_schema_version"] = CEN_DOT_SCHEMA_VERSION
+        properties["cen_dot_location"] = payload
+        cp.properties = properties
+
     def calculate_statistics(
         self,
         best_contours,
@@ -102,6 +173,7 @@ class CENDot(Analysis):
     ):
         prox_radius = self._proximity_radius_in_pixels(cen_dot_proximity_radius)
         cen_dot_distance = cen_dot_distance if (cen_dot_distance >= 0) else 37
+
         red_shape = None
         green_shape = None
         red_gray = self.preprocessed_images.get_image("gray_red")
@@ -113,53 +185,71 @@ class CENDot(Analysis):
         if red_shape is None and green_shape is None:
             return
         base_shape = red_shape or green_shape
-        red_slots = get_canonical_red_slots(contours_data, base_shape, limit=2)
-        if len(red_slots) <= 1:
-            return
-        green_slots = get_canonical_green_slots(contours_data, green_shape or base_shape)
+
+        cell_mask = contours_data.get("cell_mask")
+        mother_mask, daughter_mask = get_side_masks(contours_data)
+        neck_split = get_neck_split(contours_data)
+        threshold_unit = self._get_distance_threshold_unit()
+        proximity_unit = self._get_proximity_radius_unit()
+
+        def _finalize(category: int, status: str, extra: dict | None = None) -> None:
+            payload: dict = {
+                "status": status,
+                "category": int(category),
+                "threshold_unit": threshold_unit,
+                "proximity_unit": proximity_unit,
+                "proximity_radius_value": float(cen_dot_proximity_radius),
+                "proximity_radius_px": float(prox_radius),
+                "red_distance_threshold": float(cen_dot_distance),
+                "has_neck_split": neck_split is not None and mother_mask is not None,
+            }
+            if extra:
+                payload.update(extra)
+            self.cp.category_cen_dot = int(category)
+            self._set_location_properties(self.cp, payload)
 
         try:
-            centers = [red_slots[0].center, red_slots[1].center]
-            green_centers = {index: slot.center for index, slot in enumerate(green_slots)}
+            raw_red_slots = get_canonical_red_slots(
+                contours_data,
+                base_shape,
+                limit=_MAX_RED_SLOTS_FOR_CLASSIFICATION,
+            )
+            red_slots = self._deduplicate_slots(raw_red_slots)
 
-            if not green_centers:
-                self.cp.category_cen_dot = 4
+            raw_green_slots = get_canonical_green_slots(
+                contours_data,
+                green_shape or base_shape,
+                limit=_MAX_RED_SLOTS_FOR_CLASSIFICATION,
+            )
+            green_slots = self._deduplicate_slots(raw_green_slots)
+
+            red_count = len(red_slots)
+            if red_count != 2:
                 self.cp.biorientation = 0
+                reason = "too_few_reds" if red_count < 2 else "too_many_reds"
+                _finalize(
+                    _CATEGORY_NA,
+                    reason,
+                    {"usable_red_count": int(red_count)},
+                )
                 return
 
-            filtered_centers = {0: green_centers[0]}
-            if len(green_centers) > 1:
-                for i in range(1, len(green_centers)):
-                    close = False
-                    for j in range(len(filtered_centers)):
-                        if self.is_close(filtered_centers[j], green_centers[i]):
-                            close = True
-                    if not close:
-                        filtered_centers[i] = green_centers[i]
-            green_centers = filtered_centers
+            center_1 = red_slots[0].center
+            center_2 = red_slots[1].center
+            meets_threshold, distance, threshold = self._distance_meets_threshold(
+                center_1,
+                center_2,
+                cen_dot_distance,
+            )
 
-            if self._is_distance_above_threshold(centers[0], centers[1], cen_dot_distance):
-                num_signals = [0] * len(centers)
-                for i in range(len(centers)):
-                    for green_center in green_centers.values():
-                        if math.dist(centers[i], green_center) <= prox_radius:
-                            num_signals[i] += 1
-
-                if num_signals[0] >= 1 and num_signals[1] >= 1:
-                    self.cp.category_cen_dot = 1
-                elif (num_signals[0] == 1 and num_signals[1] == 0) or (num_signals[0] == 0 and num_signals[1] == 1):
-                    self.cp.category_cen_dot = 2
-                elif (num_signals[0] == 2 and num_signals[1] == 0) or (num_signals[0] == 0 and num_signals[1] == 2):
-                    self.cp.category_cen_dot = 3
-                else:
-                    self.cp.category_cen_dot = 4
-            else:
+            if not meets_threshold:
+                # Biorientation path: close reds preserve the legacy calculation.
                 num_between = 0
-                for green_center in green_centers.values():
+                for green_slot in green_slots:
                     if self.point_is_between(
-                        green_center,
-                        centers[0],
-                        centers[1],
+                        green_slot.center,
+                        center_1,
+                        center_2,
                         cen_dot_collinearity_threshold,
                     ):
                         num_between += 1
@@ -170,8 +260,122 @@ class CENDot(Analysis):
                     self.cp.biorientation = 2
                 else:
                     self.cp.biorientation = 0
+
+                _finalize(
+                    _CATEGORY_NA,
+                    "reds_below_threshold",
+                    {
+                        "red_distance": float(distance),
+                        "red_distance_threshold_effective": float(threshold),
+                        "biorientation_between_count": int(num_between),
+                    },
+                )
+                return
+
+            self.cp.biorientation = 0
+
+            if mother_mask is None or daughter_mask is None or neck_split is None:
+                _finalize(
+                    _CATEGORY_NA,
+                    "missing_neck_split",
+                    {"red_distance": float(distance)},
+                )
+                return
+
+            side_by_red_index: dict[int, str] = {}
+            for index, slot in enumerate(red_slots[:2]):
+                side = self._assign_slot_side(slot, mother_mask, daughter_mask)
+                if side is not None:
+                    side_by_red_index[index] = side
+
+            if len(side_by_red_index) != 2:
+                _finalize(
+                    _CATEGORY_NA,
+                    "red_side_unassigned",
+                    {"red_distance": float(distance)},
+                )
+                return
+
+            if side_by_red_index[0] == side_by_red_index[1]:
+                _finalize(
+                    _CATEGORY_NA,
+                    "reds_same_side",
+                    {
+                        "red_distance": float(distance),
+                        "red_sides": [side_by_red_index[0], side_by_red_index[1]],
+                    },
+                )
+                return
+
+            mother_red_index = next(
+                idx for idx, side in side_by_red_index.items() if side == _SIDE_MOTHER
+            )
+            daughter_red_index = next(
+                idx for idx, side in side_by_red_index.items() if side == _SIDE_DAUGHTER
+            )
+            mother_red_center = red_slots[mother_red_index].center
+            daughter_red_center = red_slots[daughter_red_index].center
+
+            mother_green_centers: list[tuple[float, float]] = []
+            daughter_green_centers: list[tuple[float, float]] = []
+            for green_slot in green_slots:
+                if not self._green_slot_inside_pair_mask(green_slot, cell_mask):
+                    continue
+                side = self._assign_slot_side(green_slot, mother_mask, daughter_mask)
+                if side is None:
+                    continue
+                if side == _SIDE_MOTHER:
+                    if math.dist(mother_red_center, green_slot.center) <= prox_radius:
+                        mother_green_centers.append(green_slot.center)
+                else:
+                    if math.dist(daughter_red_center, green_slot.center) <= prox_radius:
+                        daughter_green_centers.append(green_slot.center)
+
+            has_mother = bool(mother_green_centers)
+            has_daughter = bool(daughter_green_centers)
+
+            if has_mother and has_daughter:
+                category = _CATEGORY_BOTH
+                status = "mother_and_daughter"
+            elif has_mother:
+                category = _CATEGORY_MOTHER_ONLY
+                status = "mother_only"
+            elif has_daughter:
+                category = _CATEGORY_DAUGHTER_ONLY
+                status = "daughter_only"
+            else:
+                category = _CATEGORY_NA
+                status = "no_valid_green"
+
+            _finalize(
+                category,
+                status,
+                {
+                    "red_distance": float(distance),
+                    "red_distance_threshold_effective": float(threshold),
+                    "mother_red_center": [float(mother_red_center[0]), float(mother_red_center[1])],
+                    "daughter_red_center": [float(daughter_red_center[0]), float(daughter_red_center[1])],
+                    "mother_green_centers": [
+                        [float(c[0]), float(c[1])] for c in mother_green_centers
+                    ],
+                    "daughter_green_centers": [
+                        [float(c[0]), float(c[1])] for c in daughter_green_centers
+                    ],
+                    "green_in_mother": has_mother,
+                    "green_in_daughter": has_daughter,
+                },
+            )
         except Exception as exc:
             logger.debug("CENDot analysis skipped due to contour error: %s", exc)
-            self.cp.category_cen_dot = 4
+            self.cp.category_cen_dot = _CATEGORY_NA
             self.cp.biorientation = 0
-            return
+            self._set_location_properties(
+                self.cp,
+                {
+                    "status": "error",
+                    "category": int(_CATEGORY_NA),
+                    "threshold_unit": threshold_unit,
+                    "proximity_unit": proximity_unit,
+                    "error": str(exc),
+                },
+            )

--- a/cytocv/core/cell_analysis/nuclear_cell_pair_intensity.py
+++ b/cytocv/core/cell_analysis/nuclear_cell_pair_intensity.py
@@ -1,6 +1,7 @@
 import cv2
 import numpy as np
 
+from core.image_processing.dashed_line import draw_dashed_polyline
 from core.services.canonical_contours import (
     get_canonical_green_slots,
     get_canonical_red_slots,
@@ -38,39 +39,18 @@ class NuclearCellPairIntensity(Analysis):
         return None
 
     @staticmethod
-    def _draw_dashed_contour(image, contour, color=(0, 255, 255), dash_px=6, gap_px=4, thickness=1):
+    def _draw_dashed_contour(image, contour, color=(0, 255, 255), dash_px=2, gap_px=2, thickness=1):
         if image is None or contour is None or len(contour) < 2:
             return
-        dash_px = max(int(dash_px), 1)
-        gap_px = max(int(gap_px), 1)
-        points = contour.reshape(-1, 2).astype(np.float32)
-        if points.shape[0] < 2:
-            return
-        points = np.vstack([points, points[0]])
-        draw_segment = True
-        remaining = float(dash_px)
-        for idx in range(points.shape[0] - 1):
-            start = points[idx]
-            end = points[idx + 1]
-            segment = end - start
-            segment_length = float(np.linalg.norm(segment))
-            if segment_length <= 0:
-                continue
-            direction = segment / segment_length
-            traversed = 0.0
-            while traversed < segment_length:
-                step = min(remaining, segment_length - traversed)
-                seg_start = start + (direction * traversed)
-                seg_end = start + (direction * (traversed + step))
-                if draw_segment:
-                    p1 = tuple(np.round(seg_start).astype(int))
-                    p2 = tuple(np.round(seg_end).astype(int))
-                    cv2.line(image, p1, p2, color, thickness=thickness, lineType=cv2.LINE_AA)
-                traversed += step
-                remaining -= step
-                if remaining <= 1e-6:
-                    draw_segment = not draw_segment
-                    remaining = float(dash_px if draw_segment else gap_px)
+        draw_dashed_polyline(
+            image,
+            contour.reshape(-1, 2),
+            color,
+            closed=True,
+            dash_px=dash_px,
+            gap_px=gap_px,
+            thickness=thickness,
+        )
 
     def calculate_statistics(
         self,
@@ -167,6 +147,6 @@ class NuclearCellPairIntensity(Analysis):
 
         if self._DRAW_NUCLEAR_CONTOUR_OVERLAY:
             if red_image is not None:
-                self._draw_dashed_contour(red_image, largest_contour, color=(0, 255, 255), dash_px=6, gap_px=4, thickness=1)
+                self._draw_dashed_contour(red_image, largest_contour, color=(0, 255, 255), dash_px=2, gap_px=2, thickness=1)
             if green_image is not None:
-                self._draw_dashed_contour(green_image, largest_contour, color=(0, 255, 255), dash_px=6, gap_px=4, thickness=1)
+                self._draw_dashed_contour(green_image, largest_contour, color=(0, 255, 255), dash_px=2, gap_px=2, thickness=1)

--- a/cytocv/core/image_processing/dashed_line.py
+++ b/cytocv/core/image_processing/dashed_line.py
@@ -1,0 +1,94 @@
+"""Shared short-dash drawing primitives for debug overlays."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import cv2
+import numpy as np
+
+
+DEFAULT_DASH_PX = 2
+DEFAULT_GAP_PX = 2
+
+
+def draw_dashed_line(
+    image: np.ndarray,
+    p1: Sequence[float],
+    p2: Sequence[float],
+    color,
+    *,
+    dash_px: int = DEFAULT_DASH_PX,
+    gap_px: int = DEFAULT_GAP_PX,
+    thickness: int = 1,
+    line_type: int = cv2.LINE_AA,
+) -> None:
+    """Draw a short-dash segment from ``p1`` to ``p2`` onto ``image`` in place."""
+
+    if image is None or p1 is None or p2 is None:
+        return
+    dash_px = max(int(dash_px), 1)
+    gap_px = max(int(gap_px), 0)
+
+    start = np.asarray(p1, dtype=np.float32).reshape(-1)[:2]
+    end = np.asarray(p2, dtype=np.float32).reshape(-1)[:2]
+    segment = end - start
+    segment_length = float(np.linalg.norm(segment))
+    if segment_length <= 0:
+        return
+    direction = segment / segment_length
+
+    traversed = 0.0
+    spacing = float(dash_px + gap_px)
+    while traversed <= segment_length:
+        seg_start = start + direction * traversed
+        seg_end = start + direction * min(traversed + float(dash_px), segment_length)
+        p_a = (int(round(float(seg_start[0]))), int(round(float(seg_start[1]))))
+        p_b = (int(round(float(seg_end[0]))), int(round(float(seg_end[1]))))
+        cv2.line(image, p_a, p_b, color, thickness=thickness, lineType=line_type)
+        traversed += spacing
+
+
+def draw_dashed_polyline(
+    image: np.ndarray,
+    points: np.ndarray,
+    color,
+    *,
+    closed: bool = True,
+    dash_px: int = DEFAULT_DASH_PX,
+    gap_px: int = DEFAULT_GAP_PX,
+    thickness: int = 1,
+    line_type: int = cv2.LINE_AA,
+) -> None:
+    """Draw a short-dash polyline that preserves spacing across vertices."""
+
+    if image is None or points is None:
+        return
+    pts = np.asarray(points, dtype=np.float32).reshape(-1, 2)
+    if pts.shape[0] < 2:
+        return
+    if closed:
+        pts = np.vstack([pts, pts[0]])
+
+    dash_px = max(int(dash_px), 1)
+    gap_px = max(int(gap_px), 0)
+    spacing = float(dash_px + gap_px)
+    next_dash_at = 0.0
+
+    for idx in range(pts.shape[0] - 1):
+        start = pts[idx]
+        end = pts[idx + 1]
+        segment = end - start
+        segment_length = float(np.linalg.norm(segment))
+        if segment_length <= 0:
+            continue
+        direction = segment / segment_length
+        traversed = float(next_dash_at)
+        while traversed <= segment_length:
+            seg_start = start + direction * traversed
+            seg_end = start + direction * min(traversed + float(dash_px), segment_length)
+            p_a = (int(round(float(seg_start[0]))), int(round(float(seg_start[1]))))
+            p_b = (int(round(float(seg_end[0]))), int(round(float(seg_end[1]))))
+            cv2.line(image, p_a, p_b, color, thickness=thickness, lineType=line_type)
+            traversed += spacing
+        next_dash_at = traversed - segment_length

--- a/cytocv/core/migrations/0012_cen_dot_mother_daughter_choices.py
+++ b/cytocv/core/migrations/0012_cen_dot_mother_daughter_choices.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Choice-only metadata update for the mother/daughter CEN dot semantics.
+
+    No data migration: historical rows keep their integer codes, but the
+    schema-aware label helper surfaces a rerun-required label for legacy values.
+    """
+
+    dependencies = [
+        ("core", "0011_puncta_cell_pair_naming_cutover"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="cellstatistics",
+            name="category_cen_dot",
+            field=models.IntegerField(
+                choices=[
+                    (1, "Mother and daughter"),
+                    (2, "Mother only"),
+                    (3, "Daughter only"),
+                    (4, "N/A"),
+                ],
+                default=4,
+            ),
+        ),
+    ]

--- a/cytocv/core/models.py
+++ b/cytocv/core/models.py
@@ -174,17 +174,26 @@ class Contour(Enum):
     CIRCLE = 2
 
 
-class CategoryCENDot(models.IntegerChoices):
-    """Categories for CEN dot analysis classification."""
+CEN_DOT_SCHEMA_VERSION = 2
+CEN_DOT_LEGACY_RERUN_LABEL = "Rerun analysis for CEN location"
 
-    ONEEACH = 1, "One green dot with each red dot"
-    ONEONE = 2, "One green dot with one red dot"
-    TWOONE = 3, "Two green dots with one red dot"
+
+class CategoryCENDot(models.IntegerChoices):
+    """Mother/daughter CEN dot location classification codes."""
+
+    MOTHER_AND_DAUGHTER = 1, "Mother and daughter"
+    MOTHER_ONLY = 2, "Mother only"
+    DAUGHTER_ONLY = 3, "Daughter only"
     NONE = 4, "N/A"
 
 
-def get_cen_dot_category_label(value: int | None) -> str:
-    """Return the user-facing label for a stored CEN dot category code."""
+def get_cen_dot_category_label(value: int | None, *, schema_version: int | None = None) -> str:
+    """Return the user-facing label for a stored CEN dot category code.
+
+    Schema-aware: rows that predate ``CEN_DOT_SCHEMA_VERSION`` and still carry
+    a non-default CEN value no longer carry a valid mother/daughter meaning, so
+    they surface a rerun-required label instead of being reinterpreted.
+    """
     labels = dict(CategoryCENDot.choices)
     if isinstance(value, str):
         if value in labels.values():
@@ -193,6 +202,20 @@ def get_cen_dot_category_label(value: int | None) -> str:
         category_value = int(value)
     except (TypeError, ValueError):
         return CategoryCENDot.NONE.label
+
+    try:
+        resolved_schema = int(schema_version) if schema_version is not None else None
+    except (TypeError, ValueError):
+        resolved_schema = None
+
+    if resolved_schema is None or resolved_schema < CEN_DOT_SCHEMA_VERSION:
+        if category_value in (
+            CategoryCENDot.MOTHER_AND_DAUGHTER.value,
+            CategoryCENDot.MOTHER_ONLY.value,
+            CategoryCENDot.DAUGHTER_ONLY.value,
+        ):
+            return CEN_DOT_LEGACY_RERUN_LABEL
+
     return labels.get(category_value, CategoryCENDot.NONE.label)
 
 

--- a/cytocv/core/services/analysis_progress_contract.py
+++ b/cytocv/core/services/analysis_progress_contract.py
@@ -8,7 +8,7 @@ PROGRESS_PHASE_IDLE = "Idle"
 PROGRESS_PHASE_QUEUED = "Queued"
 PROGRESS_PHASE_PREPROCESSING = "Preprocessing Images"
 PROGRESS_PHASE_DETECTING = "Detecting Cells"
-PROGRESS_PHASE_SEGMENTING = "Segmenting Images"
+PROGRESS_PHASE_SEGMENTING = "Segmenting Cell-Pairs"
 PROGRESS_PHASE_STATISTICS = "Calculating Statistics"
 PROGRESS_PHASE_CANCELLING = "Cancelling"
 PROGRESS_PHASE_CANCELLED = "Cancelled"
@@ -78,6 +78,8 @@ _PHASE_ALIASES = {
     "preprocessing images": PROGRESS_PHASE_PREPROCESSING,
     "detecting cells": PROGRESS_PHASE_DETECTING,
     "segmenting images": PROGRESS_PHASE_SEGMENTING,
+    "segmenting cell-pairs": PROGRESS_PHASE_SEGMENTING,
+    "segmenting cell pairs": PROGRESS_PHASE_SEGMENTING,
     "calculating statistics": PROGRESS_PHASE_STATISTICS,
     "cancelling": PROGRESS_PHASE_CANCELLING,
     "canceling": PROGRESS_PHASE_CANCELLING,
@@ -96,6 +98,8 @@ _STATUS_ALIASES = {
     "preprocessing images": PROGRESS_STATUS_RUNNING,
     "detecting cells": PROGRESS_STATUS_RUNNING,
     "segmenting images": PROGRESS_STATUS_RUNNING,
+    "segmenting cell-pairs": PROGRESS_STATUS_RUNNING,
+    "segmenting cell pairs": PROGRESS_STATUS_RUNNING,
     "calculating statistics": PROGRESS_STATUS_RUNNING,
     "cancelling": PROGRESS_STATUS_CANCELLING,
     "canceling": PROGRESS_STATUS_CANCELLING,

--- a/cytocv/core/services/canonical_contours.py
+++ b/cytocv/core/services/canonical_contours.py
@@ -10,7 +10,12 @@ from typing import Iterable, Optional
 import cv2
 import numpy as np
 
-from core.services.neck_split import NeckSplit, read_neck_split, sidecar_path
+from core.services.neck_split import (
+    NeckSplit,
+    load_neck_split_from_manifest,
+    read_neck_split,
+    sidecar_path,
+)
 
 
 CELL_MASK_KEY = "cell_mask"
@@ -77,6 +82,9 @@ def load_cell_mask(image_name: str, cell_id: int, output_dir: str, shape: tuple[
 def load_neck_split(image_name: str, cell_id: int, output_dir: str) -> Optional[NeckSplit]:
     """Return the persisted neck-split for a pair, or ``None`` when absent."""
 
+    split = load_neck_split_from_manifest(output_dir, image_name, cell_id)
+    if split is not None:
+        return split
     return read_neck_split(sidecar_path(output_dir, image_name, cell_id))
 
 

--- a/cytocv/core/services/canonical_contours.py
+++ b/cytocv/core/services/canonical_contours.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from core.services.neck_split import (
     NeckSplit,
+    compute_side_areas,
     load_neck_split_from_manifest,
     read_neck_split,
     sidecar_path,
@@ -23,6 +24,8 @@ CANONICAL_RED_SLOTS_KEY = "canonical_red_slots"
 CANONICAL_GREEN_SLOTS_KEY = "canonical_green_slots"
 CANONICAL_BLUE_SLOTS_KEY = "canonical_blue_slots"
 NECK_SPLIT_KEY = "neck_split"
+MOTHER_MASK_KEY = "mother_mask"
+DAUGHTER_MASK_KEY = "daughter_mask"
 
 
 @dataclass(slots=True)
@@ -179,6 +182,27 @@ def _select_raw_blue_contours(contours_data: dict, shape: tuple[int, int]) -> li
     return []
 
 
+def _derive_side_masks(
+    cell_mask: np.ndarray,
+    split: Optional[NeckSplit],
+) -> tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+    """Return (mother_mask, daughter_mask) from the DIC pair mask and neck split.
+
+    Mother is the larger side, daughter the smaller side. Returns ``(None, None)``
+    when no split is available or the chord does not cleanly separate the mask.
+    """
+
+    if split is None or cell_mask is None or not np.any(cell_mask):
+        return None, None
+    try:
+        _, smaller_px, larger_mask, smaller_mask = compute_side_areas(cell_mask, split)
+    except ValueError:
+        return None, None
+    if smaller_px <= 0:
+        return None, None
+    return larger_mask, smaller_mask
+
+
 def build_canonical_contour_payload(
     contours_data: dict,
     *,
@@ -194,6 +218,11 @@ def build_canonical_contour_payload(
     payload = dict(contours_data or {})
     cell_mask = load_cell_mask(image_name, cell_id, output_dir, height_width)
     payload[CELL_MASK_KEY] = cell_mask
+    neck_split = load_neck_split(image_name, cell_id, output_dir)
+    payload[NECK_SPLIT_KEY] = neck_split
+    mother_mask, daughter_mask = _derive_side_masks(cell_mask, neck_split)
+    payload[MOTHER_MASK_KEY] = mother_mask
+    payload[DAUGHTER_MASK_KEY] = daughter_mask
     payload[CANONICAL_RED_SLOTS_KEY] = build_canonical_contour_slots(
         payload.get("dot_contours", []),
         cell_mask,
@@ -279,6 +308,27 @@ def get_canonical_blue_slots(
         shape,
         limit=limit,
     )
+
+
+def get_side_masks(
+    contours_data: dict,
+) -> tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+    """Return the (mother_mask, daughter_mask) pair stored on the payload."""
+
+    mother = contours_data.get(MOTHER_MASK_KEY)
+    daughter = contours_data.get(DAUGHTER_MASK_KEY)
+    if not isinstance(mother, np.ndarray):
+        mother = None
+    if not isinstance(daughter, np.ndarray):
+        daughter = None
+    return mother, daughter
+
+
+def get_neck_split(contours_data: dict) -> Optional[NeckSplit]:
+    """Return the persisted neck split attached to the payload, if any."""
+
+    split = contours_data.get(NECK_SPLIT_KEY)
+    return split if isinstance(split, NeckSplit) else None
 
 
 def flatten_slot_contours(slots: Iterable[CanonicalContourSlot]) -> list[np.ndarray]:

--- a/cytocv/core/services/canonical_contours.py
+++ b/cytocv/core/services/canonical_contours.py
@@ -5,16 +5,19 @@ from __future__ import annotations
 import csv
 import os
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, Optional
 
 import cv2
 import numpy as np
+
+from core.services.neck_split import NeckSplit, read_neck_split, sidecar_path
 
 
 CELL_MASK_KEY = "cell_mask"
 CANONICAL_RED_SLOTS_KEY = "canonical_red_slots"
 CANONICAL_GREEN_SLOTS_KEY = "canonical_green_slots"
 CANONICAL_BLUE_SLOTS_KEY = "canonical_blue_slots"
+NECK_SPLIT_KEY = "neck_split"
 
 
 @dataclass(slots=True)
@@ -69,6 +72,12 @@ def load_cell_mask(image_name: str, cell_id: int, output_dir: str, shape: tuple[
         contour = np.asarray(points, dtype=np.int32).reshape(-1, 1, 2)
         cv2.drawContours(mask, [contour], -1, 255, thickness=-1)
     return mask
+
+
+def load_neck_split(image_name: str, cell_id: int, output_dir: str) -> Optional[NeckSplit]:
+    """Return the persisted neck-split for a pair, or ``None`` when absent."""
+
+    return read_neck_split(sidecar_path(output_dir, image_name, cell_id))
 
 
 def _shape_tuple(shape: tuple[int, ...] | Iterable[int]) -> tuple[int, int]:

--- a/cytocv/core/services/cell_statistics_payload.py
+++ b/cytocv/core/services/cell_statistics_payload.py
@@ -123,7 +123,12 @@ def serialize_cell_statistics_payload(
             properties.get("nuclear_cellular_status", "unknown"),
         ),
         "category_cen_dot": cell_stat.category_cen_dot,
-        "category_cen_dot_label": get_cen_dot_category_label(cell_stat.category_cen_dot),
+        "category_cen_dot_label": get_cen_dot_category_label(
+            cell_stat.category_cen_dot,
+            schema_version=properties.get("cen_dot_schema_version"),
+        ),
+        "cen_dot_schema_version": properties.get("cen_dot_schema_version"),
+        "cen_dot_location": properties.get("cen_dot_location"),
         "biorientation": cell_stat.biorientation,
         **build_measurement_contour_ratio_payload(
             cell_stat,

--- a/cytocv/core/services/neck_split.py
+++ b/cytocv/core/services/neck_split.py
@@ -1,12 +1,9 @@
-"""Detect and persist the internal neck-split line of a connected cell pair.
-
-Phase 1 scope: pure geometry, sidecar persistence, and non-destructive area
-computation.
-"""
+"""Detect and persist the internal neck-split line of a connected cell pair."""
 
 from __future__ import annotations
 
 import csv
+import json
 import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -15,7 +12,7 @@ from typing import Optional
 import cv2
 import numpy as np
 
-from core.artifact_constants import NECK_SPLIT_SUFFIX
+from core.artifact_constants import NECK_SPLIT_SUFFIX, PAIR_GEOMETRY_FILENAME
 
 
 # `cv2.convexityDefects` returns depth in fixed-point units where 256 == 1 px.
@@ -45,6 +42,8 @@ SIDECAR_HEADER = (
     "defect_depth_1",
     "defect_depth_2",
 )
+
+PAIR_GEOMETRY_SCHEMA_VERSION = 1
 
 
 @dataclass(slots=True)
@@ -221,6 +220,12 @@ def sidecar_path(output_dir: str | os.PathLike, image_name: str, cell_id: int) -
     return Path(output_dir) / "output" / f"{stem}-{int(cell_id)}{NECK_SPLIT_SUFFIX}"
 
 
+def manifest_path(output_dir: str | os.PathLike) -> Path:
+    """Path to the run-level pair geometry manifest."""
+
+    return Path(output_dir) / "output" / PAIR_GEOMETRY_FILENAME
+
+
 def write_neck_split(path: str | os.PathLike, split: NeckSplit) -> None:
     """Persist a ``NeckSplit`` as a one-row CSV with a header."""
 
@@ -278,3 +283,73 @@ def read_neck_split(path: str | os.PathLike) -> Optional[NeckSplit]:
         defect_depth_1=depth_1,
         defect_depth_2=depth_2,
     )
+
+
+def write_neck_split_manifest(
+    path: str | os.PathLike,
+    *,
+    image_name: str,
+    pairs: dict[int | str, dict],
+) -> None:
+    """Persist all pair geometry metadata for one run as a JSON manifest."""
+
+    normalized_pairs = {
+        str(cell_id): dict(payload or {})
+        for cell_id, payload in sorted(
+            pairs.items(),
+            key=lambda item: int(item[0]),
+        )
+    }
+    payload = {
+        "schema_version": PAIR_GEOMETRY_SCHEMA_VERSION,
+        "image_name": str(image_name),
+        "pairs": normalized_pairs,
+    }
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def read_neck_split_manifest(path: str | os.PathLike) -> Optional[dict]:
+    """Read a pair geometry manifest. Missing or malformed files return ``None``."""
+
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def load_neck_split_from_manifest(
+    output_dir: str | os.PathLike,
+    image_name: str,
+    cell_id: int,
+) -> Optional[NeckSplit]:
+    """Load one neck split from the run-level manifest, if present."""
+
+    payload = read_neck_split_manifest(manifest_path(output_dir))
+    if not payload:
+        return None
+    manifest_image_name = str(payload.get("image_name", "") or "")
+    if manifest_image_name and manifest_image_name != str(image_name):
+        return None
+    pairs = payload.get("pairs", {})
+    if not isinstance(pairs, dict):
+        return None
+    entry = pairs.get(str(int(cell_id)))
+    if not isinstance(entry, dict):
+        return None
+    status = str(entry.get("status", "") or "")
+    if status != STATUS_OK:
+        return None
+    try:
+        return NeckSplit.from_dict(entry)
+    except (KeyError, TypeError, ValueError):
+        return None

--- a/cytocv/core/services/neck_split.py
+++ b/cytocv/core/services/neck_split.py
@@ -1,0 +1,280 @@
+"""Detect and persist the internal neck-split line of a connected cell pair.
+
+Phase 1 scope: pure geometry, sidecar persistence, and non-destructive area
+computation.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+import cv2
+import numpy as np
+
+from core.artifact_constants import NECK_SPLIT_SUFFIX
+
+
+# `cv2.convexityDefects` returns depth in fixed-point units where 256 == 1 px.
+DEFECT_DEPTH_FIXED_POINT = 256
+
+# Default minimum defect depth to accept (in fixed-point units). ~1 px of
+# inward concavity. Looser than a tuned value but rejects contour noise.
+DEFAULT_MIN_DEFECT_DEPTH = DEFECT_DEPTH_FIXED_POINT
+
+# Search the top-N deepest defects for a valid cross-lobe chord.
+MAX_DEFECT_CANDIDATES = 6
+
+# Number of evenly-spaced samples along the chord used to verify it lies
+# inside the pair mask.
+CHORD_SAMPLE_COUNT = 20
+
+STATUS_OK = "ok"
+STATUS_NO_NECK = "no_neck"
+STATUS_MULTI_COMPONENT = "multi_component"
+
+SIDECAR_HEADER = (
+    "status",
+    "x1",
+    "y1",
+    "x2",
+    "y2",
+    "defect_depth_1",
+    "defect_depth_2",
+)
+
+
+@dataclass(slots=True)
+class NeckSplit:
+    """Two absolute-frame endpoints of the internal neck chord."""
+
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+    status: str = STATUS_OK
+    defect_depth_1: int = 0
+    defect_depth_2: int = 0
+
+    @property
+    def endpoints(self) -> tuple[tuple[int, int], tuple[int, int]]:
+        return (self.x1, self.y1), (self.x2, self.y2)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "NeckSplit":
+        return cls(
+            x1=int(data["x1"]),
+            y1=int(data["y1"]),
+            x2=int(data["x2"]),
+            y2=int(data["y2"]),
+            status=str(data.get("status", STATUS_OK)),
+            defect_depth_1=int(data.get("defect_depth_1", 0)),
+            defect_depth_2=int(data.get("defect_depth_2", 0)),
+        )
+
+
+def _chord_inside_mask(p1: tuple[int, int], p2: tuple[int, int], mask: np.ndarray) -> bool:
+    """Sample the chord and require every interior sample to land on mask."""
+
+    h, w = mask.shape[:2]
+    xs = np.linspace(p1[0], p2[0], CHORD_SAMPLE_COUNT)
+    ys = np.linspace(p1[1], p2[1], CHORD_SAMPLE_COUNT)
+    # Skip the two endpoints (which sit on the contour boundary, not interior).
+    for i in range(1, CHORD_SAMPLE_COUNT - 1):
+        x = int(round(xs[i]))
+        y = int(round(ys[i]))
+        if x < 0 or x >= w or y < 0 or y >= h:
+            return False
+        if not mask[y, x]:
+            return False
+    return True
+
+
+def _component_count(pair_mask: np.ndarray) -> int:
+    """Number of foreground components in a binary mask."""
+
+    binary = (pair_mask > 0).astype(np.uint8)
+    num, _ = cv2.connectedComponents(binary, connectivity=8)
+    return max(num - 1, 0)
+
+
+def detect_neck_split(
+    outer_contour: np.ndarray,
+    pair_mask: np.ndarray,
+    *,
+    min_defect_depth: int = DEFAULT_MIN_DEFECT_DEPTH,
+) -> Optional[NeckSplit]:
+    """Return the chord across the pair's neck, or ``None`` if one is not found.
+
+    Uses `cv2.convexityDefects` on the outer contour: the two deepest defect
+    `far` points on opposite sides of the neck form the natural split chord.
+    Returns ``None`` when the mask has no usable neck, letting callers
+    distinguish "write sidecar" from "skip".
+    """
+
+    if outer_contour is None or len(outer_contour) < 4:
+        return None
+    if pair_mask is None or pair_mask.size == 0:
+        return None
+    if _component_count(pair_mask) > 1:
+        return None
+
+    hull = cv2.convexHull(outer_contour, returnPoints=False)
+    if hull is None or len(hull) < 3:
+        return None
+
+    # `cv2.convexityDefects` requires hull indices to be in ascending order.
+    hull = np.sort(hull.flatten()).reshape(-1, 1)
+    try:
+        defects = cv2.convexityDefects(outer_contour, hull)
+    except cv2.error:
+        return None
+    if defects is None:
+        return None
+
+    candidates = [
+        (int(far_idx), int(depth))
+        for _start, _end, far_idx, depth in defects[:, 0]
+        if int(depth) >= int(min_defect_depth)
+    ]
+    candidates.sort(key=lambda row: row[1], reverse=True)
+    candidates = candidates[:MAX_DEFECT_CANDIDATES]
+
+    for i in range(len(candidates)):
+        for j in range(i + 1, len(candidates)):
+            far_i, depth_i = candidates[i]
+            far_j, depth_j = candidates[j]
+            p1 = tuple(int(v) for v in outer_contour[far_i][0])
+            p2 = tuple(int(v) for v in outer_contour[far_j][0])
+            if p1 == p2:
+                continue
+            if not _chord_inside_mask(p1, p2, pair_mask):
+                continue
+            return NeckSplit(
+                x1=p1[0],
+                y1=p1[1],
+                x2=p2[0],
+                y2=p2[1],
+                status=STATUS_OK,
+                defect_depth_1=depth_i,
+                defect_depth_2=depth_j,
+            )
+
+    return None
+
+
+def compute_side_areas(
+    pair_mask: np.ndarray,
+    split: NeckSplit,
+    *,
+    line_thickness: int = 2,
+) -> tuple[int, int, np.ndarray, np.ndarray]:
+    """Compute the two side areas without mutating ``pair_mask``.
+
+    Rasterizes a black chord onto a copy of the mask and runs
+    ``cv2.connectedComponents``. Returns ``(larger_px, smaller_px, larger_mask,
+    smaller_mask)`` with ``*_mask`` as ``uint8`` 0/255 arrays. If the chord
+    does not cleanly separate the mask into two components, returns the full
+    mask as ``larger_mask`` and an empty ``smaller_mask``.
+    """
+
+    if pair_mask is None or pair_mask.size == 0:
+        raise ValueError("pair_mask is empty")
+    working = pair_mask.copy()
+    cv2.line(
+        working,
+        (int(split.x1), int(split.y1)),
+        (int(split.x2), int(split.y2)),
+        0,
+        thickness=int(line_thickness),
+        lineType=cv2.LINE_8,
+    )
+    binary = (working > 0).astype(np.uint8)
+    num, labels = cv2.connectedComponents(binary, connectivity=8)
+    regions: list[tuple[int, np.ndarray]] = []
+    for label in range(1, num):
+        region = (labels == label).astype(np.uint8) * 255
+        regions.append((int(np.count_nonzero(region)), region))
+    regions.sort(key=lambda row: row[0], reverse=True)
+    if not regions:
+        empty = np.zeros_like(pair_mask, dtype=np.uint8)
+        return 0, 0, empty, empty.copy()
+    if len(regions) == 1:
+        larger_px, larger_mask = regions[0]
+        empty = np.zeros_like(pair_mask, dtype=np.uint8)
+        return larger_px, 0, larger_mask, empty
+    larger_px, larger_mask = regions[0]
+    smaller_px, smaller_mask = regions[1]
+    return larger_px, smaller_px, larger_mask, smaller_mask
+
+
+def sidecar_path(output_dir: str | os.PathLike, image_name: str, cell_id: int) -> Path:
+    """Path to the neck-split sidecar for a given pair."""
+
+    stem = os.path.splitext(str(image_name))[0]
+    return Path(output_dir) / "output" / f"{stem}-{int(cell_id)}{NECK_SPLIT_SUFFIX}"
+
+
+def write_neck_split(path: str | os.PathLike, split: NeckSplit) -> None:
+    """Persist a ``NeckSplit`` as a one-row CSV with a header."""
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle, lineterminator="\n")
+        writer.writerow(SIDECAR_HEADER)
+        writer.writerow(
+            [
+                split.status,
+                int(split.x1),
+                int(split.y1),
+                int(split.x2),
+                int(split.y2),
+                int(split.defect_depth_1),
+                int(split.defect_depth_2),
+            ]
+        )
+
+
+def read_neck_split(path: str | os.PathLike) -> Optional[NeckSplit]:
+    """Read a sidecar. Missing file returns ``None``; malformed rows return ``None``."""
+
+    try:
+        with open(path, "r", encoding="utf-8", newline="") as handle:
+            reader = csv.reader(handle)
+            rows = [row for row in reader if row]
+    except FileNotFoundError:
+        return None
+    if not rows:
+        return None
+    data_rows = rows[1:] if rows[0] and rows[0][0] == SIDECAR_HEADER[0] else rows
+    if not data_rows:
+        return None
+    row = data_rows[0]
+    if len(row) < 5:
+        return None
+    try:
+        status = str(row[0])
+        x1 = int(row[1])
+        y1 = int(row[2])
+        x2 = int(row[3])
+        y2 = int(row[4])
+        depth_1 = int(row[5]) if len(row) > 5 else 0
+        depth_2 = int(row[6]) if len(row) > 6 else 0
+    except (TypeError, ValueError):
+        return None
+    return NeckSplit(
+        x1=x1,
+        y1=y1,
+        x2=x2,
+        y2=y2,
+        status=status,
+        defect_depth_1=depth_1,
+        defect_depth_2=depth_2,
+    )

--- a/cytocv/core/services/overlay_rendering.py
+++ b/cytocv/core/services/overlay_rendering.py
@@ -34,7 +34,7 @@ from core.stats_plugins import build_stats_execution_plan
 
 logger = logging.getLogger(__name__)
 
-OVERLAY_RENDER_SCHEMA_VERSION = 1
+OVERLAY_RENDER_SCHEMA_VERSION = 2
 OVERLAY_RENDER_CONFIG_FILENAME = "overlay-render-config.json"
 OVERLAY_CACHE_DIRNAME = f"overlay-cache-v{OVERLAY_RENDER_SCHEMA_VERSION}"
 OVERLAY_CHANNEL_LABELS = {

--- a/cytocv/core/services/segmentation_pipeline.py
+++ b/cytocv/core/services/segmentation_pipeline.py
@@ -55,8 +55,8 @@ from core.services.neck_split import (
     NeckSplit,
     compute_side_areas,
     detect_neck_split,
-    sidecar_path as neck_split_sidecar_path,
-    write_neck_split,
+    manifest_path as neck_split_manifest_path,
+    write_neck_split_manifest,
 )
 from core.services.pair_refinement import refine_pair_label_image
 from core.services.overlay_rendering import (
@@ -268,6 +268,36 @@ def _build_neck_split_properties(entry: PairGeometryCacheEntry | None) -> dict:
         "side_area_large_px": int(entry.side_area_large_px),
         "side_area_small_px": int(entry.side_area_small_px),
     }
+
+
+def _build_neck_split_manifest_pairs(
+    pair_geometry_cache: dict[int, PairGeometryCacheEntry],
+) -> dict[int, dict]:
+    """Build the persisted neck-split payload map for one run."""
+
+    return {
+        int(cell_id): _build_neck_split_properties(entry)
+        for cell_id, entry in sorted(pair_geometry_cache.items())
+    }
+
+
+def _write_neck_split_manifest_for_run(
+    output_dir: str | os.PathLike,
+    *,
+    image_name: str,
+    pair_geometry_cache: dict[int, PairGeometryCacheEntry],
+    use_cache: bool,
+) -> Path:
+    """Persist one run-level pair geometry manifest for all neck splits."""
+
+    path = neck_split_manifest_path(output_dir)
+    if not path.exists() or not use_cache:
+        write_neck_split_manifest(
+            path,
+            image_name=image_name,
+            pairs=_build_neck_split_manifest_pairs(pair_geometry_cache),
+        )
+    return path
 
 
 def _finalize_segmented_run_batch_for_user(
@@ -514,6 +544,12 @@ def run_segmentation_batch(
             seg_image.save(str(outputdirectory) + "\\cellpairs.tif")
 
         pair_geometry_cache = _build_pair_geometry_cache(seg)
+        _write_neck_split_manifest_for_run(
+            os.path.join(str(settings.MEDIA_ROOT), str(uuid)),
+            image_name=f"{dv_name}.dv",
+            pair_geometry_cache=pair_geometry_cache,
+            use_cache=use_cache,
+        )
 
         for frame_idx in range(image_stack.shape[0]):
             _raise_if_cancelled(progress)
@@ -599,7 +635,6 @@ def run_segmentation_batch(
                 max_x = entry.max_x
                 min_y = entry.min_y
                 max_y = entry.max_y
-                local_split = entry.local_split
 
                 outline_path = Path(f"{outputdirectory}{dv_name}-{i}.outline")
                 if not outline_path.exists() or not use_cache:
@@ -610,15 +645,6 @@ def run_segmentation_batch(
                                 csvwriter.writerow([])
                             for point in contour.reshape(-1, 2):
                                 csvwriter.writerow([int(point[1]), int(point[0])])
-
-                if local_split is not None:
-                    neck_split_path = neck_split_sidecar_path(
-                        os.path.join(str(settings.MEDIA_ROOT), str(uuid)),
-                        f"{dv_name}.dv",
-                        i,
-                    )
-                    if not neck_split_path.exists() or not use_cache:
-                        write_neck_split(neck_split_path, local_split)
 
                 cellpair_image = image_outlined[min_x:max_x, min_y:max_y]
                 not_outlined_image = image[min_x:max_x, min_y:max_y]

--- a/cytocv/core/services/segmentation_pipeline.py
+++ b/cytocv/core/services/segmentation_pipeline.py
@@ -16,7 +16,7 @@ import matplotlib.patheffects as PathEffects
 import matplotlib.pyplot as plt
 import numpy as np
 import skimage
-from PIL import Image
+from PIL import Image, ImageDraw, ImageFont
 from cv2_rolling_ball import subtract_background_rolling_ball
 from django.conf import settings
 from django.db import transaction
@@ -80,6 +80,21 @@ from core.views.segment_image import (
 logger = logging.getLogger(__name__)
 CYAN_DEBUG_COLOR = (0, 255, 255)
 PAIR_CROP_MARGIN_PX = 4
+_PARENTAGE_FONT_CANDIDATES = (
+    "C:/Windows/Fonts/segoeui.ttf",
+    "C:/Windows/Fonts/arial.ttf",
+    "DejaVuSans.ttf",
+    "Segoe UI.ttf",
+    "segoeui.ttf",
+    "Arial.ttf",
+    "arial.ttf",
+    "SegoeUI.ttf",
+    "C:/Windows/Fonts/segoeuib.ttf",
+    "C:/Windows/Fonts/arialbd.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "DejaVuSans-Bold.ttf",
+)
 
 
 def _process_config_value(
@@ -113,6 +128,8 @@ class PairGeometryCacheEntry:
     full_split: NeckSplit | None = None
     side_area_large_px: int = 0
     side_area_small_px: int = 0
+    mother_label_position: tuple[int, int] | None = None
+    daughter_label_position: tuple[int, int] | None = None
 
 
 def _current_owner_filter_for_user(user) -> dict[str, object]:
@@ -164,6 +181,97 @@ def _crop_bounds_for_label_mask(
     return min_x, max_x, min_y, max_y
 
 
+def _mask_centroid(mask: np.ndarray) -> tuple[int, int] | None:
+    """Return the integer x,y centroid of a binary mask."""
+
+    binary = (mask > 0).astype(np.uint8)
+    if not np.any(binary):
+        return None
+    moments = cv2.moments(binary, binaryImage=True)
+    if moments["m00"] != 0:
+        x = int(round(moments["m10"] / moments["m00"]))
+        y = int(round(moments["m01"] / moments["m00"]))
+        return x, y
+    points = np.column_stack(np.nonzero(binary))
+    if points.size == 0:
+        return None
+    return int(round(float(np.mean(points[:, 1])))), int(round(float(np.mean(points[:, 0]))))
+
+
+def _draw_centered_label(
+    image: np.ndarray,
+    label: str,
+    center: tuple[int, int] | None,
+    *,
+    text_color: tuple[int, int, int] = (255, 255, 255),
+    stroke_color: tuple[int, int, int] = (0, 0, 0),
+    font_size: int = 10,
+    stroke_width: int = 1,
+) -> None:
+    """Draw centered debug text with a smooth stroked font for DIC readability."""
+
+    if image is None or center is None:
+        return
+    height, width = image.shape[:2]
+    if height <= 0 or width <= 0:
+        return
+    pil_image = Image.fromarray(image)
+    draw = ImageDraw.Draw(pil_image)
+    resolved_font_size = max(int(font_size), 8)
+    font = None
+    for candidate in _PARENTAGE_FONT_CANDIDATES:
+        try:
+            font = ImageFont.truetype(candidate, resolved_font_size)
+            break
+        except OSError:
+            continue
+    if font is None:
+        font = ImageFont.load_default()
+    x0, y0, x1, y1 = draw.textbbox((0, 0), label, font=font, stroke_width=int(stroke_width))
+    text_width = x1 - x0
+    text_height = y1 - y0
+    x = int(round(center[0] - (text_width / 2.0) - x0))
+    y = int(round(center[1] - (text_height / 2.0) - y0))
+    x = max(0, min(x, max(width - text_width, 0)))
+    y = max(0, min(y, max(height - text_height, 0)))
+    draw.text(
+        (x, y),
+        label,
+        font=font,
+        fill=text_color,
+        stroke_width=int(stroke_width),
+        stroke_fill=stroke_color,
+    )
+    np.copyto(image, np.asarray(pil_image))
+
+
+def _draw_pair_parentage_labels(
+    image: np.ndarray,
+    entry: PairGeometryCacheEntry,
+) -> None:
+    """Draw inferred mother/daughter labels on one DIC crop only."""
+
+    if entry.local_split is None:
+        return
+    label_font_size = max(7, min(image.shape[:2]) // 8)
+    _draw_centered_label(
+        image,
+        "M",
+        entry.mother_label_position,
+        font_size=label_font_size,
+        text_color=(255, 255, 255),
+        stroke_color=(0, 0, 0),
+    )
+    _draw_centered_label(
+        image,
+        "D",
+        entry.daughter_label_position,
+        font_size=label_font_size,
+        text_color=(255, 255, 255),
+        stroke_color=(0, 0, 0),
+    )
+
+
 def _build_pair_geometry_cache(seg: np.ndarray) -> dict[int, PairGeometryCacheEntry]:
     """Build one shared geometry cache per pair label from the finalized mask."""
 
@@ -191,6 +299,8 @@ def _build_pair_geometry_cache(seg: np.ndarray) -> dict[int, PairGeometryCacheEn
         full_split = None
         side_area_large_px = 0
         side_area_small_px = 0
+        mother_label_position = None
+        daughter_label_position = None
         if local_contours:
             primary_contour = max(local_contours, key=len)
             try:
@@ -209,10 +319,17 @@ def _build_pair_geometry_cache(seg: np.ndarray) -> dict[int, PairGeometryCacheEn
                     col_offset=min_y,
                 )
                 try:
-                    side_area_large_px, side_area_small_px, _, _ = compute_side_areas(
+                    (
+                        side_area_large_px,
+                        side_area_small_px,
+                        mother_mask,
+                        daughter_mask,
+                    ) = compute_side_areas(
                         local_mask,
                         local_split,
                     )
+                    mother_label_position = _mask_centroid(mother_mask)
+                    daughter_label_position = _mask_centroid(daughter_mask)
                 except Exception:
                     logger.debug(
                         "Neck-split side-area computation failed for cell %s",
@@ -233,6 +350,8 @@ def _build_pair_geometry_cache(seg: np.ndarray) -> dict[int, PairGeometryCacheEn
             full_split=full_split,
             side_area_large_px=int(side_area_large_px),
             side_area_small_px=int(side_area_small_px),
+            mother_label_position=mother_label_position,
+            daughter_label_position=daughter_label_position,
         )
     return cache
 
@@ -648,6 +767,8 @@ def run_segmentation_batch(
 
                 cellpair_image = image_outlined[min_x:max_x, min_y:max_y]
                 not_outlined_image = image[min_x:max_x, min_y:max_y]
+                if cached_channel_name == CHANNEL_ROLE_DIC:
+                    _draw_pair_parentage_labels(cellpair_image, entry)
                 if cached_channel_name:
                     cell_image_cache[i][cached_channel_name] = np.array(
                         not_outlined_image,

--- a/cytocv/core/services/segmentation_pipeline.py
+++ b/cytocv/core/services/segmentation_pipeline.py
@@ -478,7 +478,7 @@ def run_segmentation_batch(
     choice_var = "Metaphase Arrested"
     start_time = time.time()
 
-    progress.set_phase("Segmenting Images", status="running")
+    progress.set_phase("Segmenting Cell-Pairs", status="running")
 
     for uuid in uuid_list:
         _raise_if_cancelled(progress)

--- a/cytocv/core/services/segmentation_pipeline.py
+++ b/cytocv/core/services/segmentation_pipeline.py
@@ -30,6 +30,7 @@ from core.channel_roles import (
 )
 from core.config import DEFAULT_CHANNEL_CONFIG, DEFAULT_PROCESS_CONFIG, input_dir
 from core.contour_processing import get_contour_center, get_neighbor_count
+from core.image_processing.dashed_line import draw_dashed_line
 from core.models import CellStatistics, SegmentedImage, UploadedImage, get_guest_user
 from core.scale import (
     convert_length_to_pixels,
@@ -49,6 +50,13 @@ from core.services.artifact_storage import (
     log_storage_capacity_failure,
     refresh_user_storage_usage,
     save_png_array,
+)
+from core.services.neck_split import (
+    NeckSplit,
+    compute_side_areas,
+    detect_neck_split,
+    sidecar_path as neck_split_sidecar_path,
+    write_neck_split,
 )
 from core.services.pair_refinement import refine_pair_label_image
 from core.services.overlay_rendering import (
@@ -70,6 +78,8 @@ from core.views.segment_image import (
 )
 
 logger = logging.getLogger(__name__)
+CYAN_DEBUG_COLOR = (0, 255, 255)
+PAIR_CROP_MARGIN_PX = 4
 
 
 def _process_config_value(
@@ -88,6 +98,23 @@ class SegmentationBatchResult:
     storage_warning_message: str = ""
 
 
+@dataclass(frozen=True, slots=True)
+class PairGeometryCacheEntry:
+    """Cached pair geometry reused across frame render, crop, and stats phases."""
+
+    cell_id: int
+    full_contours: tuple[np.ndarray, ...]
+    local_contours: tuple[np.ndarray, ...]
+    min_x: int
+    max_x: int
+    min_y: int
+    max_y: int
+    local_split: NeckSplit | None = None
+    full_split: NeckSplit | None = None
+    side_area_large_px: int = 0
+    side_area_small_px: int = 0
+
+
 def _current_owner_filter_for_user(user) -> dict[str, object]:
     if getattr(user, "is_authenticated", False):
         return {"user": user}
@@ -97,6 +124,150 @@ def _current_owner_filter_for_user(user) -> dict[str, object]:
 def _raise_if_cancelled(progress: AnalysisProgressHandle) -> None:
     if progress.is_cancel_requested():
         raise AnalysisCancelled()
+
+
+def _offset_neck_split(
+    split: NeckSplit | None,
+    *,
+    row_offset: int,
+    col_offset: int,
+) -> NeckSplit | None:
+    """Return a shifted copy of a split, or ``None`` when absent."""
+
+    if split is None:
+        return None
+    return NeckSplit(
+        x1=int(split.x1) + int(col_offset),
+        y1=int(split.y1) + int(row_offset),
+        x2=int(split.x2) + int(col_offset),
+        y2=int(split.y2) + int(row_offset),
+        status=split.status,
+        defect_depth_1=int(split.defect_depth_1),
+        defect_depth_2=int(split.defect_depth_2),
+    )
+
+
+def _crop_bounds_for_label_mask(
+    label_mask: np.ndarray,
+    *,
+    margin_px: int = PAIR_CROP_MARGIN_PX,
+) -> tuple[int, int, int, int] | None:
+    """Return symmetric crop bounds for a single pair mask."""
+
+    points = np.where(label_mask > 0)
+    if points[0].size == 0:
+        return None
+    min_x = max(int(np.min(points[0])) - int(margin_px), 0)
+    max_x = min(int(np.max(points[0])) + int(margin_px) + 1, label_mask.shape[0])
+    min_y = max(int(np.min(points[1])) - int(margin_px), 0)
+    max_y = min(int(np.max(points[1])) + int(margin_px) + 1, label_mask.shape[1])
+    return min_x, max_x, min_y, max_y
+
+
+def _build_pair_geometry_cache(seg: np.ndarray) -> dict[int, PairGeometryCacheEntry]:
+    """Build one shared geometry cache per pair label from the finalized mask."""
+
+    cache: dict[int, PairGeometryCacheEntry] = {}
+    for cell_id in range(1, int(np.max(seg) + 1)):
+        cell_mask_full = ((seg == cell_id).astype(np.uint8)) * 255
+        if not np.any(cell_mask_full):
+            continue
+        bounds = _crop_bounds_for_label_mask(cell_mask_full)
+        if bounds is None:
+            continue
+        min_x, max_x, min_y, max_y = bounds
+        full_contours, _ = cv2.findContours(
+            cell_mask_full,
+            cv2.RETR_EXTERNAL,
+            cv2.CHAIN_APPROX_NONE,
+        )
+        local_mask = cell_mask_full[min_x:max_x, min_y:max_y]
+        local_contours, _ = cv2.findContours(
+            local_mask,
+            cv2.RETR_EXTERNAL,
+            cv2.CHAIN_APPROX_NONE,
+        )
+        local_split = None
+        full_split = None
+        side_area_large_px = 0
+        side_area_small_px = 0
+        if local_contours:
+            primary_contour = max(local_contours, key=len)
+            try:
+                local_split = detect_neck_split(primary_contour, local_mask)
+            except Exception:
+                logger.debug(
+                    "Neck-split detection failed for cell %s",
+                    cell_id,
+                    exc_info=True,
+                )
+                local_split = None
+            if local_split is not None:
+                full_split = _offset_neck_split(
+                    local_split,
+                    row_offset=min_x,
+                    col_offset=min_y,
+                )
+                try:
+                    side_area_large_px, side_area_small_px, _, _ = compute_side_areas(
+                        local_mask,
+                        local_split,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Neck-split side-area computation failed for cell %s",
+                        cell_id,
+                        exc_info=True,
+                    )
+                    side_area_large_px = 0
+                    side_area_small_px = 0
+        cache[cell_id] = PairGeometryCacheEntry(
+            cell_id=cell_id,
+            full_contours=tuple(full_contours),
+            local_contours=tuple(local_contours),
+            min_x=min_x,
+            max_x=max_x,
+            min_y=min_y,
+            max_y=max_y,
+            local_split=local_split,
+            full_split=full_split,
+            side_area_large_px=int(side_area_large_px),
+            side_area_small_px=int(side_area_small_px),
+        )
+    return cache
+
+
+def _draw_pair_geometry_overlay(
+    image: np.ndarray,
+    pair_geometry_cache: dict[int, PairGeometryCacheEntry],
+) -> None:
+    """Draw the solid pair contour and dashed neck seam onto one frame."""
+
+    for entry in pair_geometry_cache.values():
+        if entry.full_contours:
+            cv2.drawContours(image, list(entry.full_contours), -1, CYAN_DEBUG_COLOR, 1)
+        if entry.full_split is not None:
+            draw_dashed_line(
+                image,
+                (entry.full_split.x1, entry.full_split.y1),
+                (entry.full_split.x2, entry.full_split.y2),
+                CYAN_DEBUG_COLOR,
+                dash_px=2,
+                gap_px=2,
+                thickness=1,
+            )
+
+
+def _build_neck_split_properties(entry: PairGeometryCacheEntry | None) -> dict:
+    """Return the persisted-style neutral neck-split payload for one pair."""
+
+    if entry is None or entry.local_split is None:
+        return {"status": "no_neck"}
+    return {
+        **entry.local_split.to_dict(),
+        "side_area_large_px": int(entry.side_area_large_px),
+        "side_area_small_px": int(entry.side_area_small_px),
+    }
 
 
 def _finalize_segmented_run_batch_for_user(
@@ -342,6 +513,8 @@ def run_segmentation_batch(
             seg_image = Image.fromarray(seg)
             seg_image.save(str(outputdirectory) + "\\cellpairs.tif")
 
+        pair_geometry_cache = _build_pair_geometry_cache(seg)
+
         for frame_idx in range(image_stack.shape[0]):
             _raise_if_cancelled(progress)
             image = Image.fromarray(image_stack[frame_idx])
@@ -352,13 +525,7 @@ def run_segmentation_batch(
                 image = np.tile(image, 3)
 
             image_outlined = image.copy()
-            for i in range(1, int(np.max(seg) + 1)):
-                cell_mask_full = (seg == i).astype(np.uint8) * 255
-                contours, _ = cv2.findContours(
-                    cell_mask_full, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE
-                )
-                if contours:
-                    cv2.drawContours(image_outlined, contours, -1, (0, 255, 255), 1)
+            _draw_pair_geometry_overlay(image_outlined, pair_geometry_cache)
 
             fig = plt.figure(frameon=False)
             ax = plt.Axes(fig, [0.0, 0.0, 1.0, 1.0])
@@ -417,42 +584,22 @@ def run_segmentation_batch(
 
             cached_channel_name = layer_channel_lookup.get(image_num)
             image_outlined = image.copy()
-            cell_contour_cache: dict[
-                int, tuple[tuple[np.ndarray, ...], int, int, int, int]
-            ] = {}
-            for i in range(1, int(np.max(seg) + 1)):
-                a = np.where(seg == i)
-                if a[0].size == 0:
-                    continue
-                min_x = max(int(np.min(a[0])) - 4, 0)
-                max_x = min(int(np.max(a[0])) + 4 + 1, seg.shape[0])
-                min_y = max(int(np.min(a[1])) - 4, 0)
-                max_y = min(int(np.max(a[1])) + 4 + 1, seg.shape[1])
-                local_mask = ((seg[min_x:max_x, min_y:max_y] == i).astype(np.uint8)) * 255
-                local_contours, _ = cv2.findContours(
-                    local_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE
-                )
-                cell_contour_cache[i] = (
-                    tuple(local_contours),
-                    min_x,
-                    max_x,
-                    min_y,
-                    max_y,
-                )
-                for contour in local_contours:
-                    shifted = contour.copy()
-                    shifted[:, :, 0] += min_y
-                    shifted[:, :, 1] += min_x
-                    cv2.drawContours(image_outlined, [shifted], -1, (0, 255, 255), 1)
+            if cached_channel_name == CHANNEL_ROLE_DIC:
+                _draw_pair_geometry_overlay(image_outlined, pair_geometry_cache)
 
             for i in range(1, int(np.max(seg) + 1)):
                 cell_tif_image = f"{dv_name}-{image_num}-{i}.png"
                 no_outline_image = f"{dv_name}-{image_num}-{i}-no_outline.png"
 
-                entry = cell_contour_cache.get(i)
+                entry = pair_geometry_cache.get(i)
                 if entry is None:
                     continue
-                local_contours, min_x, max_x, min_y, max_y = entry
+                local_contours = entry.local_contours
+                min_x = entry.min_x
+                max_x = entry.max_x
+                min_y = entry.min_y
+                max_y = entry.max_y
+                local_split = entry.local_split
 
                 outline_path = Path(f"{outputdirectory}{dv_name}-{i}.outline")
                 if not outline_path.exists() or not use_cache:
@@ -463,6 +610,15 @@ def run_segmentation_batch(
                                 csvwriter.writerow([])
                             for point in contour.reshape(-1, 2):
                                 csvwriter.writerow([int(point[1]), int(point[0])])
+
+                if local_split is not None:
+                    neck_split_path = neck_split_sidecar_path(
+                        os.path.join(str(settings.MEDIA_ROOT), str(uuid)),
+                        f"{dv_name}.dv",
+                        i,
+                    )
+                    if not neck_split_path.exists() or not use_cache:
+                        write_neck_split(neck_split_path, local_split)
 
                 cellpair_image = image_outlined[min_x:max_x, min_y:max_y]
                 not_outlined_image = image[min_x:max_x, min_y:max_y]
@@ -747,6 +903,10 @@ def run_segmentation_batch(
             cp.properties["stats_cen_dot_proximity_radius_px"] = cen_dot_proximity_radius_px_equivalent
             cp.properties["stats_cen_dot_proximity_radius_value"] = cen_dot_proximity_radius
             cp.properties["stats_cen_dot_proximity_radius_unit"] = cen_dot_proximity_radius_unit
+
+            cp.properties["neck_split"] = _build_neck_split_properties(
+                pair_geometry_cache.get(cell_number)
+            )
 
             debug_red, debug_green, debug_blue = get_stats(
                 cp,

--- a/cytocv/core/stats_plugins.py
+++ b/cytocv/core/stats_plugins.py
@@ -94,12 +94,16 @@ PLUGIN_DEFINITIONS: dict[str, StatsPluginDefinition] = {
     ),
     "CENDot": StatsPluginDefinition(
         plugin_id="CENDot",
-        label="CEN dot Classification",
+        label="CEN dot Location",
         description=(
-            "Classifies CEN-dot category and biorientation relative to paired red puncta. "
-            "Minimum signal distance sets the threshold between the two red signals for "
-            "category vs. biorientation mode. Signal proximity radius controls how close "
-            "a green signal must be to a red signal to count as co-localized."
+            "Classifies CEN-dot location as mother and/or daughter and evaluates "
+            "biorientation for close red pairs. Requires exactly two usable red puncta "
+            "on opposite sides of the DIC-derived neck split; green puncta only count "
+            "when they lie inside the DIC pair mask, on the same side as the red punctum "
+            "being tested, and within the signal proximity radius. When the red-to-red "
+            "distance meets the minimum threshold, mother/daughter location is reported; "
+            "below threshold, the biorientation calculation runs instead and the location "
+            "stays N/A. Legacy runs must be rerun to surface the new mother/daughter label."
         ),
         module_name="core.cell_analysis.cen_dot",
         class_name="CENDot",

--- a/cytocv/core/tables.py
+++ b/cytocv/core/tables.py
@@ -42,11 +42,16 @@ class NumberColumn(tables.Column):
 class ChoiceLabelColumn(tables.Column):
     """Render stored choice codes using their human-readable labels."""
 
-    def render(self, value: int) -> str:
-        return get_cen_dot_category_label(value)
+    @staticmethod
+    def _schema_version(record) -> int | None:
+        properties = getattr(record, "properties", {}) or {}
+        return properties.get("cen_dot_schema_version")
 
-    def value(self, value: int) -> str:
-        return self.render(value)
+    def render(self, value: int, record=None) -> str:
+        return get_cen_dot_category_label(value, schema_version=self._schema_version(record))
+
+    def value(self, value: int, record=None) -> str:
+        return self.render(value, record=record)
 
 
 class CellTable(tables.Table):
@@ -107,7 +112,7 @@ class CellTable(tables.Table):
     nucleus_intensity_sum = NumberColumn(verbose_name=FALLBACK_NUCLEAR_CELL_PAIR_LABELS[1])
     cytoplasmic_intensity = NumberColumn(verbose_name="Cytoplasmic Intensity")
 
-    category_cen_dot = ChoiceLabelColumn(verbose_name="CEN dot Category")
+    category_cen_dot = ChoiceLabelColumn(verbose_name="CEN dot Location")
     biorientation = tables.Column(verbose_name="Biorientation")
 
     class Meta:

--- a/cytocv/core/tests/test_accounts_preferences.py
+++ b/cytocv/core/tests/test_accounts_preferences.py
@@ -480,6 +480,7 @@ class DisplayManualSaveTests(TestCase):
             category_cen_dot=1,
             properties={
                 "nuclear_cell_pair_mode": "red_nucleus",
+                "cen_dot_schema_version": 2,
                 "puncta_distance_delta_x_px": 1.0,
                 "puncta_distance_delta_y_px": 0.0,
                 "distance_of_green_from_red_1_delta_x_px": 6.0,
@@ -724,8 +725,8 @@ class DisplayManualSaveTests(TestCase):
         self.assertIn("Measurement/Contour Ratio 1 (Green/Red)", csv_text)
         self.assertIn("5.000", csv_text)
         self.assertIn("8.000", csv_text)
-        self.assertIn("CEN dot Category", csv_text)
-        self.assertIn("One green dot with each red dot", csv_text)
+        self.assertIn("CEN dot Location", csv_text)
+        self.assertIn("Mother and daughter", csv_text)
 
     def test_dashboard_xlsx_export_for_file_uuid_returns_attachment(self):
         file_name = "dashboard_xlsx_export"
@@ -807,9 +808,9 @@ class DisplayManualSaveTests(TestCase):
         self.assertIn("Distance between Red Puncta (µm)", headers)
         self.assertIn("Blue Contour Size (µm²)", headers)
         self.assertIn("Distance of Green from Red 1 (µm)", headers)
-        self.assertIn("CEN dot Category", headers)
-        gfp_dot_col = headers.index("CEN dot Category") + 1
-        self.assertEqual(sheet.cell(row=2, column=gfp_dot_col).value, "One green dot with each red dot")
+        self.assertIn("CEN dot Location", headers)
+        gfp_dot_col = headers.index("CEN dot Location") + 1
+        self.assertEqual(sheet.cell(row=2, column=gfp_dot_col).value, "Mother and daughter")
 
     def test_display_csv_export_uses_uploaded_file_name(self):
         file_name = "display_csv_export_source"

--- a/cytocv/core/tests/test_canonical_contours.py
+++ b/cytocv/core/tests/test_canonical_contours.py
@@ -13,7 +13,9 @@ from core.services.canonical_contours import (
     build_canonical_contour_payload,
     build_canonical_contour_slots,
     get_canonical_blue_slots,
+    load_neck_split,
 )
+from core.services.neck_split import NeckSplit, sidecar_path, write_neck_split
 
 
 class CanonicalContourHelpersTests(SimpleTestCase):
@@ -159,3 +161,12 @@ class CanonicalContourHelpersTests(SimpleTestCase):
         slots = get_canonical_blue_slots(contours_data, shape)
 
         self.assertEqual(slots, [])
+
+    def test_load_neck_split_round_trips_sidecar(self):
+        expected = NeckSplit(x1=2, y1=3, x2=8, y2=9, defect_depth_1=512, defect_depth_2=384)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            write_neck_split(sidecar_path(temp_dir, "test.dv", 1), expected)
+            loaded = load_neck_split("test.dv", 1, temp_dir)
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.to_dict(), expected.to_dict())

--- a/cytocv/core/tests/test_canonical_contours.py
+++ b/cytocv/core/tests/test_canonical_contours.py
@@ -10,6 +10,9 @@ from core.services.canonical_contours import (
     CANONICAL_GREEN_SLOTS_KEY,
     CANONICAL_RED_SLOTS_KEY,
     CELL_MASK_KEY,
+    DAUGHTER_MASK_KEY,
+    MOTHER_MASK_KEY,
+    NECK_SPLIT_KEY,
     build_canonical_contour_payload,
     build_canonical_contour_slots,
     get_canonical_blue_slots,
@@ -194,3 +197,74 @@ class CanonicalContourHelpersTests(SimpleTestCase):
 
         self.assertIsNotNone(loaded)
         self.assertEqual(loaded.to_dict(), expected.to_dict())
+
+    def test_build_canonical_contour_payload_attaches_mother_and_daughter_masks(self):
+        """Mother/daughter masks derive from the persisted neck split and DIC mask."""
+
+        shape = (30, 30)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            # Pair outline: tall rectangle covering y=2..27, x=10..19.
+            outline_path = output_dir / "test-1.outline"
+            with outline_path.open("w", encoding="utf-8") as handle:
+                for vy, vx in ((2, 10), (2, 19), (27, 19), (27, 10)):
+                    handle.write(f"{vy},{vx}\n")
+            # Horizontal neck split dividing the rectangle just below the middle
+            # so the top half is strictly larger.
+            write_neck_split(
+                sidecar_path(temp_dir, "test.dv", 1),
+                NeckSplit(x1=10, y1=17, x2=19, y2=17, status="ok"),
+            )
+
+            payload = build_canonical_contour_payload(
+                {"dot_contours": [], "contours_green": []},
+                image_name="test.dv",
+                cell_id=1,
+                output_dir=temp_dir,
+                shape=shape,
+            )
+
+        mother = payload[MOTHER_MASK_KEY]
+        daughter = payload[DAUGHTER_MASK_KEY]
+        cell = payload[CELL_MASK_KEY]
+        self.assertIsNotNone(mother)
+        self.assertIsNotNone(daughter)
+        self.assertEqual(mother.shape, shape)
+        self.assertEqual(daughter.shape, shape)
+        # Larger side (mother) is the top half; smaller side (daughter) is below.
+        self.assertGreater(int(np.count_nonzero(mother)), int(np.count_nonzero(daughter)))
+        # The masks must be disjoint and both live inside the cell mask.
+        overlap = cv2.bitwise_and(mother, daughter)
+        self.assertEqual(int(np.count_nonzero(overlap)), 0)
+        self.assertEqual(int(np.count_nonzero(cv2.bitwise_and(mother, cv2.bitwise_not(cell)))), 0)
+        self.assertEqual(int(np.count_nonzero(cv2.bitwise_and(daughter, cv2.bitwise_not(cell)))), 0)
+        # Mother is above the neck chord, daughter below.
+        self.assertGreater(int(np.count_nonzero(mother[5, 10:20])), 0)
+        self.assertEqual(int(np.count_nonzero(mother[25, 10:20])), 0)
+        self.assertGreater(int(np.count_nonzero(daughter[25, 10:20])), 0)
+        self.assertEqual(int(np.count_nonzero(daughter[5, 10:20])), 0)
+        # Payload also exposes the NeckSplit for downstream consumers.
+        self.assertIsNotNone(payload[NECK_SPLIT_KEY])
+
+    def test_build_canonical_contour_payload_yields_none_side_masks_without_neck_split(self):
+        shape = (20, 20)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            outline_path = output_dir / "test-1.outline"
+            with outline_path.open("w", encoding="utf-8") as handle:
+                for vy, vx in ((2, 2), (2, 17), (17, 17), (17, 2)):
+                    handle.write(f"{vy},{vx}\n")
+
+            payload = build_canonical_contour_payload(
+                {"dot_contours": [], "contours_green": []},
+                image_name="test.dv",
+                cell_id=1,
+                output_dir=temp_dir,
+                shape=shape,
+            )
+
+        self.assertIsNone(payload[MOTHER_MASK_KEY])
+        self.assertIsNone(payload[DAUGHTER_MASK_KEY])
+        self.assertIsNone(payload[NECK_SPLIT_KEY])

--- a/cytocv/core/tests/test_canonical_contours.py
+++ b/cytocv/core/tests/test_canonical_contours.py
@@ -16,6 +16,7 @@ from core.services.canonical_contours import (
     load_neck_split,
 )
 from core.services.neck_split import NeckSplit, sidecar_path, write_neck_split
+from core.services.neck_split import manifest_path, write_neck_split_manifest
 
 
 class CanonicalContourHelpersTests(SimpleTestCase):
@@ -162,7 +163,30 @@ class CanonicalContourHelpersTests(SimpleTestCase):
 
         self.assertEqual(slots, [])
 
-    def test_load_neck_split_round_trips_sidecar(self):
+    def test_load_neck_split_prefers_manifest(self):
+        expected = {
+            "status": "ok",
+            "x1": 2,
+            "y1": 3,
+            "x2": 8,
+            "y2": 9,
+            "defect_depth_1": 512,
+            "defect_depth_2": 384,
+            "side_area_large_px": 120,
+            "side_area_small_px": 50,
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            write_neck_split_manifest(
+                manifest_path(temp_dir),
+                image_name="test.dv",
+                pairs={1: expected},
+            )
+            loaded = load_neck_split("test.dv", 1, temp_dir)
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.to_dict(), NeckSplit.from_dict(expected).to_dict())
+
+    def test_load_neck_split_falls_back_to_legacy_sidecar(self):
         expected = NeckSplit(x1=2, y1=3, x2=8, y2=9, defect_depth_1=512, defect_depth_2=384)
         with tempfile.TemporaryDirectory() as temp_dir:
             write_neck_split(sidecar_path(temp_dir, "test.dv", 1), expected)

--- a/cytocv/core/tests/test_cen_dot_classification.py
+++ b/cytocv/core/tests/test_cen_dot_classification.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import cv2
+import numpy as np
+from django.test import SimpleTestCase
+
+from core.cell_analysis.cen_dot import CENDot
+from core.image_processing import GrayImage
+from core.services.canonical_contours import (
+    CANONICAL_BLUE_SLOTS_KEY,
+    CANONICAL_GREEN_SLOTS_KEY,
+    CANONICAL_RED_SLOTS_KEY,
+    CELL_MASK_KEY,
+    CanonicalContourSlot,
+    DAUGHTER_MASK_KEY,
+    MOTHER_MASK_KEY,
+    NECK_SPLIT_KEY,
+)
+from core.services.neck_split import NeckSplit
+
+
+SHAPE = (60, 40)
+
+
+def _disk_slot(source_index: int, center_xy, radius: int = 2) -> CanonicalContourSlot:
+    mask = np.zeros(SHAPE, dtype=np.uint8)
+    cv2.circle(
+        mask,
+        (int(round(center_xy[0])), int(round(center_xy[1]))),
+        radius,
+        255,
+        -1,
+    )
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    return CanonicalContourSlot(
+        source_index=source_index,
+        mask=mask,
+        contours=tuple(contours),
+        area=float(np.count_nonzero(mask)),
+        center=(float(center_xy[0]), float(center_xy[1])),
+    )
+
+
+def _slot_with_override(
+    source_index: int,
+    mask: np.ndarray,
+    center_xy,
+) -> CanonicalContourSlot:
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    return CanonicalContourSlot(
+        source_index=source_index,
+        mask=mask,
+        contours=tuple(contours),
+        area=float(np.count_nonzero(mask)),
+        center=(float(center_xy[0]), float(center_xy[1])),
+    )
+
+
+def _build_side_masks() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    mother = np.zeros(SHAPE, dtype=np.uint8)
+    mother[5:32, 5:35] = 255
+    daughter = np.zeros(SHAPE, dtype=np.uint8)
+    daughter[33:55, 8:32] = 255
+    cell = cv2.bitwise_or(mother, daughter)
+    return cell, mother, daughter
+
+
+def _build_preprocessed_images() -> GrayImage:
+    red_gray = np.zeros(SHAPE, dtype=np.uint8)
+    green_gray = np.zeros(SHAPE, dtype=np.uint8)
+    blue_gray = np.zeros(SHAPE, dtype=np.uint8)
+    return GrayImage(
+        img={
+            "gray_red": red_gray,
+            "red_no_bg": red_gray,
+            "green": green_gray,
+            "green_no_bg": green_gray,
+            "gray_blue": blue_gray,
+            "gray_blue_3": blue_gray,
+        }
+    )
+
+
+class CENDotMotherDaughterClassificationTests(SimpleTestCase):
+    def _run(
+        self,
+        *,
+        red_slots,
+        green_slots,
+        cell_mask,
+        mother_mask,
+        daughter_mask,
+        neck_split,
+        cen_dot_distance: float = 5.0,
+        cen_dot_proximity_radius: float = 10.0,
+        cen_dot_collinearity_threshold: int = 66,
+    ):
+        cp = SimpleNamespace(
+            image_name="test.dv",
+            cell_id=1,
+            properties={},
+        )
+        images = _build_preprocessed_images()
+        analysis = CENDot(cp=cp, image=images, output_dir="/tmp")
+        contours_data = {
+            CELL_MASK_KEY: cell_mask,
+            MOTHER_MASK_KEY: mother_mask,
+            DAUGHTER_MASK_KEY: daughter_mask,
+            NECK_SPLIT_KEY: neck_split,
+            CANONICAL_RED_SLOTS_KEY: red_slots,
+            CANONICAL_GREEN_SLOTS_KEY: green_slots,
+            CANONICAL_BLUE_SLOTS_KEY: [],
+        }
+        red_image = np.dstack(
+            [images.get_image("gray_red")] * 3
+        ).astype(np.uint8)
+        green_image = np.dstack(
+            [images.get_image("green")] * 3
+        ).astype(np.uint8)
+        analysis.calculate_statistics(
+            best_contours=[],
+            contours_data=contours_data,
+            red_image=red_image,
+            green_image=green_image,
+            puncta_line_width_input=1,
+            cen_dot_distance=cen_dot_distance,
+            cen_dot_collinearity_threshold=cen_dot_collinearity_threshold,
+            cen_dot_proximity_radius=cen_dot_proximity_radius,
+        )
+        return cp
+
+    @staticmethod
+    def _standard_split() -> NeckSplit:
+        return NeckSplit(x1=5, y1=32, x2=34, y2=32, status="ok")
+
+    def test_two_reds_opposite_sides_and_green_in_both_yields_mother_and_daughter(self):
+        cell, mother, daughter = _build_side_masks()
+        red_top = _disk_slot(0, (20, 15))
+        red_bot = _disk_slot(1, (20, 45))
+        green_top = _disk_slot(0, (22, 17))
+        green_bot = _disk_slot(1, (22, 43))
+
+        cp = self._run(
+            red_slots=[red_top, red_bot],
+            green_slots=[green_top, green_bot],
+            cell_mask=cell,
+            mother_mask=mother,
+            daughter_mask=daughter,
+            neck_split=self._standard_split(),
+        )
+
+        self.assertEqual(cp.category_cen_dot, 1)
+        payload = cp.properties["cen_dot_location"]
+        self.assertEqual(payload["status"], "mother_and_daughter")
+        self.assertTrue(payload["green_in_mother"])
+        self.assertTrue(payload["green_in_daughter"])
+        self.assertEqual(cp.properties["cen_dot_schema_version"], 2)
+        self.assertEqual(cp.biorientation, 0)
+
+    def test_green_only_in_mother_yields_mother_only(self):
+        cell, mother, daughter = _build_side_masks()
+        red_top = _disk_slot(0, (20, 15))
+        red_bot = _disk_slot(1, (20, 45))
+        green_top = _disk_slot(0, (22, 17))
+
+        cp = self._run(
+            red_slots=[red_top, red_bot],
+            green_slots=[green_top],
+            cell_mask=cell,
+            mother_mask=mother,
+            daughter_mask=daughter,
+            neck_split=self._standard_split(),
+        )
+
+        self.assertEqual(cp.category_cen_dot, 2)
+        self.assertEqual(cp.properties["cen_dot_location"]["status"], "mother_only")
+
+    def test_green_only_in_daughter_yields_daughter_only(self):
+        cell, mother, daughter = _build_side_masks()
+        red_top = _disk_slot(0, (20, 15))
+        red_bot = _disk_slot(1, (20, 45))
+        green_bot = _disk_slot(0, (22, 43))
+
+        cp = self._run(
+            red_slots=[red_top, red_bot],
+            green_slots=[green_bot],
+            cell_mask=cell,
+            mother_mask=mother,
+            daughter_mask=daughter,
+            neck_split=self._standard_split(),
+        )
+
+        self.assertEqual(cp.category_cen_dot, 3)
+        self.assertEqual(cp.properties["cen_dot_location"]["status"], "daughter_only")
+
+    def test_two_reds_on_same_side_yields_na(self):
+        cell, mother, daughter = _build_side_masks()
+        red_a = _disk_slot(0, (15, 12))
+        red_b = _disk_slot(1, (25, 28))
+        green_any = _disk_slot(0, (20, 43))
+
+        cp = self._run(
+            red_slots=[red_a, red_b],
+            green_slots=[green_any],
+            cell_mask=cell,
+            mother_mask=mother,
+            daughter_mask=daughter,
+            neck_split=self._standard_split(),
+        )
+
+        self.assertEqual(cp.category_cen_dot, 4)
+        self.assertEqual(cp.properties["cen_dot_location"]["status"], "reds_same_side")
+
+    def test_more_than_two_usable_reds_yields_na(self):
+        cell, mother, daughter = _build_side_masks()
+        red_a = _disk_slot(0, (20, 15))
+        red_b = _disk_slot(1, (20, 45))
+        red_c = _disk_slot(2, (10, 10))
+
+        cp = self._run(
+            red_slots=[red_a, red_b, red_c],
+            green_slots=[],
+            cell_mask=cell,
+            mother_mask=mother,
+            daughter_mask=daughter,
+            neck_split=self._standard_split(),
+        )
+
+        self.assertEqual(cp.category_cen_dot, 4)
+        payload = cp.properties["cen_dot_location"]
+        self.assertEqual(payload["status"], "too_many_reds")
+        self.assertEqual(payload["usable_red_count"], 3)
+
+    def test_red_distance_equal_to_threshold_qualifies(self):
+        cell, mother, daughter = _build_side_masks()
+        # Reds exactly `cen_dot_distance` pixels apart.
+        red_top = _disk_slot(0, (20, 15))
+        red_bot = _disk_slot(1, (20, 45))
+        green_top = _disk_slot(0, (22, 17))
+        green_bot = _disk_slot(1, (22, 43))
+
+        cp = self._run(
+            red_slots=[red_top, red_bot],
+            green_slots=[green_top, green_bot],
+            cell_mask=cell,
+            mother_mask=mother,
+            daughter_mask=daughter,
+            neck_split=self._standard_split(),
+            cen_dot_distance=30.0,  # exact distance between (20,15) and (20,45)
+        )
+
+        self.assertEqual(cp.category_cen_dot, 1)
+        payload = cp.properties["cen_dot_location"]
+        self.assertAlmostEqual(payload["red_distance"], 30.0, places=4)
+        self.assertAlmostEqual(payload["red_distance_threshold_effective"], 30.0, places=4)
+
+    def test_greens_outside_pair_mask_do_not_count(self):
+        cell, mother, daughter = _build_side_masks()
+        red_top = _disk_slot(0, (20, 15))
+        red_bot = _disk_slot(1, (20, 45))
+        # Green slot centered outside the cell mask entirely.
+        green_outside_mother = _disk_slot(0, (2, 15))
+        green_outside_daughter = _disk_slot(1, (2, 45))
+
+        cp = self._run(
+            red_slots=[red_top, red_bot],
+            green_slots=[green_outside_mother, green_outside_daughter],
+            cell_mask=cell,
+            mother_mask=mother,
+            daughter_mask=daughter,
+            neck_split=self._standard_split(),
+        )
+
+        self.assertEqual(cp.category_cen_dot, 4)
+        payload = cp.properties["cen_dot_location"]
+        self.assertEqual(payload["status"], "no_valid_green")
+        self.assertFalse(payload["green_in_mother"])
+        self.assertFalse(payload["green_in_daughter"])
+
+    def test_greens_in_wrong_side_do_not_count_even_if_near_other_red(self):
+        """Side assignment is mask-driven; proximity only counts for same-side red.
+
+        A green whose *mask* lies in mother-side but whose *center* is near
+        daughter_red must not contribute to either side: it is assigned to
+        mother, so only mother_red proximity is considered (and fails).
+        """
+        cell, mother, daughter = _build_side_masks()
+        red_top = _disk_slot(0, (20, 15))
+        red_bot = _disk_slot(1, (20, 45))
+
+        # Build a green whose mask is fully inside mother-side but override
+        # the center to be next to daughter_red's location.
+        mother_only_mask = np.zeros(SHAPE, dtype=np.uint8)
+        cv2.circle(mother_only_mask, (20, 15), 2, 255, -1)
+        mother_only_mask = cv2.bitwise_and(mother_only_mask, mother)
+        self.assertTrue(np.any(mother_only_mask))
+        wrong_side_green = _slot_with_override(
+            source_index=0,
+            mask=mother_only_mask,
+            center_xy=(20, 45),  # center close to daughter_red
+        )
+
+        cp = self._run(
+            red_slots=[red_top, red_bot],
+            green_slots=[wrong_side_green],
+            cell_mask=cell,
+            mother_mask=mother,
+            daughter_mask=daughter,
+            neck_split=self._standard_split(),
+            cen_dot_proximity_radius=5.0,
+        )
+
+        self.assertEqual(cp.category_cen_dot, 4)
+        payload = cp.properties["cen_dot_location"]
+        self.assertEqual(payload["status"], "no_valid_green")
+        self.assertFalse(payload["green_in_mother"])
+        self.assertFalse(payload["green_in_daughter"])
+
+    def test_missing_neck_split_yields_na(self):
+        cell, _, _ = _build_side_masks()
+        red_top = _disk_slot(0, (20, 15))
+        red_bot = _disk_slot(1, (20, 45))
+        green_top = _disk_slot(0, (22, 17))
+
+        cp = self._run(
+            red_slots=[red_top, red_bot],
+            green_slots=[green_top],
+            cell_mask=cell,
+            mother_mask=None,
+            daughter_mask=None,
+            neck_split=None,
+        )
+
+        self.assertEqual(cp.category_cen_dot, 4)
+        payload = cp.properties["cen_dot_location"]
+        self.assertEqual(payload["status"], "missing_neck_split")
+        self.assertFalse(payload["has_neck_split"])
+
+    def test_reds_below_threshold_path_preserves_biorientation(self):
+        """Close reds skip mother/daughter classification but retain biorientation."""
+        cell, mother, daughter = _build_side_masks()
+        red_a = _disk_slot(0, (15, 20))
+        red_b = _disk_slot(1, (25, 20))
+        # One green between the two reds to trip biorientation=1.
+        green_between = _disk_slot(0, (20, 20))
+
+        cp = self._run(
+            red_slots=[red_a, red_b],
+            green_slots=[green_between],
+            cell_mask=cell,
+            mother_mask=mother,
+            daughter_mask=daughter,
+            neck_split=self._standard_split(),
+            cen_dot_distance=50.0,  # reds are 10 px apart, below threshold
+        )
+
+        self.assertEqual(cp.category_cen_dot, 4)
+        payload = cp.properties["cen_dot_location"]
+        self.assertEqual(payload["status"], "reds_below_threshold")
+        self.assertEqual(cp.biorientation, 1)

--- a/cytocv/core/tests/test_core_app.py
+++ b/cytocv/core/tests/test_core_app.py
@@ -22,6 +22,7 @@ from core.cell_analysis import Analysis
 from core.config import DEFAULT_CHANNEL_CONFIG
 from core.image_processing import GrayImage
 from core.models import CellStatistics, DVLayerTifPreview, SegmentedImage, UploadedImage
+from core.services.neck_split import NeckSplit, sidecar_path, write_neck_split
 from core.services.overlay_rendering import (
     build_legacy_debug_image_path,
     build_overlay_render_config,
@@ -176,6 +177,22 @@ class RouteSurfaceRefactorTests(TestCase):
         )
         write_overlay_render_config(uuid_value, render_config)
         return render_config
+
+    @staticmethod
+    def _write_neck_split_sidecar(
+        media_root: Path,
+        uuid_value: str,
+        image_stem: str,
+        *,
+        cell_id: int = 1,
+        split: NeckSplit | None = None,
+    ) -> Path:
+        target = sidecar_path(media_root / uuid_value, f"{image_stem}.dv", cell_id)
+        write_neck_split(
+            target,
+            split or NeckSplit(x1=0, y1=0, x2=5, y2=5),
+        )
+        return target
 
     @staticmethod
     def _create_cell_stats(
@@ -581,6 +598,39 @@ class RouteSurfaceRefactorTests(TestCase):
             self.assertTrue(
                 overlay_cache_image_path(uuid_value, 1, "green").exists()
             )
+
+    def test_overlay_endpoint_ignores_neck_split_sidecar_for_fluorescence_channels(self):
+        uuid_value = str(uuid4())
+        with temporary_media_root() as media_root:
+            self._write_channel_config(media_root, uuid_value)
+            self._create_uploaded_image(uuid_value, name="overlay-neck")
+            segmented = self._create_segmented_image(uuid_value, name="overlay-neck")
+            segmented.NumCells = 1
+            segmented.save(update_fields=["NumCells"])
+            self._write_segmented_cell_assets(media_root, uuid_value, "overlay-neck")
+            self._create_cell_stats(segmented, "overlay-neck")
+            self._write_overlay_config(uuid_value, "overlay-neck")
+            self._write_neck_split_sidecar(media_root, uuid_value, "overlay-neck")
+
+            response = self.client.get(
+                reverse("cell_overlay_image", args=[uuid_value, 1, "green"])
+            )
+            payload = b"".join(response.streaming_content)
+            response.close()
+
+        self.assertEqual(response.status_code, 200)
+        rendered = np.array(Image.open(BytesIO(payload)))
+        cyan_like = (
+            (rendered[:, :, 0] < 100)
+            & (rendered[:, :, 1] > 150)
+            & (rendered[:, :, 2] > 150)
+        )
+        self.assertEqual(int(np.count_nonzero(cyan_like)), 0)
+
+    def test_overlay_cache_path_uses_schema_v2_directory(self):
+        uuid_value = str(uuid4())
+        cache_path = overlay_cache_image_path(uuid_value, 1, "green")
+        self.assertIn("overlay-cache-v2", str(cache_path))
 
     def test_overlay_endpoint_returns_404_for_unauthorized_user(self):
         other_user = get_user_model().objects.create_user(
@@ -1023,4 +1073,3 @@ class PluginMappingRegressionTests(TestCase):
             [instance.__class__.__name__ for instance in plan.analyses],
             ["NuclearCellPairIntensity"],
         )
-

--- a/cytocv/core/tests/test_core_app.py
+++ b/cytocv/core/tests/test_core_app.py
@@ -904,6 +904,7 @@ class RouteSurfaceRefactorTests(TestCase):
                 properties={
                     "nuclear_cell_pair_mode": "red_nucleus",
                     "puncta_line_mode": "green_puncta",
+                    "cen_dot_schema_version": 2,
                 },
                 category_cen_dot=1,
             )
@@ -932,7 +933,7 @@ class RouteSurfaceRefactorTests(TestCase):
         self.assertContains(response, '"puncta_distance_label": "Distance between Green Puncta"', html=False)
         self.assertContains(
             response,
-            '"category_cen_dot_label": "One green dot with each red dot"',
+            '"category_cen_dot_label": "Mother and daughter"',
             html=False,
         )
         self.assertContains(response, "cellStats.category_cen_dot_label || 'N/A'", html=False)
@@ -960,6 +961,7 @@ class RouteSurfaceRefactorTests(TestCase):
                 properties={
                     "nuclear_cell_pair_mode": "green_nucleus",
                     "puncta_line_mode": "green_puncta",
+                    "cen_dot_schema_version": 2,
                 },
                 category_cen_dot=1,
             )
@@ -987,7 +989,7 @@ class RouteSurfaceRefactorTests(TestCase):
         self.assertContains(response, '"puncta_distance_label": "Distance between Green Puncta"', html=False)
         self.assertContains(
             response,
-            '"category_cen_dot_label": "One green dot with each red dot"',
+            '"category_cen_dot_label": "Mother and daughter"',
             html=False,
         )
         self.assertContains(response, "cellStats.category_cen_dot_label || 'N/A'", html=False)

--- a/cytocv/core/tests/test_dashed_line.py
+++ b/cytocv/core/tests/test_dashed_line.py
@@ -1,0 +1,62 @@
+"""Tests for the shared dashed-line helpers."""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from django.test import SimpleTestCase
+
+from core.image_processing.dashed_line import draw_dashed_line, draw_dashed_polyline
+
+
+class DrawDashedLineTests(SimpleTestCase):
+    def test_horizontal_line_produces_alternating_gaps(self):
+        canvas = np.zeros((10, 60), dtype=np.uint8)
+        draw_dashed_line(
+            canvas,
+            (5, 5),
+            (54, 5),
+            255,
+            dash_px=6,
+            gap_px=4,
+            thickness=1,
+            line_type=cv2.LINE_8,
+        )
+        # There should be both lit and unlit pixels along the row.
+        row = canvas[5, 5:55]
+        self.assertGreater(int(np.count_nonzero(row)), 0)
+        self.assertGreater(int((row == 0).sum()), 0)
+        # The first pixel of a new dash is always lit (we start with draw=True).
+        self.assertEqual(int(canvas[5, 5]), 255)
+
+    def test_zero_length_segment_is_noop(self):
+        canvas = np.zeros((10, 10), dtype=np.uint8)
+        draw_dashed_line(canvas, (3, 3), (3, 3), 255)
+        self.assertEqual(int(canvas.sum()), 0)
+
+    def test_polyline_dash_phase_persists_across_vertices(self):
+        canvas = np.zeros((40, 40), dtype=np.uint8)
+        # Closed square perimeter. We just verify something is drawn and
+        # the helper does not raise for closed polylines.
+        points = np.array([[5, 5], [34, 5], [34, 34], [5, 34]], dtype=np.int32)
+        draw_dashed_polyline(
+            canvas,
+            points,
+            255,
+            closed=True,
+            dash_px=6,
+            gap_px=4,
+            thickness=1,
+            line_type=cv2.LINE_8,
+        )
+        self.assertGreater(int(np.count_nonzero(canvas)), 0)
+
+    def test_none_image_is_ignored(self):
+        # Should not raise.
+        draw_dashed_line(None, (0, 0), (10, 10), 255)
+        draw_dashed_polyline(None, np.array([[0, 0], [1, 1]]), 255)
+
+    def test_single_point_polyline_is_noop(self):
+        canvas = np.zeros((10, 10), dtype=np.uint8)
+        draw_dashed_polyline(canvas, np.array([[5, 5]]), 255)
+        self.assertEqual(int(canvas.sum()), 0)

--- a/cytocv/core/tests/test_modern_contour_statistics.py
+++ b/cytocv/core/tests/test_modern_contour_statistics.py
@@ -226,7 +226,8 @@ class ModernContourStatisticsTests(SimpleTestCase):
         self.assertGreater(cp.red_intensity_1, cp.red_intensity_2)
         self.assertGreater(cp.red_intensity_2, cp.red_intensity_3)
         self.assertAlmostEqual(cp.puncta_distance, math.dist((57.0, 17.0), (15.0, 55.0)), places=4)
-        self.assertEqual(cp.category_cen_dot, 1)
+        self.assertEqual(cp.category_cen_dot, 4)
+        self.assertEqual(cp.properties["cen_dot_location"]["status"], "too_many_reds")
 
     def test_green_puncta_mode_measures_red_intensity_over_green_line(self):
         shape = (16, 16)

--- a/cytocv/core/tests/test_neck_split.py
+++ b/cytocv/core/tests/test_neck_split.py
@@ -10,12 +10,17 @@ import numpy as np
 from django.test import SimpleTestCase
 
 from core.services.neck_split import (
+    PAIR_GEOMETRY_SCHEMA_VERSION,
     STATUS_OK,
     NeckSplit,
     compute_side_areas,
     detect_neck_split,
+    load_neck_split_from_manifest,
+    manifest_path,
+    read_neck_split_manifest,
     read_neck_split,
     sidecar_path,
+    write_neck_split_manifest,
     write_neck_split,
 )
 
@@ -139,3 +144,65 @@ class SidecarRoundTripTests(SimpleTestCase):
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text("garbage", encoding="utf-8")
             self.assertIsNone(read_neck_split(path))
+
+
+class ManifestRoundTripTests(SimpleTestCase):
+    def test_write_then_read_manifest_equal(self):
+        pairs = {
+            1: {
+                "status": "ok",
+                "x1": 10,
+                "y1": 20,
+                "x2": 30,
+                "y2": 40,
+                "defect_depth_1": 512,
+                "defect_depth_2": 400,
+                "side_area_large_px": 100,
+                "side_area_small_px": 40,
+            },
+            2: {
+                "status": "no_neck",
+            },
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = manifest_path(temp_dir)
+            write_neck_split_manifest(path, image_name="image.dv", pairs=pairs)
+            loaded = read_neck_split_manifest(path)
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual(int(loaded["schema_version"]), PAIR_GEOMETRY_SCHEMA_VERSION)
+        self.assertEqual(str(loaded["image_name"]), "image.dv")
+        self.assertEqual(dict(loaded["pairs"]), {"1": pairs[1], "2": pairs[2]})
+
+    def test_load_from_manifest_returns_single_entry(self):
+        expected = {
+            "status": "ok",
+            "x1": 2,
+            "y1": 3,
+            "x2": 8,
+            "y2": 9,
+            "defect_depth_1": 512,
+            "defect_depth_2": 384,
+            "side_area_large_px": 111,
+            "side_area_small_px": 42,
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            write_neck_split_manifest(
+                manifest_path(temp_dir),
+                image_name="test.dv",
+                pairs={1: expected},
+            )
+            loaded = load_neck_split_from_manifest(temp_dir, "test.dv", 1)
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.to_dict(), NeckSplit.from_dict(expected).to_dict())
+
+    def test_manifest_missing_or_no_neck_returns_none(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.assertIsNone(load_neck_split_from_manifest(temp_dir, "test.dv", 1))
+            write_neck_split_manifest(
+                manifest_path(temp_dir),
+                image_name="test.dv",
+                pairs={1: {"status": "no_neck"}},
+            )
+            self.assertIsNone(load_neck_split_from_manifest(temp_dir, "test.dv", 1))

--- a/cytocv/core/tests/test_neck_split.py
+++ b/cytocv/core/tests/test_neck_split.py
@@ -1,0 +1,141 @@
+"""Tests for `core.services.neck_split`."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import cv2
+import numpy as np
+from django.test import SimpleTestCase
+
+from core.services.neck_split import (
+    STATUS_OK,
+    NeckSplit,
+    compute_side_areas,
+    detect_neck_split,
+    read_neck_split,
+    sidecar_path,
+    write_neck_split,
+)
+
+
+def _dumbbell(radius_a: int, radius_b: int, center_distance: int, shape=(120, 160)) -> np.ndarray:
+    """Binary mask containing two overlapping circles on a horizontal axis."""
+
+    mask = np.zeros(shape, dtype=np.uint8)
+    cy = shape[0] // 2
+    cx_a = shape[1] // 2 - center_distance // 2
+    cx_b = shape[1] // 2 + center_distance // 2
+    cv2.circle(mask, (cx_a, cy), radius_a, 255, -1)
+    cv2.circle(mask, (cx_b, cy), radius_b, 255, -1)
+    return mask
+
+
+def _outer_contour(mask: np.ndarray) -> np.ndarray:
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
+    return max(contours, key=len)
+
+
+class DetectNeckSplitTests(SimpleTestCase):
+    def test_symmetric_dumbbell_returns_ok_split_near_midline(self):
+        mask = _dumbbell(25, 25, center_distance=40)
+        contour = _outer_contour(mask)
+
+        split = detect_neck_split(contour, mask)
+
+        self.assertIsNotNone(split)
+        self.assertEqual(split.status, STATUS_OK)
+        midline_x = mask.shape[1] // 2
+        self.assertLess(abs(split.x1 - midline_x), 4)
+        self.assertLess(abs(split.x2 - midline_x), 4)
+        # Chord runs vertically across the neck with meaningful length.
+        self.assertGreater(abs(split.y1 - split.y2), 10)
+
+    def test_single_circle_returns_none(self):
+        mask = np.zeros((80, 80), dtype=np.uint8)
+        cv2.circle(mask, (40, 40), 25, 255, -1)
+        contour = _outer_contour(mask)
+
+        self.assertIsNone(detect_neck_split(contour, mask))
+
+    def test_multi_component_mask_returns_none(self):
+        mask = np.zeros((80, 120), dtype=np.uint8)
+        cv2.circle(mask, (25, 40), 15, 255, -1)
+        cv2.circle(mask, (95, 40), 15, 255, -1)
+        # Use the first circle's contour; the multi-component guard should
+        # still reject the mask before convex-hull analysis runs.
+        contour = _outer_contour(mask)
+
+        self.assertIsNone(detect_neck_split(contour, mask))
+
+    def test_asymmetric_dumbbell_side_areas_ordered(self):
+        mask = _dumbbell(25, 12, center_distance=30)
+        contour = _outer_contour(mask)
+
+        split = detect_neck_split(contour, mask)
+        self.assertIsNotNone(split)
+
+        larger_px, smaller_px, larger_mask, smaller_mask = compute_side_areas(mask, split)
+        self.assertGreater(larger_px, smaller_px)
+        self.assertEqual(larger_mask.shape, mask.shape)
+        self.assertEqual(smaller_mask.shape, mask.shape)
+        self.assertGreater(int(np.count_nonzero(larger_mask)), 0)
+        self.assertGreater(int(np.count_nonzero(smaller_mask)), 0)
+
+    def test_symmetric_dumbbell_side_areas_roughly_equal(self):
+        mask = _dumbbell(25, 25, center_distance=40)
+        contour = _outer_contour(mask)
+
+        split = detect_neck_split(contour, mask)
+        self.assertIsNotNone(split)
+
+        larger_px, smaller_px, _, _ = compute_side_areas(mask, split)
+        total = larger_px + smaller_px
+        # Allow 10 % asymmetry for pixelization of the chord.
+        self.assertLess(abs(larger_px - smaller_px) / max(total, 1), 0.10)
+
+    def test_compute_side_areas_does_not_mutate_input(self):
+        mask = _dumbbell(25, 25, center_distance=40)
+        contour = _outer_contour(mask)
+        split = detect_neck_split(contour, mask)
+        self.assertIsNotNone(split)
+
+        snapshot = mask.copy()
+        compute_side_areas(mask, split)
+        self.assertTrue(np.array_equal(mask, snapshot))
+
+    def test_degenerate_short_contour_returns_none(self):
+        mask = np.zeros((20, 20), dtype=np.uint8)
+        mask[5:7, 5:8] = 255
+        contour = _outer_contour(mask)
+
+        self.assertIsNone(detect_neck_split(contour, mask))
+
+
+class SidecarRoundTripTests(SimpleTestCase):
+    def test_write_then_read_equal(self):
+        split = NeckSplit(x1=10, y1=20, x2=30, y2=40, defect_depth_1=512, defect_depth_2=400)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = sidecar_path(temp_dir, "image.dv", 7)
+            write_neck_split(path, split)
+            loaded = read_neck_split(path)
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.to_dict(), split.to_dict())
+
+    def test_sidecar_path_mirrors_outline_naming(self):
+        path = sidecar_path("/tmp/run", "sample.dv", 3)
+        self.assertTrue(str(path).endswith("output/sample-3.neck_split") or str(path).endswith("output\\sample-3.neck_split"))
+
+    def test_missing_sidecar_returns_none(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "output" / "missing-1.neck_split"
+            self.assertIsNone(read_neck_split(path))
+
+    def test_malformed_sidecar_returns_none(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "output" / "bad-1.neck_split"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("garbage", encoding="utf-8")
+            self.assertIsNone(read_neck_split(path))

--- a/cytocv/core/tests/test_outline_contour_artifact.py
+++ b/cytocv/core/tests/test_outline_contour_artifact.py
@@ -11,11 +11,14 @@ import numpy as np
 from django.test import SimpleTestCase
 
 from core.services.canonical_contours import load_cell_mask
+from core.services.neck_split import manifest_path, sidecar_path
 from core.services.segmentation_pipeline import (
     CYAN_DEBUG_COLOR,
     _build_pair_geometry_cache,
+    _build_neck_split_manifest_pairs,
     _crop_bounds_for_label_mask,
     _draw_pair_geometry_overlay,
+    _write_neck_split_manifest_for_run,
 )
 
 
@@ -161,3 +164,34 @@ class OutlineContourArtifactTests(SimpleTestCase):
 
         self.assertGreater(int(np.count_nonzero(self._cyan_like_mask(dic_crop))), 0)
         self.assertEqual(int(np.count_nonzero(self._cyan_like_mask(fluorescence_crop))), 0)
+
+    def test_neck_split_manifest_writer_persists_one_run_file(self):
+        seg = np.zeros((80, 100), dtype=np.int32)
+        binary = np.zeros(seg.shape, dtype=np.uint8)
+        cv2.circle(binary, (38, 40), 18, 255, -1)
+        cv2.circle(binary, (58, 40), 18, 255, -1)
+        seg[binary > 0] = 1
+
+        cache = _build_pair_geometry_cache(seg)
+        manifest_pairs = _build_neck_split_manifest_pairs(cache)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = _write_neck_split_manifest_for_run(
+                temp_dir,
+                image_name="test.dv",
+                pair_geometry_cache=cache,
+                use_cache=False,
+            )
+
+            self.assertEqual(manifest, manifest_path(temp_dir))
+            self.assertTrue(manifest.exists())
+            self.assertFalse(sidecar_path(temp_dir, "test.dv", 1).exists())
+
+            payload = manifest.read_text(encoding="utf-8")
+
+        self.assertIn('"image_name": "test.dv"', payload)
+        self.assertIn('"pairs"', payload)
+        self.assertIn('"1"', payload)
+        self.assertEqual(manifest_pairs[1]["status"], "ok")
+        self.assertIn("side_area_large_px", manifest_pairs[1])
+        self.assertIn("side_area_small_px", manifest_pairs[1])

--- a/cytocv/core/tests/test_outline_contour_artifact.py
+++ b/cytocv/core/tests/test_outline_contour_artifact.py
@@ -17,6 +17,7 @@ from core.services.segmentation_pipeline import (
     _build_pair_geometry_cache,
     _build_neck_split_manifest_pairs,
     _crop_bounds_for_label_mask,
+    _draw_pair_parentage_labels,
     _draw_pair_geometry_overlay,
     _write_neck_split_manifest_for_run,
 )
@@ -43,6 +44,14 @@ class OutlineContourArtifactTests(SimpleTestCase):
             (image[:, :, 0] < 80)
             & (image[:, :, 1] > 150)
             & (image[:, :, 2] > 150)
+        )
+
+    @staticmethod
+    def _bright_label_mask(image: np.ndarray) -> np.ndarray:
+        return (
+            (image[:, :, 0] > 200)
+            & (image[:, :, 1] > 200)
+            & (image[:, :, 2] > 200)
         )
 
     def test_contour_roundtrip_reconstructs_support_mask(self):
@@ -164,6 +173,28 @@ class OutlineContourArtifactTests(SimpleTestCase):
 
         self.assertGreater(int(np.count_nonzero(self._cyan_like_mask(dic_crop))), 0)
         self.assertEqual(int(np.count_nonzero(self._cyan_like_mask(fluorescence_crop))), 0)
+
+    def test_parentage_labels_are_applied_only_to_dic_like_crop(self):
+        seg = np.zeros((80, 100), dtype=np.int32)
+        binary = np.zeros(seg.shape, dtype=np.uint8)
+        cv2.circle(binary, (38, 40), 18, 255, -1)
+        cv2.circle(binary, (58, 40), 18, 255, -1)
+        seg[binary > 0] = 1
+
+        cache = _build_pair_geometry_cache(seg)
+        entry = cache[1]
+
+        self.assertIsNotNone(entry.local_split)
+        self.assertIsNotNone(entry.mother_label_position)
+        self.assertIsNotNone(entry.daughter_label_position)
+
+        dic_crop = np.zeros((entry.max_x - entry.min_x, entry.max_y - entry.min_y, 3), dtype=np.uint8)
+        fluorescence_crop = np.zeros_like(dic_crop)
+
+        _draw_pair_parentage_labels(dic_crop, entry)
+
+        self.assertGreater(int(np.count_nonzero(self._bright_label_mask(dic_crop))), 0)
+        self.assertEqual(int(np.count_nonzero(self._bright_label_mask(fluorescence_crop))), 0)
 
     def test_neck_split_manifest_writer_persists_one_run_file(self):
         seg = np.zeros((80, 100), dtype=np.int32)

--- a/cytocv/core/tests/test_outline_contour_artifact.py
+++ b/cytocv/core/tests/test_outline_contour_artifact.py
@@ -11,6 +11,12 @@ import numpy as np
 from django.test import SimpleTestCase
 
 from core.services.canonical_contours import load_cell_mask
+from core.services.segmentation_pipeline import (
+    CYAN_DEBUG_COLOR,
+    _build_pair_geometry_cache,
+    _crop_bounds_for_label_mask,
+    _draw_pair_geometry_overlay,
+)
 
 
 def _write_outline(output_dir: Path, contours: list[list[tuple[int, int]]], *, image_stem: str = "test", cell_id: int = 1) -> Path:
@@ -28,6 +34,14 @@ def _write_outline(output_dir: Path, contours: list[list[tuple[int, int]]], *, i
 
 
 class OutlineContourArtifactTests(SimpleTestCase):
+    @staticmethod
+    def _cyan_like_mask(image: np.ndarray) -> np.ndarray:
+        return (
+            (image[:, :, 0] < 80)
+            & (image[:, :, 1] > 150)
+            & (image[:, :, 2] > 150)
+        )
+
     def test_contour_roundtrip_reconstructs_support_mask(self):
         shape = (40, 40)
         pair_mask = np.zeros(shape, np.uint8)
@@ -64,11 +78,9 @@ class OutlineContourArtifactTests(SimpleTestCase):
         seg = np.zeros((60, 60), dtype=np.int32)
         seg[20:30, 20:30] = 1
 
-        a = np.where(seg == 1)
-        min_x = max(int(np.min(a[0])) - 4, 0)
-        max_x = min(int(np.max(a[0])) + 4 + 1, seg.shape[0])
-        min_y = max(int(np.min(a[1])) - 4, 0)
-        max_y = min(int(np.max(a[1])) + 4 + 1, seg.shape[1])
+        bounds = _crop_bounds_for_label_mask((seg == 1).astype(np.uint8) * 255)
+        self.assertIsNotNone(bounds)
+        min_x, max_x, min_y, max_y = bounds
 
         self.assertEqual(min_x, 16)
         self.assertEqual(max_x, 34)
@@ -96,3 +108,56 @@ class OutlineContourArtifactTests(SimpleTestCase):
         self.assertTrue(np.array_equal(image[15, 15], np.array([0, 0, 0], dtype=np.uint8)))
         # Exterior is untouched.
         self.assertTrue(np.array_equal(image[5, 5], np.array([0, 0, 0], dtype=np.uint8)))
+
+    def test_pair_geometry_overlay_draws_dashed_neck_seam_on_full_frame_and_crop(self):
+        seg = np.zeros((80, 100), dtype=np.int32)
+        binary = np.zeros(seg.shape, dtype=np.uint8)
+        cv2.circle(binary, (38, 40), 18, 255, -1)
+        cv2.circle(binary, (58, 40), 18, 255, -1)
+        seg[binary > 0] = 1
+
+        cache = _build_pair_geometry_cache(seg)
+        entry = cache[1]
+
+        self.assertIsNotNone(entry.local_split)
+        self.assertIsNotNone(entry.full_split)
+
+        contour_only = np.zeros((80, 100, 3), dtype=np.uint8)
+        cv2.drawContours(contour_only, list(entry.full_contours), -1, CYAN_DEBUG_COLOR, 1)
+
+        outlined = np.zeros((80, 100, 3), dtype=np.uint8)
+        _draw_pair_geometry_overlay(outlined, cache)
+
+        contour_mask = self._cyan_like_mask(contour_only)
+        outlined_mask = self._cyan_like_mask(outlined)
+        seam_mask = outlined_mask & ~contour_mask
+
+        self.assertGreater(int(np.count_nonzero(seam_mask)), 0)
+
+        outlined_crop = outlined[entry.min_x:entry.max_x, entry.min_y:entry.max_y]
+        contour_only_crop = contour_only[entry.min_x:entry.max_x, entry.min_y:entry.max_y]
+        crop_seam_mask = self._cyan_like_mask(outlined_crop) & ~self._cyan_like_mask(contour_only_crop)
+        self.assertGreater(int(np.count_nonzero(crop_seam_mask)), 0)
+
+        no_outline_crop = np.zeros_like(outlined_crop)
+        self.assertEqual(int(np.count_nonzero(self._cyan_like_mask(no_outline_crop))), 0)
+
+    def test_per_cell_crop_overlay_is_applied_only_to_dic_like_image(self):
+        seg = np.zeros((80, 100), dtype=np.int32)
+        binary = np.zeros(seg.shape, dtype=np.uint8)
+        cv2.circle(binary, (38, 40), 18, 255, -1)
+        cv2.circle(binary, (58, 40), 18, 255, -1)
+        seg[binary > 0] = 1
+
+        cache = _build_pair_geometry_cache(seg)
+        entry = cache[1]
+
+        dic_canvas = np.zeros((80, 100, 3), dtype=np.uint8)
+        _draw_pair_geometry_overlay(dic_canvas, cache)
+        dic_crop = dic_canvas[entry.min_x:entry.max_x, entry.min_y:entry.max_y]
+
+        fluorescence_canvas = np.zeros((80, 100, 3), dtype=np.uint8)
+        fluorescence_crop = fluorescence_canvas[entry.min_x:entry.max_x, entry.min_y:entry.max_y]
+
+        self.assertGreater(int(np.count_nonzero(self._cyan_like_mask(dic_crop))), 0)
+        self.assertEqual(int(np.count_nonzero(self._cyan_like_mask(fluorescence_crop))), 0)

--- a/cytocv/core/tests/test_tables.py
+++ b/cytocv/core/tests/test_tables.py
@@ -38,19 +38,40 @@ class CellTableNuclearCellPairRenderingTests(SimpleTestCase):
         self.assertEqual(self.table.value_nucleus_intensity_sum(234.567, record), "234.567")
         self.assertEqual(self.table.value_cytoplasmic_intensity(345.678, record), "345.678")
 
-    def test_render_gfp_dot_category_uses_choice_label(self):
-        category_table = CellTable([SimpleNamespace(category_cen_dot=1)], intensity_mode="green_nucleus")
+    def test_render_cen_dot_location_uses_schema_aware_choice_label(self):
+        record = SimpleNamespace(
+            category_cen_dot=1,
+            properties={"cen_dot_schema_version": 2},
+        )
+        category_table = CellTable([record], intensity_mode="green_nucleus")
         row = list(category_table.rows)[0]
 
-        self.assertEqual(row.get_cell("category_cen_dot"), "One green dot with each red dot")
-        self.assertEqual(list(category_table.as_values())[1][-2], "One green dot with each red dot")
+        self.assertEqual(row.get_cell("category_cen_dot"), "Mother and daughter")
+        self.assertEqual(list(category_table.as_values())[1][-2], "Mother and daughter")
 
-    def test_render_gfp_dot_category_falls_back_to_na_for_invalid_values(self):
-        category_table = CellTable([SimpleNamespace(category_cen_dot=999)], intensity_mode="green_nucleus")
+    def test_render_cen_dot_location_falls_back_to_na_for_invalid_values(self):
+        record = SimpleNamespace(
+            category_cen_dot=999,
+            properties={"cen_dot_schema_version": 2},
+        )
+        category_table = CellTable([record], intensity_mode="green_nucleus")
         row = list(category_table.rows)[0]
 
         self.assertEqual(row.get_cell("category_cen_dot"), "N/A")
         self.assertEqual(list(category_table.as_values())[1][-2], "N/A")
+
+    def test_legacy_rows_render_rerun_required_label_for_non_na_cen_values(self):
+        record = SimpleNamespace(category_cen_dot=1, properties={})
+        category_table = CellTable([record], intensity_mode="green_nucleus")
+        row = list(category_table.rows)[0]
+
+        self.assertEqual(row.get_cell("category_cen_dot"), "Rerun analysis for CEN location")
+
+    def test_cen_dot_location_header_replaces_legacy_category_header(self):
+        header_row = list(self.table.as_values())[0]
+
+        self.assertIn("CEN dot Location", header_row)
+        self.assertNotIn("CEN dot Category", header_row)
 
     def test_ratio_columns_are_present_with_explicit_compatibility_labels(self):
         header_row = list(self.table.as_values())[0]

--- a/cytocv/core/tests/test_upload_length_scale.py
+++ b/cytocv/core/tests/test_upload_length_scale.py
@@ -290,7 +290,8 @@ class AnisotropicDistanceConversionTests(SimpleTestCase):
                 "scale_y_um_per_px": 0.2,
             }
         )
-        self.assertTrue(plugin._is_distance_above_threshold((0, 0), (10, 0), 1.5))
+        meets, _, _ = plugin._distance_meets_threshold((0, 0), (10, 0), 1.5)
+        self.assertTrue(meets)
 
         plugin.cp = SimpleNamespace(
             properties={
@@ -299,7 +300,8 @@ class AnisotropicDistanceConversionTests(SimpleTestCase):
                 "scale_y_um_per_px": 0.1,
             }
         )
-        self.assertFalse(plugin._is_distance_above_threshold((0, 0), (10, 0), 1.5))
+        meets, _, _ = plugin._distance_meets_threshold((0, 0), (10, 0), 1.5)
+        self.assertFalse(meets)
 
 
 class DVScaleMetadataParserTests(SimpleTestCase):

--- a/cytocv/templates/home.html
+++ b/cytocv/templates/home.html
@@ -606,8 +606,8 @@
                             <span>Measures opposite-channel intensity along the line drawn between paired puncta.</span>
                         </li>
                         <li>
-                            <strong>CEN dot classification and biorientation</strong>
-                            <span>Classifies Green-dot behavior relative to paired red signals in the modern workflow.</span>
+                            <strong>CEN dot location and biorientation</strong>
+                            <span>Classifies CEN-dot location as mother and/or daughter using the DIC-derived neck split, and evaluates biorientation when the paired red signals are too close to split.</span>
                         </li>
                         <li>
                             <strong>Green and red contour intensity summaries</strong>

--- a/cytocv/templates/pre_process.html
+++ b/cytocv/templates/pre_process.html
@@ -2296,7 +2296,7 @@
                   textEl.textContent = "Processing Images";
                 } else if (data.phase === "Detecting Cells") {
                   textEl.textContent = data.phase;
-                } else if (data.phase === "Segmenting Images") {
+                } else if (data.phase === "Segmenting Cell-Pairs") {
                   textEl.textContent = data.phase;
                 } else if (data.phase === "Calculating Statistics") {
                   // Only show statistics phase if user selected at least one analysis at upload step.

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,34 @@
+# CytoCV `systemd` Units
+
+These files are production-oriented example units for Linux hosts that run:
+
+- Gunicorn for the web process
+- a separate long-lived background analysis worker
+
+They are intentionally checked into the repository so redeployments do not
+depend on hand-recreated service files.
+
+## Usage
+
+1. Copy the desired unit file to `/etc/systemd/system/`.
+2. Replace `REPLACE_WITH_DEPLOY_USER` with the actual Linux user that owns the
+   checkout and virtual environment.
+3. Replace `/home/REPLACE_WITH_DEPLOY_USER/CytoCV/...` paths if the repository
+   lives elsewhere.
+4. Run:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable cytocv
+sudo systemctl enable cytocv-worker
+sudo systemctl restart cytocv
+sudo systemctl restart cytocv-worker
+```
+
+## Notes
+
+- The Django application reads `~/CytoCV/.env` directly, so these units do not
+  require an `EnvironmentFile=` entry just to load application settings.
+- Keep `CYTOCV_ANALYSIS_EXECUTION_MODE=worker` in the deployed `.env` when the
+  worker service is enabled.
+- Adjust Gunicorn worker count and timeout to match the deployment host.

--- a/deploy/systemd/cytocv-worker.service.example
+++ b/deploy/systemd/cytocv-worker.service.example
@@ -1,0 +1,15 @@
+[Unit]
+Description=CytoCV Analysis Worker
+After=network.target postgresql.service cytocv.service
+
+[Service]
+User=REPLACE_WITH_DEPLOY_USER
+Group=REPLACE_WITH_DEPLOY_USER
+WorkingDirectory=/home/REPLACE_WITH_DEPLOY_USER/CytoCV/cytocv
+Environment="PATH=/home/REPLACE_WITH_DEPLOY_USER/CytoCV/cyto_cv/bin"
+ExecStart=/home/REPLACE_WITH_DEPLOY_USER/CytoCV/cyto_cv/bin/python /home/REPLACE_WITH_DEPLOY_USER/CytoCV/cytocv/manage.py run_analysis_worker
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/cytocv.service.example
+++ b/deploy/systemd/cytocv.service.example
@@ -1,0 +1,15 @@
+[Unit]
+Description=CytoCV Gunicorn
+After=network.target postgresql.service
+
+[Service]
+User=REPLACE_WITH_DEPLOY_USER
+Group=REPLACE_WITH_DEPLOY_USER
+WorkingDirectory=/home/REPLACE_WITH_DEPLOY_USER/CytoCV/cytocv
+Environment="PATH=/home/REPLACE_WITH_DEPLOY_USER/CytoCV/cyto_cv/bin"
+ExecStart=/home/REPLACE_WITH_DEPLOY_USER/CytoCV/cyto_cv/bin/gunicorn --workers 5 --timeout 120 --bind 127.0.0.1:8000 cytocv.wsgi:application
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/ops/deployment-guide.md
+++ b/docs/ops/deployment-guide.md
@@ -51,6 +51,7 @@ Optional worker startup paths:
 - Docker Compose includes an optional `analysis-worker` service profile
 - local or server installs can run `python manage.py run_analysis_worker`
 - production should supervise the worker separately from Gunicorn
+- repo-owned example `systemd` units live under `deploy/systemd/`
 
 ## Application Startup Sequence
 
@@ -86,6 +87,14 @@ Example `systemd` service command:
 
 `/path/to/venv/bin/python /path/to/repo/cytocv/manage.py run_analysis_worker`
 
+Repository examples:
+
+- `deploy/systemd/cytocv.service.example`
+- `deploy/systemd/cytocv-worker.service.example`
+
+These example units should be copied to `/etc/systemd/system/` and adjusted for
+the actual deploy user and checkout path.
+
 Rollback guidance:
 
 - if the worker is unavailable, set `CYTOCV_ANALYSIS_EXECUTION_MODE=sync` and restart the web process to fall back to the legacy request-driven flow
@@ -112,4 +121,3 @@ After deployment:
 - [`environment-reference.md`](environment-reference.md)
 - [`postgres-setup.md`](postgres-setup.md)
 - [`backup-retention-and-storage.md`](backup-retention-and-storage.md)
-

--- a/docs/vm-deployment-guide/README.md
+++ b/docs/vm-deployment-guide/README.md
@@ -395,6 +395,14 @@ Important:
 
 ## 12. Create the Gunicorn `systemd` Service
 
+The repository now includes example units under:
+
+- `deploy/systemd/cytocv.service.example`
+- `deploy/systemd/cytocv-worker.service.example`
+
+You can either copy those files to `/etc/systemd/system/` and replace the
+deploy-user path placeholders, or create the service manually as shown below.
+
 Create the service file:
 
 ```bash
@@ -428,6 +436,46 @@ sudo systemctl daemon-reload
 sudo systemctl enable cytocv
 sudo systemctl start cytocv
 sudo systemctl status cytocv --no-pager
+```
+
+### Background Analysis Worker `systemd` Service
+
+Production worker mode also needs a second service so the queued analysis jobs
+survive logout and reboot.
+
+Create the worker file:
+
+```bash
+sudo nano /etc/systemd/system/cytocv-worker.service
+```
+
+Paste this:
+
+```ini
+[Unit]
+Description=CytoCV Analysis Worker
+After=network.target postgresql.service cytocv.service
+
+[Service]
+User=ngioanni
+Group=ngioanni
+WorkingDirectory=/home/NETID/ngioanni/CytoCV/cytocv
+Environment="PATH=/home/NETID/ngioanni/CytoCV/cyto_cv/bin"
+ExecStart=/home/NETID/ngioanni/CytoCV/cyto_cv/bin/python /home/NETID/ngioanni/CytoCV/cytocv/manage.py run_analysis_worker
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Then enable and start it:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable cytocv-worker
+sudo systemctl start cytocv-worker
+sudo systemctl status cytocv-worker --no-pager
 ```
 
 ## 13. Install and Configure Nginx
@@ -784,4 +832,3 @@ After the server is up:
 2. Lock provider settings to the production domain only.
 3. Finish SMTP configuration with UW IT.
 4. Confirm the VM or analysis host has AVX-capable CPU support before expecting image analysis to work.
-


### PR DESCRIPTION
This pull request introduces significant improvements to the CEN dot analysis logic and streamlines code related to contour overlays. The main changes include a major refactor and upgrade of the `CENDot` analysis, improved slot deduplication and assignment, enhanced error handling, and the use of a shared dashed polyline drawing utility. Additionally, minor documentation and dependency updates are included.

### CEN Dot Analysis Refactor and Improvements

* Refactored and modernized the `CENDot` analysis (`cen_dot.py`): introduced schema versioning, explicit slot deduplication, robust category assignment, and detailed status reporting in cell properties. The logic for associating red and green slots, handling side assignments, and error cases is now more explicit and reliable. [[1]](diffhunk://#diff-673c37dbbdbce7d31a4eba7f822196e3a16220570c6d1463058aa610f3c3440bR21-R33) [[2]](diffhunk://#diff-673c37dbbdbce7d31a4eba7f822196e3a16220570c6d1463058aa610f3c3440bR107-R162) [[3]](diffhunk://#diff-673c37dbbdbce7d31a4eba7f822196e3a16220570c6d1463058aa610f3c3440bL116-R252) [[4]](diffhunk://#diff-673c37dbbdbce7d31a4eba7f822196e3a16220570c6d1463058aa610f3c3440bR263-R381)
* Added new helper methods for deduplication (`_deduplicate_slots`), slot side assignment (`_assign_slot_side`), and mask intersection checks, improving modularity and testability.
* Updated the red/green slot classification to handle ambiguous and error cases with detailed status messages, and to store analysis metadata in cell properties. [[1]](diffhunk://#diff-673c37dbbdbce7d31a4eba7f822196e3a16220570c6d1463058aa610f3c3440bL116-R252) [[2]](diffhunk://#diff-673c37dbbdbce7d31a4eba7f822196e3a16220570c6d1463058aa610f3c3440bR263-R381)

### Visualization and Drawing Utilities

* Replaced the local dashed contour drawing implementation with a call to a shared utility function `draw_dashed_polyline` for consistency and maintainability. [[1]](diffhunk://#diff-c4441932788d895102f919f56f12a4f4d4455c180b67f2f776b26119fda57459R4) [[2]](diffhunk://#diff-c4441932788d895102f919f56f12a4f4d4455c180b67f2f776b26119fda57459L41-R53)
* Standardized dashed line parameters for overlays in nuclear cell pair intensity analysis, making them thinner and more consistent.

### Constants and Documentation

* Added new artifact constants (`PAIR_GEOMETRY_FILENAME`, `NECK_SPLIT_SUFFIX`) to support legacy and future processing steps.
* Updated the `README.md` to include a reference to example `systemd` units for deployment.
* Minor whitespace and formatting cleanup in documentation.

These changes collectively improve the robustness, clarity, and maintainability of the cell analysis codebase, especially for CEN dot classification and result reporting.