### PR TITLE
Align Mask R-CNN inference with Keras 3 and improve compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,15 @@
 __pycache__/
 db.sqlite3
 media/
-cytocv_venv/
 cyto_cv/
 .cytocv-local-install/
+
+# Local Python virtual environments
+.venv/
+venv/
+env/
+ENV/
+cytocv_venv*/
 
 # Neural network
 deepretina_final.h5

--- a/cytocv/core/mrcnn/bootstrap.py
+++ b/cytocv/core/mrcnn/bootstrap.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import os
+
+
+def configure_environment(*, cpu_only: bool = False) -> None:
+    """Set TensorFlow/Keras environment flags before importing ML libraries."""
+
+    os.environ.setdefault("KERAS_BACKEND", "tensorflow")
+    os.environ.setdefault("TF_ENABLE_ONEDNN_OPTS", "0")
+
+    if cpu_only:
+        os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
+        os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+
+__all__ = ["configure_environment"]

--- a/cytocv/core/mrcnn/hdf5_weights.py
+++ b/cytocv/core/mrcnn/hdf5_weights.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+import h5py
+import numpy as np
+
+
+def load_legacy_hdf5_weights(model, filepath, *, by_name: bool = False, exclude=None) -> None:
+    """Load legacy Keras `.h5` weights without TensorFlow private APIs."""
+
+    excluded_names = set(exclude or [])
+    target_model = model.inner_model if hasattr(model, "inner_model") else model
+
+    if exclude:
+        by_name = True
+
+    with h5py.File(filepath, mode="r") as handle:
+        weights_group = handle
+        if "layer_names" not in handle.attrs and "model_weights" in handle:
+            weights_group = handle["model_weights"]
+
+        if by_name:
+            _load_weights_by_name(weights_group, target_model, excluded_names)
+        else:
+            _load_weights_topological(weights_group, target_model, excluded_names)
+
+
+def _load_weights_topological(weights_group, model, excluded_names: set[str]) -> None:
+    filtered_layers = [
+        layer
+        for layer in model.layers
+        if _legacy_layer_weights(layer) and layer.name not in excluded_names
+    ]
+    filtered_layer_names = [
+        name
+        for name in _load_attributes_from_hdf5_group(weights_group, "layer_names")
+        if name in weights_group and _load_attributes_from_hdf5_group(weights_group[name], "weight_names")
+    ]
+
+    if len(filtered_layer_names) != len(filtered_layers):
+        raise ValueError(
+            "Layer count mismatch when loading weights from file. "
+            f"File has {len(filtered_layer_names)} weighted layer(s), "
+            f"model expects {len(filtered_layers)}."
+        )
+
+    for name, layer in zip(filtered_layer_names, filtered_layers):
+        saved_group = weights_group[name]
+        _assign_layer_weights(
+            layer,
+            weight_values=_load_subset_weights_from_hdf5_group(saved_group),
+        )
+
+    if "top_level_model_weights" in weights_group:
+        symbolic_weights = _legacy_model_weights(model)
+        weight_values = _load_subset_weights_from_hdf5_group(weights_group["top_level_model_weights"])
+        if len(weight_values) != len(symbolic_weights):
+            raise ValueError(
+                "Weight count mismatch for top-level weights when loading weights from file. "
+                f"Model expects {len(symbolic_weights)} top-level weight(s). "
+                f"File has {len(weight_values)}."
+            )
+        _assign_symbolic_weights(symbolic_weights, weight_values)
+
+
+def _load_weights_by_name(weights_group, model, excluded_names: set[str]) -> None:
+    index = defaultdict(list)
+    for layer in model.layers:
+        index[layer.name].append(layer)
+
+    for name in _load_attributes_from_hdf5_group(weights_group, "layer_names"):
+        if name not in weights_group or name in excluded_names:
+            continue
+        saved_group = weights_group[name]
+        weight_values = _load_subset_weights_from_hdf5_group(saved_group)
+        if not weight_values:
+            continue
+        for layer in index.get(name, []):
+            _assign_layer_weights(layer, weight_values=weight_values)
+
+
+def _assign_layer_weights(layer, *, weight_values: list[np.ndarray]) -> None:
+    symbolic_weights = _legacy_layer_weights(layer)
+    if len(weight_values) != len(symbolic_weights):
+        raise ValueError(
+            f"Weight count mismatch when loading layer '{layer.name}'. "
+            f"Layer expects {len(symbolic_weights)} weight(s). "
+            f"File has {len(weight_values)}."
+        )
+    _assign_symbolic_weights(symbolic_weights, weight_values)
+
+
+def _assign_symbolic_weights(symbolic_weights, weight_values: list[np.ndarray]) -> None:
+    for reference, value in zip(symbolic_weights, weight_values):
+        reference.assign(value)
+
+
+def _decode_attribute_value(value):
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return str(value)
+
+
+def _load_attributes_from_hdf5_group(group, name: str) -> list[str]:
+    values = []
+    if name in group.attrs:
+        values.extend(group.attrs[name])
+    else:
+        index = 0
+        while f"{name}{index}" in group.attrs:
+            values.extend(group.attrs[f"{name}{index}"])
+            index += 1
+    return [_decode_attribute_value(value) for value in values]
+
+
+def _legacy_model_weights(model) -> list[object]:
+    return list(model.trainable_weights) + list(model.non_trainable_weights)
+
+
+def _legacy_layer_weights(layer) -> list[object]:
+    return list(layer.trainable_weights) + list(layer.non_trainable_weights)
+
+
+def _load_subset_weights_from_hdf5_group(group) -> list[np.ndarray]:
+    return [
+        np.asarray(group[weight_name])
+        for weight_name in _load_attributes_from_hdf5_group(group, "weight_names")
+    ]
+
+
+__all__ = ["load_legacy_hdf5_weights"]

--- a/cytocv/core/mrcnn/inference_runtime.py
+++ b/cytocv/core/mrcnn/inference_runtime.py
@@ -8,10 +8,9 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
-os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
-os.environ["CUDA_VISIBLE_DEVICES"] = ""
-os.environ["KERAS_BACKEND"] = "tensorflow"
-os.environ.setdefault("TF_ENABLE_ONEDNN_OPTS", "0")
+from .bootstrap import configure_environment
+
+configure_environment(cpu_only=True)
 
 from core.mrcnn import config
 import core

--- a/cytocv/core/mrcnn/model.py
+++ b/cytocv/core/mrcnn/model.py
@@ -17,22 +17,23 @@ from collections import OrderedDict
 import multiprocessing
 import numpy as np
 import skimage.transform
-os.environ.setdefault("TF_ENABLE_ONEDNN_OPTS", "0")
+
+try:
+    from .bootstrap import configure_environment
+    from .hdf5_weights import load_legacy_hdf5_weights
+    from . import utils
+except ImportError:
+    from bootstrap import configure_environment
+    from hdf5_weights import load_legacy_hdf5_weights
+    import utils
+
+configure_environment()
+
 import tensorflow as tf
-import tensorflow.keras as keras
-
-# from keras import backend as K
-# from keras import layers as KL
-# # from keras.python import engine as KE
-# from keras import models as KM
-
-import tensorflow.keras.backend as K
-import tensorflow.keras.layers as KL
-import tensorflow.python.keras.engine as KE
-import tensorflow.keras.models as KM
-
-# from mrcnn import utils
-from . import utils
+import keras
+import keras.backend as K
+import keras.layers as KL
+import keras.models as KM
 
 # Requires TensorFlow 1.3+ and Keras 2.0.8+.
 from distutils.version import LooseVersion
@@ -44,15 +45,7 @@ def _resolve_keras_version():
 
     candidates = [
         getattr(keras, "__version__", None),
-        getattr(tf.keras, "__version__", None),
     ]
-    try:
-        import keras as standalone_keras
-
-        candidates.append(getattr(standalone_keras, "__version__", None))
-    except Exception:
-        pass
-    # As a safe fallback, use TF version (bundled tf.keras tracks TF release).
     candidates.append(getattr(tf, "__version__", None))
 
     for value in candidates:
@@ -940,8 +933,39 @@ def build_rpn_model(anchor_stride, anchors_per_location, depth):
 #  Feature Pyramid Network Heads
 ############################################################
 
+def _require_static_roi_count(inputs, context, *, fallback=None, fallback_value=None):
+    """Return the statically-known ROI count for one ROI head tensor."""
+
+    roi_count = inputs.shape[1]
+    if roi_count is None and fallback is not None:
+        roi_count = fallback.shape[1]
+    if roi_count is None and fallback_value is not None:
+        roi_count = fallback_value
+    if roi_count is None:
+        raise ValueError(f"{context} requires a statically-known ROI dimension.")
+    return int(roi_count)
+
+
+def _apply_roi_layer(inputs, layer, *, context, roi_count=None, **call_kwargs):
+    """Apply one layer across `[batch, rois, ...]` without `TimeDistributed`."""
+
+    input_shape = tuple(inputs.shape)
+    if roi_count is None:
+        roi_count = _require_static_roi_count(inputs, context)
+    child_input_shape = (None,) + tuple(input_shape[2:])
+    reshape_op = keras.ops.reshape if hasattr(keras, "ops") else tf.reshape
+    flattened_inputs = reshape_op(inputs, (-1,) + tuple(input_shape[2:]))
+    flattened_outputs = layer(flattened_inputs, **call_kwargs) if call_kwargs else layer(
+        flattened_inputs
+    )
+    child_output_shape = tuple(layer.compute_output_shape(child_input_shape))
+    restored_shape = (-1, roi_count) + tuple(child_output_shape[1:])
+    return reshape_op(flattened_outputs, restored_shape)
+
+
 def fpn_classifier_graph(rois, feature_maps, image_meta,
                          pool_size, num_classes, train_bn=True,
+                         roi_count=None,
                          fc_layers_size=1024):
     """Builds the computation graph of the feature pyramid network classifier
     and regressor heads.
@@ -966,43 +990,60 @@ def fpn_classifier_graph(rois, feature_maps, image_meta,
     # Shape: [batch, num_boxes, pool_height, pool_width, channels]
     x = PyramidROIAlign([pool_size, pool_size],
                         name="roi_align_classifier")([rois, image_meta] + feature_maps)
+    roi_count = _require_static_roi_count(
+        x,
+        "fpn_classifier_graph",
+        fallback=rois,
+        fallback_value=roi_count,
+    )
     # Two 1024 FC layers (implemented with Conv2D for consistency)
-    x = KL.TimeDistributed(KL.Conv2D(fc_layers_size, (pool_size, pool_size), padding="valid"),
-                           name="mrcnn_class_conv1")(x)
-    x = KL.TimeDistributed(BatchNorm(), name='mrcnn_class_bn1')(x, training=train_bn)
+    x = _apply_roi_layer(
+        x,
+        KL.Conv2D(fc_layers_size, (pool_size, pool_size), padding="valid", name="mrcnn_class_conv1"),
+        context="mrcnn_class_conv1",
+        roi_count=roi_count,
+    )
+    x = _apply_roi_layer(
+        x,
+        BatchNorm(name="mrcnn_class_bn1"),
+        context="mrcnn_class_bn1",
+        roi_count=roi_count,
+        training=train_bn,
+    )
     x = KL.Activation('relu')(x)
-    x = KL.TimeDistributed(KL.Conv2D(fc_layers_size, (1, 1)),
-                           name="mrcnn_class_conv2")(x)
-    x = KL.TimeDistributed(BatchNorm(), name='mrcnn_class_bn2')(x, training=train_bn)
+    x = _apply_roi_layer(
+        x,
+        KL.Conv2D(fc_layers_size, (1, 1), name="mrcnn_class_conv2"),
+        context="mrcnn_class_conv2",
+        roi_count=roi_count,
+    )
+    x = _apply_roi_layer(
+        x,
+        BatchNorm(name="mrcnn_class_bn2"),
+        context="mrcnn_class_bn2",
+        roi_count=roi_count,
+        training=train_bn,
+    )
     x = KL.Activation('relu')(x)
 
-    shared = KL.Lambda(lambda x: K.squeeze(K.squeeze(x, 3), 2),
-                       name="pool_squeeze")(x)
+    shared = KL.Reshape((roi_count, fc_layers_size), name="pool_squeeze")(x)
 
     # Classifier head
-    mrcnn_class_logits = KL.TimeDistributed(KL.Dense(num_classes),
-                                            name='mrcnn_class_logits')(shared)
-    mrcnn_probs = KL.TimeDistributed(KL.Activation("softmax"),
-                                     name="mrcnn_class")(mrcnn_class_logits)
+    mrcnn_class_logits = KL.Dense(num_classes, name='mrcnn_class_logits')(shared)
+    mrcnn_probs = KL.Activation("softmax", name="mrcnn_class")(mrcnn_class_logits)
 
     # BBox head
     # [batch, boxes, num_classes * (dy, dx, log(dh), log(dw))]
-    x = KL.TimeDistributed(KL.Dense(num_classes * 4, activation='linear'),
-                           name='mrcnn_bbox_fc')(shared)
+    x = KL.Dense(num_classes * 4, activation='linear', name='mrcnn_bbox_fc')(shared)
     # Reshape to [batch, boxes, num_classes, (dy, dx, log(dh), log(dw))]
-    s = K.int_shape(x)
-    #mrcnn_bbox = KL.Reshape((s[1], num_classes, 4), name="mrcnn_bbox")(x)
-    if s[1]==None:
-        mrcnn_bbox = KL.Reshape((-1, num_classes, 4), name="mrcnn_bbox")(x)
-    else:
-        mrcnn_bbox = KL.Reshape((s[1], num_classes, 4), name="mrcnn_bbox")(x)
-
+    mrcnn_bbox = KL.Reshape((roi_count, num_classes, 4), name="mrcnn_bbox")(x)
 
     return mrcnn_class_logits, mrcnn_probs, mrcnn_bbox
 
 
 def build_fpn_mask_graph(rois, feature_maps, image_meta,
-                         pool_size, num_classes, train_bn=True):
+                         pool_size, num_classes, train_bn=True,
+                         roi_count=None):
     """Builds the computation graph of the mask head of Feature Pyramid Network.
 
     rois: [batch, num_rois, (y1, x1, y2, x2)] Proposal boxes in normalized
@@ -1020,36 +1061,86 @@ def build_fpn_mask_graph(rois, feature_maps, image_meta,
     # Shape: [batch, boxes, pool_height, pool_width, channels]
     x = PyramidROIAlign([pool_size, pool_size],
                         name="roi_align_mask")([rois, image_meta] + feature_maps)
+    roi_count = _require_static_roi_count(
+        x,
+        "build_fpn_mask_graph",
+        fallback=rois,
+        fallback_value=roi_count,
+    )
 
     # Conv layers
-    x = KL.TimeDistributed(KL.Conv2D(256, (3, 3), padding="same"),
-                           name="mrcnn_mask_conv1")(x)
-    x = KL.TimeDistributed(BatchNorm(),
-                           name='mrcnn_mask_bn1')(x, training=train_bn)
+    x = _apply_roi_layer(
+        x,
+        KL.Conv2D(256, (3, 3), padding="same", name="mrcnn_mask_conv1"),
+        context="mrcnn_mask_conv1",
+        roi_count=roi_count,
+    )
+    x = _apply_roi_layer(
+        x,
+        BatchNorm(name='mrcnn_mask_bn1'),
+        context="mrcnn_mask_bn1",
+        roi_count=roi_count,
+        training=train_bn,
+    )
     x = KL.Activation('relu')(x)
 
-    x = KL.TimeDistributed(KL.Conv2D(256, (3, 3), padding="same"),
-                           name="mrcnn_mask_conv2")(x)
-    x = KL.TimeDistributed(BatchNorm(),
-                           name='mrcnn_mask_bn2')(x, training=train_bn)
+    x = _apply_roi_layer(
+        x,
+        KL.Conv2D(256, (3, 3), padding="same", name="mrcnn_mask_conv2"),
+        context="mrcnn_mask_conv2",
+        roi_count=roi_count,
+    )
+    x = _apply_roi_layer(
+        x,
+        BatchNorm(name='mrcnn_mask_bn2'),
+        context="mrcnn_mask_bn2",
+        roi_count=roi_count,
+        training=train_bn,
+    )
     x = KL.Activation('relu')(x)
 
-    x = KL.TimeDistributed(KL.Conv2D(256, (3, 3), padding="same"),
-                           name="mrcnn_mask_conv3")(x)
-    x = KL.TimeDistributed(BatchNorm(),
-                           name='mrcnn_mask_bn3')(x, training=train_bn)
+    x = _apply_roi_layer(
+        x,
+        KL.Conv2D(256, (3, 3), padding="same", name="mrcnn_mask_conv3"),
+        context="mrcnn_mask_conv3",
+        roi_count=roi_count,
+    )
+    x = _apply_roi_layer(
+        x,
+        BatchNorm(name='mrcnn_mask_bn3'),
+        context="mrcnn_mask_bn3",
+        roi_count=roi_count,
+        training=train_bn,
+    )
     x = KL.Activation('relu')(x)
 
-    x = KL.TimeDistributed(KL.Conv2D(256, (3, 3), padding="same"),
-                           name="mrcnn_mask_conv4")(x)
-    x = KL.TimeDistributed(BatchNorm(),
-                           name='mrcnn_mask_bn4')(x, training=train_bn)
+    x = _apply_roi_layer(
+        x,
+        KL.Conv2D(256, (3, 3), padding="same", name="mrcnn_mask_conv4"),
+        context="mrcnn_mask_conv4",
+        roi_count=roi_count,
+    )
+    x = _apply_roi_layer(
+        x,
+        BatchNorm(name='mrcnn_mask_bn4'),
+        context="mrcnn_mask_bn4",
+        roi_count=roi_count,
+        training=train_bn,
+    )
     x = KL.Activation('relu')(x)
 
-    x = KL.TimeDistributed(KL.Conv2DTranspose(256, (2, 2), strides=2, activation="relu"),
-                           name="mrcnn_mask_deconv")(x)
-    x = KL.TimeDistributed(KL.Conv2D(num_classes, (1, 1), strides=1, activation="sigmoid"),
-                           name="mrcnn_mask")(x)
+    x = _apply_roi_layer(
+        x,
+        KL.Conv2DTranspose(256, (2, 2), strides=2, activation="relu", name="mrcnn_mask_deconv"),
+        context="mrcnn_mask_deconv",
+        roi_count=roi_count,
+    )
+    x = _apply_roi_layer(
+        x,
+        KL.Conv2D(num_classes, (1, 1), strides=1, activation="sigmoid", name="mrcnn_mask"),
+        context="mrcnn_mask",
+        roi_count=roi_count,
+    )
     return x
 
 
@@ -2131,13 +2222,15 @@ class MaskRCNN():
                 fpn_classifier_graph(rois, mrcnn_feature_maps, input_image_meta,
                                      config.POOL_SIZE, config.NUM_CLASSES,
                                      train_bn=config.TRAIN_BN,
+                                     roi_count=config.TRAIN_ROIS_PER_IMAGE,
                                      fc_layers_size=config.FPN_CLASSIF_FC_LAYERS_SIZE)
 
             mrcnn_mask = build_fpn_mask_graph(rois, mrcnn_feature_maps,
                                               input_image_meta,
                                               config.MASK_POOL_SIZE,
                                               config.NUM_CLASSES,
-                                              train_bn=config.TRAIN_BN)
+                                              train_bn=config.TRAIN_BN,
+                                              roi_count=config.TRAIN_ROIS_PER_IMAGE)
 
             # TODO: clean up (use tf.identify if necessary)
             output_rois = KL.Lambda(lambda x: x * 1, name="output_rois")(rois)
@@ -2171,6 +2264,7 @@ class MaskRCNN():
                 fpn_classifier_graph(rpn_rois, mrcnn_feature_maps, input_image_meta,
                                      config.POOL_SIZE, config.NUM_CLASSES,
                                      train_bn=config.TRAIN_BN,
+                                     roi_count=config.POST_NMS_ROIS_INFERENCE,
                                      fc_layers_size=config.FPN_CLASSIF_FC_LAYERS_SIZE)
 
             # Detections
@@ -2185,7 +2279,8 @@ class MaskRCNN():
                                               input_image_meta,
                                               config.MASK_POOL_SIZE,
                                               config.NUM_CLASSES,
-                                              train_bn=config.TRAIN_BN)
+                                              train_bn=config.TRAIN_BN,
+                                              roi_count=config.DETECTION_MAX_INSTANCES)
 
             model = KM.Model([input_image, input_image_meta, input_anchors],
                              [detections, mrcnn_class, mrcnn_bbox,
@@ -2234,34 +2329,12 @@ class MaskRCNN():
         some layers from loading.
         exlude: list of layer names to excluce
         """
-        import h5py
-        from tensorflow.python.keras import saving as topology
-
-        if exclude:
-            by_name = True
-
-        if h5py is None:
-            raise ImportError('`load_weights` requires h5py.')
-        f = h5py.File(filepath, mode='r')
-        if 'layer_names' not in f.attrs and 'model_weights' in f:
-            f = f['model_weights']
-
-        # In multi-GPU training, we wrap the model. Get layers
-        # of the inner model because they have the weights.
-        keras_model = self.keras_model
-        layers = keras_model.inner_model.layers if hasattr(keras_model, "inner_model")\
-            else keras_model.layers
-
-        # Exclude some layers
-        if exclude:
-            layers = filter(lambda l: l.name not in exclude, layers)
-
-        if by_name:
-            topology.hdf5_format.load_weights_from_hdf5_group_by_name(f, layers)
-        else:
-            topology.hdf5_format.load_weights_from_hdf5_group(f, layers)
-        if hasattr(f, 'close'):
-            f.close()
+        load_legacy_hdf5_weights(
+            self.keras_model,
+            filepath,
+            by_name=by_name,
+            exclude=exclude,
+        )
 
         # Update the log directory
         self.set_log_dir(filepath)
@@ -2270,7 +2343,7 @@ class MaskRCNN():
         """Downloads ImageNet trained weights from Keras.
         Returns path to weights file.
         """
-        from tensorflow.keras.utils import get_file
+        from keras.utils import get_file
         TF_WEIGHTS_PATH_NO_TOP = 'https://github.com/fchollet/deep-learning-models/'\
                                  'releases/download/v0.2/'\
                                  'resnet50_weights_tf_dim_ordering_tf_kernels_notop.h5'
@@ -2805,11 +2878,7 @@ class MaskRCNN():
         for o in outputs.values():
             assert o is not None
 
-        # Build a Keras function to run parts of the computation graph
-        inputs = model.inputs
-        if model.uses_learning_phase and not isinstance(K.learning_phase(), int):
-            inputs += [K.learning_phase()]
-        kf = K.function(model.inputs, list(outputs.values()))
+        debug_model = KM.Model(model.inputs, list(outputs.values()))
 
         # Prepare inputs
         if image_metas is None:
@@ -2824,10 +2893,9 @@ class MaskRCNN():
         anchors = np.broadcast_to(anchors, (self.config.BATCH_SIZE,) + anchors.shape)
         model_in = [molded_images, image_metas, anchors]
 
-        # Run inference
-        if model.uses_learning_phase and not isinstance(K.learning_phase(), int):
-            model_in.append(0.)
-        outputs_np = kf(model_in)
+        outputs_np = debug_model.predict(model_in, verbose=0)
+        if not isinstance(outputs_np, list):
+            outputs_np = [outputs_np]
 
         # Pack the generated Numpy arrays into a a dict and log the results.
         outputs_np = OrderedDict([(k, v)

--- a/cytocv/core/mrcnn/utils.py
+++ b/cytocv/core/mrcnn/utils.py
@@ -198,8 +198,8 @@ def box_refinement_graph(box, gt_box):
 
     dy = (gt_center_y - center_y) / height
     dx = (gt_center_x - center_x) / width
-    dh = tf.log(gt_height / height)
-    dw = tf.log(gt_width / width)
+    dh = tf.math.log(gt_height / height)
+    dw = tf.math.log(gt_width / width)
 
     result = tf.stack([dy, dx, dh, dw], axis=1)
     return result

--- a/cytocv/core/tests/test_mrcnn_inference.py
+++ b/cytocv/core/tests/test_mrcnn_inference.py
@@ -1,12 +1,14 @@
 ﻿from __future__ import annotations
 
 import threading
+import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import cv2
+import keras
 import numpy as np
 from django.test import SimpleTestCase
 from PIL import Image
@@ -14,6 +16,7 @@ from PIL import Image
 from core.mrcnn.inference_runtime import (
     InferenceRuntimeKey,
     _resolve_runtime_cache_key,
+    _resolve_weights_path,
     clear_inference_runtime_cache,
     get_inference_runtime,
 )
@@ -87,6 +90,80 @@ class InferenceRuntimeCacheTests(SimpleTestCase):
         self.assertEqual(
             [call.args[0] for call in build_runtime.call_args_list],
             [first_key, second_key],
+        )
+
+
+class InferenceGraphSmokeTests(SimpleTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        try:
+            _resolve_weights_path()
+        except FileNotFoundError as exc:
+            raise unittest.SkipTest(str(exc))
+        cls.runtime = get_inference_runtime()
+
+    @classmethod
+    def tearDownClass(cls):
+        clear_inference_runtime_cache()
+        super().tearDownClass()
+
+    def test_detect_runs_real_keras_graph_on_zero_image(self):
+        image = np.zeros((512, 512, 3), dtype=np.uint8)
+
+        results = self.runtime.model.detect([image], verbose=0)
+
+        self.assertEqual(len(results), 1)
+        result = results[0]
+        self.assertEqual(set(result.keys()), {"rois", "class_ids", "scores", "masks"})
+        self.assertEqual(result["rois"].shape[1:], (4,))
+        self.assertEqual(result["class_ids"].ndim, 1)
+        self.assertEqual(result["scores"].ndim, 1)
+        self.assertEqual(result["masks"].shape[:2], image.shape[:2])
+        self.assertEqual(result["masks"].shape[2], result["class_ids"].shape[0])
+        self.assertEqual(result["scores"].shape[0], result["class_ids"].shape[0])
+
+    def test_classifier_head_probe_runs_past_first_roi_conv(self):
+        runtime_model = self.runtime.model
+        keras_model = runtime_model.keras_model
+        probe_model = keras.Model(
+            keras_model.inputs,
+            [
+                keras_model.get_layer("roi_align_classifier").output,
+                keras_model.get_layer("mrcnn_class_conv1").output,
+            ],
+        )
+        image = np.zeros((512, 512, 3), dtype=np.uint8)
+        molded_images, image_metas, _ = runtime_model.mold_inputs([image])
+        anchors = runtime_model.get_anchors(molded_images[0].shape)
+        anchors = np.broadcast_to(
+            anchors,
+            (runtime_model.config.BATCH_SIZE,) + anchors.shape,
+        )
+
+        roi_align_output, conv1_output = probe_model.predict(
+            [molded_images, image_metas, anchors],
+            verbose=0,
+        )
+
+        self.assertEqual(
+            roi_align_output.shape,
+            (
+                runtime_model.config.BATCH_SIZE,
+                runtime_model.config.POST_NMS_ROIS_INFERENCE,
+                7,
+                7,
+                256,
+            ),
+        )
+        self.assertEqual(
+            conv1_output.shape,
+            (
+                runtime_model.config.POST_NMS_ROIS_INFERENCE,
+                1,
+                1,
+                runtime_model.config.FPN_CLASSIF_FC_LAYERS_SIZE,
+            ),
         )
 
 


### PR DESCRIPTION
This pull request modernizes and refactors the Mask R-CNN codebase to improve compatibility with recent Keras/TensorFlow versions, simplify environment setup, and remove deprecated or private API usage. Key improvements include centralizing environment configuration, updating weight loading to avoid TensorFlow private APIs, and generalizing the ROI head architecture for better flexibility and maintainability.

**Environment and Dependency Handling:**
- Centralized all ML environment variable setup into a new `configure_environment` function in `bootstrap.py`, which is now called from all entry points to ensure consistent configuration [[1]](diffhunk://#diff-a254887fe37ffabe6c57c19ca0d1ae71b37b4e0e95366d61a00ab86d077bf8d5R1-R17) [[2]](diffhunk://#diff-dd77a9fb7e9a4783d7ffab8bf4dedd6ad6c4ec05532a16514b66cf0eb07a9e78L11-R13) [[3]](diffhunk://#diff-03fd8ef755feb14ad0ff5b7a2344a40d638ee294e1af47745e43843ddd45362aL20-R36).

**Legacy Weight Loading Refactor:**
- Introduced `load_legacy_hdf5_weights` in `hdf5_weights.py` to replace direct use of TensorFlow private APIs for loading `.h5` weights, improving forward compatibility and code clarity [[1]](diffhunk://#diff-9c85c2a4f683f7cf97a9570c9d5db1e3766ee66472369f91dee359529d75e85aR1-R132) [[2]](diffhunk://#diff-03fd8ef755feb14ad0ff5b7a2344a40d638ee294e1af47745e43843ddd45362aL2237-R2337).

**Keras/TensorFlow API Modernization:**
- Updated imports to use the public `keras` package instead of `tensorflow.keras`, and replaced deprecated or private API calls throughout `model.py` [[1]](diffhunk://#diff-03fd8ef755feb14ad0ff5b7a2344a40d638ee294e1af47745e43843ddd45362aL20-R36) [[2]](diffhunk://#diff-03fd8ef755feb14ad0ff5b7a2344a40d638ee294e1af47745e43843ddd45362aL2237-R2337) [[3]](diffhunk://#diff-03fd8ef755feb14ad0ff5b7a2344a40d638ee294e1af47745e43843ddd45362aL2273-R2346).
- Changed the ImageNet weights utility to use `keras.utils.get_file`.

**ROI Head Generalization and Refactor:**
- Replaced all uses of `TimeDistributed` with new `_apply_roi_layer` and `_require_static_roi_count` utilities, allowing for more robust and flexible handling of ROI-based operations in both classifier and mask heads [[1]](diffhunk://#diff-03fd8ef755feb14ad0ff5b7a2344a40d638ee294e1af47745e43843ddd45362aR936-R968) [[2]](diffhunk://#diff-03fd8ef755feb14ad0ff5b7a2344a40d638ee294e1af47745e43843ddd45362aR993-R1046) [[3]](diffhunk://#diff-03fd8ef755feb14ad0ff5b7a2344a40d638ee294e1af47745e43843ddd45362aR1064-R1143).
- Updated model building code to pass explicit `roi_count` parameters based on configuration, ensuring that all ROI layers have statically-known dimensions [[1]](diffhunk://#diff-03fd8ef755feb14ad0ff5b7a2344a40d638ee294e1af47745e43843ddd45362aR2225-R2233) [[2]](diffhunk://#diff-03fd8ef755feb14ad0ff5b7a2344a40d638ee294e1af47745e43843ddd45362aR2267) [[3]](diffhunk://#diff-03fd8ef755feb14ad0ff5b7a2344a40d638ee294e1af47745e43843ddd45362aL2188-R2283).

**Model Debugging and Inference Improvements:**
- Simplified the `run_graph` method to use a standard Keras model for inference instead of a custom Keras function, improving compatibility and maintainability [[1]](diffhunk://#diff-03fd8ef755feb14ad0ff5b7a2344a40d638ee294e1af47745e43843ddd45362aL2808-R2881) [[2]](diffhunk://#diff-03fd8ef755feb14ad0ff5b7a2344a40d638ee294e1af47745e43843ddd45362aL2827-R2898).

These changes collectively improve the maintainability, forward compatibility, and clarity of the codebase, particularly for users working with modern Keras and TensorFlow environments.