### PR TITLE
Enhance green dot contour splitting and save experiment defaults

### DIFF
--- a/cytocv/accounts/preferences.py
+++ b/cytocv/accounts/preferences.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import math
 from typing import Any
 
 from core.channel_roles import CHANNEL_ROLE_ORDER
@@ -14,11 +15,21 @@ from core.services.green_dot_split import (
     DEFAULT_GREEN_DOT_SPLIT_MODE,
     normalize_green_dot_split_mode,
 )
-from core.stats_plugins import CHANNEL_ORDER, normalize_selected_plugins
+from core.stats_plugins import (
+    ALWAYS_REQUIRED_CHANNELS,
+    CHANNEL_ORDER,
+    PLUGIN_DEFINITIONS,
+    PLUGIN_ID_ALIASES,
+    normalize_selected_plugins,
+)
 
 NUCLEAR_CELL_PAIR_MODES = {"green_nucleus", "red_nucleus"}
 LENGTH_UNITS = {"px", "um"}
 DEFAULT_MICRONS_PER_PIXEL = 0.1
+
+
+class PreferenceValidationError(ValueError):
+    """Raised when an interactive preference payload is invalid."""
 
 DEFAULT_USER_PREFERENCES: dict[str, Any] = {
     "experiment_defaults": {
@@ -100,6 +111,61 @@ def _normalize_unit(value: Any, default: str) -> str:
     if unit not in LENGTH_UNITS:
         return default
     return unit
+
+
+def _strict_bool(value: Any, *, field: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in {0, 1}:
+        return bool(value)
+    if isinstance(value, float) and value in {0.0, 1.0}:
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise PreferenceValidationError(f"{field} must be a boolean.")
+
+
+def _strict_float(value: Any, *, field: str, minimum: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        raise PreferenceValidationError(f"{field} must be a number.") from None
+    if not math.isfinite(parsed) or parsed < minimum:
+        raise PreferenceValidationError(f"{field} must be at least {minimum}.")
+    return parsed
+
+
+def _strict_int(value: Any, *, field: str, minimum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise PreferenceValidationError(f"{field} must be an integer.") from None
+    if parsed < minimum:
+        raise PreferenceValidationError(f"{field} must be at least {minimum}.")
+    return parsed
+
+
+def _strict_unit(value: Any, *, field: str) -> str:
+    unit = str(value or "").strip().lower()
+    if unit not in LENGTH_UNITS:
+        raise PreferenceValidationError(f"{field} must be 'px' or 'um'.")
+    return unit
+
+
+def _strict_mode(
+    value: Any,
+    *,
+    field: str,
+    allowed: set[str],
+) -> str:
+    mode = str(value or "").strip()
+    if mode not in allowed:
+        raise PreferenceValidationError(f"{field} is invalid.")
+    return mode
 
 
 def _first_present(*values: Any) -> Any:
@@ -305,6 +371,238 @@ def normalize_preferences_payload(raw_payload: Any) -> dict[str, Any]:
         default=normalized["experiment_defaults"]["spatial_stats_unit"],
     )
     return normalized
+
+
+def build_experiment_defaults_from_popup_payload(
+    raw_payload: Any,
+    *,
+    current_defaults: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Validate experiment-popup JSON and return normalized experiment defaults."""
+
+    if not isinstance(raw_payload, dict):
+        raise PreferenceValidationError("Request body must be a JSON object.")
+
+    allowed_fields = {
+        "selected_plugins",
+        "module_enabled",
+        "enforce_layer_count",
+        "enforce_wavelengths",
+        "show_legacy_plugins",
+        "manual_required_channels",
+        "green_contour_filter_enabled",
+        "green_dot_split_enabled",
+        "green_dot_split_mode",
+        "alternate_red_detection",
+        "puncta_line_width",
+        "puncta_line_width_unit",
+        "cen_dot_distance",
+        "cen_dot_distance_unit",
+        "cen_dot_proximity_radius",
+        "cen_dot_proximity_radius_unit",
+        "biorientation_red_min_distance",
+        "biorientation_red_min_distance_unit",
+        "biorientation_red_max_distance",
+        "biorientation_red_max_distance_unit",
+        "biorientation_collinearity_threshold",
+        "puncta_line_mode",
+        "nuclear_cell_pair_mode",
+        "microns_per_pixel",
+        "use_metadata_scale",
+    }
+    unknown_fields = sorted(set(raw_payload.keys()) - allowed_fields)
+    if unknown_fields:
+        raise PreferenceValidationError(
+            f"Unknown workflow-default fields: {', '.join(unknown_fields)}."
+        )
+
+    current = normalize_preferences_payload(
+        {"experiment_defaults": current_defaults or {}}
+    )["experiment_defaults"]
+
+    raw_selected_plugins = raw_payload.get("selected_plugins")
+    if not isinstance(raw_selected_plugins, list):
+        raise PreferenceValidationError("selected_plugins must be a list.")
+    resolved_plugins: list[str] = []
+    exclusive_groups: dict[str, str] = {}
+    for raw_plugin in raw_selected_plugins:
+        if not isinstance(raw_plugin, str):
+            raise PreferenceValidationError("selected_plugins must contain strings.")
+        plugin_id = PLUGIN_ID_ALIASES.get(raw_plugin.strip(), raw_plugin.strip())
+        if plugin_id not in PLUGIN_DEFINITIONS:
+            raise PreferenceValidationError(f"Unknown plugin ID: {raw_plugin}.")
+        definition = PLUGIN_DEFINITIONS[plugin_id]
+        if definition.exclusive_group:
+            existing = exclusive_groups.get(definition.exclusive_group)
+            if existing and existing != plugin_id:
+                raise PreferenceValidationError(
+                    "Only one plugin can be selected in each exclusive group."
+                )
+            exclusive_groups[definition.exclusive_group] = plugin_id
+        resolved_plugins.append(plugin_id)
+    selected_plugins = normalize_selected_plugins(resolved_plugins)
+
+    raw_manual_channels = raw_payload.get("manual_required_channels")
+    if not isinstance(raw_manual_channels, list):
+        raise PreferenceValidationError("manual_required_channels must be a list.")
+    manual_required_channels: list[str] = []
+    seen_channels: set[str] = set()
+    for raw_channel in raw_manual_channels:
+        if not isinstance(raw_channel, str):
+            raise PreferenceValidationError(
+                "manual_required_channels must contain strings."
+            )
+        channel = raw_channel.strip()
+        if channel not in CHANNEL_ORDER or channel in ALWAYS_REQUIRED_CHANNELS:
+            raise PreferenceValidationError(
+                f"manual_required_channels contains an invalid channel: {raw_channel}."
+            )
+        if channel in seen_channels:
+            continue
+        seen_channels.add(channel)
+        manual_required_channels.append(channel)
+
+    puncta_line_width_unit = _strict_unit(
+        raw_payload.get("puncta_line_width_unit"),
+        field="puncta_line_width_unit",
+    )
+    cen_dot_distance_unit = _strict_unit(
+        raw_payload.get("cen_dot_distance_unit"),
+        field="cen_dot_distance_unit",
+    )
+    cen_dot_proximity_radius_unit = _strict_unit(
+        raw_payload.get("cen_dot_proximity_radius_unit"),
+        field="cen_dot_proximity_radius_unit",
+    )
+    biorientation_red_min_distance_unit = _strict_unit(
+        raw_payload.get("biorientation_red_min_distance_unit"),
+        field="biorientation_red_min_distance_unit",
+    )
+    biorientation_red_max_distance_unit = _strict_unit(
+        raw_payload.get("biorientation_red_max_distance_unit"),
+        field="biorientation_red_max_distance_unit",
+    )
+
+    puncta_line_width_minimum = 1.0 if puncta_line_width_unit == "px" else 0.01
+    puncta_line_width = _strict_float(
+        raw_payload.get("puncta_line_width"),
+        field="puncta_line_width",
+        minimum=puncta_line_width_minimum,
+    )
+    cen_dot_distance = _strict_float(
+        raw_payload.get("cen_dot_distance"),
+        field="cen_dot_distance",
+        minimum=0.0,
+    )
+    cen_dot_proximity_radius = _strict_float(
+        raw_payload.get("cen_dot_proximity_radius"),
+        field="cen_dot_proximity_radius",
+        minimum=0.0,
+    )
+    biorientation_red_min_distance = _strict_float(
+        raw_payload.get("biorientation_red_min_distance"),
+        field="biorientation_red_min_distance",
+        minimum=0.0,
+    )
+    biorientation_red_max_distance = _strict_float(
+        raw_payload.get("biorientation_red_max_distance"),
+        field="biorientation_red_max_distance",
+        minimum=0.0,
+    )
+    biorientation_collinearity_threshold = _strict_int(
+        raw_payload.get("biorientation_collinearity_threshold"),
+        field="biorientation_collinearity_threshold",
+        minimum=0,
+    )
+    microns_per_pixel = _strict_float(
+        raw_payload.get("microns_per_pixel"),
+        field="microns_per_pixel",
+        minimum=0.0001,
+    )
+
+    puncta_line_mode = _strict_mode(
+        raw_payload.get("puncta_line_mode"),
+        field="puncta_line_mode",
+        allowed={"red_puncta", "green_puncta"},
+    )
+    nuclear_cell_pair_mode = _strict_mode(
+        raw_payload.get("nuclear_cell_pair_mode"),
+        field="nuclear_cell_pair_mode",
+        allowed=NUCLEAR_CELL_PAIR_MODES,
+    )
+    green_dot_split_mode = _strict_mode(
+        raw_payload.get("green_dot_split_mode"),
+        field="green_dot_split_mode",
+        allowed={"balanced", "aggressive"},
+    )
+
+    show_legacy_plugins = _strict_bool(
+        raw_payload.get("show_legacy_plugins"),
+        field="show_legacy_plugins",
+    )
+    if not show_legacy_plugins:
+        legacy_plugins = [
+            plugin_id
+            for plugin_id in selected_plugins
+            if PLUGIN_DEFINITIONS[plugin_id].is_legacy
+        ]
+        if legacy_plugins:
+            raise PreferenceValidationError(
+                "Legacy plugins can only be saved when show_legacy_plugins is enabled."
+            )
+
+    next_defaults = dict(current)
+    next_defaults.update(
+        {
+            "selected_plugins": selected_plugins,
+            "module_enabled": _strict_bool(
+                raw_payload.get("module_enabled"),
+                field="module_enabled",
+            ),
+            "enforce_layer_count": _strict_bool(
+                raw_payload.get("enforce_layer_count"),
+                field="enforce_layer_count",
+            ),
+            "enforce_wavelengths": _strict_bool(
+                raw_payload.get("enforce_wavelengths"),
+                field="enforce_wavelengths",
+            ),
+            "show_legacy_plugins": show_legacy_plugins,
+            "manual_required_channels": manual_required_channels,
+            "green_contour_filter_enabled": _strict_bool(
+                raw_payload.get("green_contour_filter_enabled"),
+                field="green_contour_filter_enabled",
+            ),
+            "green_dot_split_enabled": _strict_bool(
+                raw_payload.get("green_dot_split_enabled"),
+                field="green_dot_split_enabled",
+            ),
+            "green_dot_split_mode": green_dot_split_mode,
+            "alternate_red_detection": _strict_bool(
+                raw_payload.get("alternate_red_detection"),
+                field="alternate_red_detection",
+            ),
+            "puncta_line_width": puncta_line_width,
+            "puncta_line_width_unit": puncta_line_width_unit,
+            "cen_dot_distance": cen_dot_distance,
+            "cen_dot_distance_unit": cen_dot_distance_unit,
+            "cen_dot_proximity_radius": cen_dot_proximity_radius,
+            "cen_dot_proximity_radius_unit": cen_dot_proximity_radius_unit,
+            "biorientation_red_min_distance": biorientation_red_min_distance,
+            "biorientation_red_min_distance_unit": biorientation_red_min_distance_unit,
+            "biorientation_red_max_distance": biorientation_red_max_distance,
+            "biorientation_red_max_distance_unit": biorientation_red_max_distance_unit,
+            "biorientation_collinearity_threshold": biorientation_collinearity_threshold,
+            "puncta_line_mode": puncta_line_mode,
+            "nuclear_cell_pair_mode": nuclear_cell_pair_mode,
+            "microns_per_pixel": microns_per_pixel,
+            "use_metadata_scale": _strict_bool(
+                raw_payload.get("use_metadata_scale"),
+                field="use_metadata_scale",
+            ),
+        }
+    )
+    return next_defaults
 
 
 def get_user_preferences(user: Any) -> dict[str, Any]:

--- a/cytocv/core/contour_processing/contour_operations.py
+++ b/cytocv/core/contour_processing/contour_operations.py
@@ -2,6 +2,7 @@ import cv2
 import math
 import numpy as np
 import logging
+from dataclasses import dataclass
 from scipy import ndimage as ndi
 from skimage.feature import peak_local_max
 from skimage.segmentation import find_boundaries, watershed
@@ -17,53 +18,624 @@ logger = logging.getLogger(__name__)
 
 GREEN_DOT_SPLIT_PARAMS = {
     "balanced": {
+        "min_original_area_px": 14,
         "min_peak_distance": 3,
-        "min_peak_ratio": 0.40,
+        "min_peak_ratio": 0.42,
+        "min_intensity_peak_ratio": 0.42,
+        "min_second_peak_ratio": 0.50,
+        "max_intensity_valley_ratio": 0.82,
+        "max_distance_valley_ratio": 0.86,
         "min_defect_depth_px": 1.0,
-        "min_split_circularity": 0.30,
+        "min_relative_defect_depth": 0.10,
+        "max_neck_width_ratio": 0.84,
+        "min_chord_mask_fraction": 0.72,
+        "max_single_dot_circularity": 0.84,
+        "min_single_dot_solidity": 0.96,
+        "max_single_dot_aspect_ratio": 1.28,
+        "min_suspicious_aspect_ratio": 1.18,
+        "max_suspicious_circularity": 0.74,
+        "max_suspicious_solidity": 0.96,
+        "min_split_circularity": 0.22,
+        "min_split_solidity": 0.72,
         "min_split_area_px": 8,
+        "min_child_area_fraction": 0.16,
+        "min_combined_area_ratio": 0.72,
+        "min_child_center_distance_px": 3.0,
+        "max_child_aspect_ratio": 3.2,
+        "min_child_peak_ratio": 0.38,
+        "max_neck_alignment_cos": 0.78,
+        "neck_cut_line_thickness": 1,
+        "asymmetric_fallback_enabled": False,
     },
     "aggressive": {
+        "min_original_area_px": 10,
         "min_peak_distance": 2,
-        "min_peak_ratio": 0.30,
-        "min_defect_depth_px": 0.5,
-        "min_split_circularity": 0.30,
-        "min_split_area_px": 8,
+        "min_peak_ratio": 0.25,
+        "min_intensity_peak_ratio": 0.28,
+        "min_second_peak_ratio": 0.32,
+        "max_intensity_valley_ratio": 0.92,
+        "max_distance_valley_ratio": 0.94,
+        "min_defect_depth_px": 0.45,
+        "min_relative_defect_depth": 0.07,
+        "max_neck_width_ratio": 0.94,
+        "min_chord_mask_fraction": 0.58,
+        "max_single_dot_circularity": 0.90,
+        "min_single_dot_solidity": 0.985,
+        "max_single_dot_aspect_ratio": 1.18,
+        "min_suspicious_aspect_ratio": 1.08,
+        "max_suspicious_circularity": 0.84,
+        "max_suspicious_solidity": 0.985,
+        "min_split_circularity": 0.16,
+        "min_split_solidity": 0.58,
+        "min_split_area_px": 6,
+        "min_child_area_fraction": 0.10,
+        "min_combined_area_ratio": 0.66,
+        "min_child_center_distance_px": 2.0,
+        "max_child_aspect_ratio": 4.0,
+        "min_child_peak_ratio": 0.25,
+        "max_neck_alignment_cos": 0.88,
+        "neck_cut_line_thickness": 1,
+        "asymmetric_fallback_enabled": True,
+        "asymmetric_min_peak_distance_px": 4.0,
+        "asymmetric_min_second_peak_ratio": 0.32,
+        "asymmetric_max_intensity_valley_ratio": 0.88,
+        "asymmetric_min_intensity_drop_ratio": 0.10,
+        "asymmetric_max_distance_saddle_ratio": 0.88,
+        "asymmetric_min_peak_line_mask_fraction": 0.80,
+        "asymmetric_min_single_defect_depth_px": 0.75,
+        "asymmetric_max_saddle_to_defect_distance_px": 8.0,
+        "asymmetric_min_child_area_fraction": 0.16,
+        "asymmetric_min_child_mean_ratio": 0.16,
+        "asymmetric_min_boundary_low_signal_fraction": 0.55,
+        "asymmetric_max_boundary_saddle_distance_px": 6.0,
     },
 }
 
+MAX_DEFECT_CANDIDATES = 8
+MAX_PEAK_CANDIDATES = 8
+PROFILE_SAMPLE_COUNT = 48
 
-def _component_has_neck_defect(
-    component: np.ndarray,
-    *,
-    min_defect_depth_px: float,
-) -> bool:
-    contours, _ = cv2.findContours(
-        (component.astype(np.uint8) * 255),
-        cv2.RETR_EXTERNAL,
-        cv2.CHAIN_APPROX_NONE,
-    )
+
+@dataclass(slots=True)
+class _ContourShapeMetrics:
+    contour: np.ndarray
+    mask: np.ndarray
+    area: float
+    pixel_area: int
+    perimeter: float
+    circularity: float
+    aspect_ratio: float
+    solidity: float
+    hull_area: float
+    centroid: tuple[float, float]
+    lobe_width_px: float
+    deep_defect_count: int
+    max_defect_depth_px: float
+
+
+@dataclass(slots=True)
+class _NeckCandidate:
+    point_a: tuple[int, int]
+    point_b: tuple[int, int]
+    width_px: float
+    neck_ratio: float
+    depth_a_px: float
+    depth_b_px: float
+    chord_mask_fraction: float
+    score: float
+
+
+@dataclass(slots=True)
+class _Peak:
+    x: int
+    y: int
+    value: float
+
+    @property
+    def point(self) -> tuple[int, int]:
+        return self.x, self.y
+
+
+@dataclass(slots=True)
+class _PeakPair:
+    peak_a: _Peak
+    peak_b: _Peak
+    distance_px: float
+    valley_value: float
+    valley_ratio: float
+    second_peak_ratio: float
+    score: float
+
+
+@dataclass(slots=True)
+class _SingleDefectCandidate:
+    point: tuple[int, int]
+    depth_px: float
+    score: float
+
+
+@dataclass(slots=True)
+class _SaddleMetrics:
+    point: tuple[int, int]
+    intensity_valley_ratio: float
+    intensity_drop_ratio: float
+    distance_saddle_ratio: float
+
+
+@dataclass(slots=True)
+class _AsymmetricSplitCandidate:
+    peak_pair: _PeakPair
+    saddle: _SaddleMetrics
+    single_defect: _SingleDefectCandidate | None
+    score: float
+
+
+def _split_params(split_mode: str) -> dict:
+    mode = normalize_green_dot_split_mode(split_mode)
+    return GREEN_DOT_SPLIT_PARAMS[mode]
+
+
+def contour_to_mask(contour: np.ndarray, shape: tuple[int, int] | tuple[int, int, int]) -> np.ndarray:
+    """Return a filled binary mask for one contour in image coordinates."""
+
+    height, width = int(shape[0]), int(shape[1])
+    mask = np.zeros((height, width), dtype=np.uint8)
+    if contour is not None and len(contour) >= 3:
+        cv2.drawContours(mask, [contour], -1, 255, thickness=-1)
+    return mask
+
+
+def _dense_outer_contour(mask: np.ndarray) -> np.ndarray | None:
+    contours, _ = cv2.findContours(mask.copy(), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
     if not contours:
-        return False
+        return None
+    return max(contours, key=cv2.contourArea)
 
-    contour = max(contours, key=cv2.contourArea)
-    if len(contour) < 4:
-        return False
 
+def _contour_center_from_mask(mask: np.ndarray) -> tuple[float, float]:
+    moment = cv2.moments(mask, binaryImage=True)
+    if moment["m00"] != 0:
+        return (moment["m10"] / moment["m00"], moment["m01"] / moment["m00"])
+    points = np.column_stack(np.nonzero(mask))
+    if points.size == 0:
+        return (0.0, 0.0)
+    return (float(np.mean(points[:, 1])), float(np.mean(points[:, 0])))
+
+
+def _contour_defects(contour: np.ndarray):
+    if contour is None or len(contour) < 4:
+        return None
     hull = cv2.convexHull(contour, returnPoints=False)
     if hull is None or len(hull) < 3:
-        return False
-
-    hull = np.sort(hull.flatten()).reshape(-1, 1)
+        return None
     try:
-        defects = cv2.convexityDefects(contour, hull)
+        return cv2.convexityDefects(contour, hull)
     except cv2.error:
-        return False
-    if defects is None:
-        return False
+        try:
+            sorted_hull = np.sort(hull.flatten()).reshape(-1, 1)
+            return cv2.convexityDefects(contour, sorted_hull)
+        except cv2.error:
+            return None
 
-    min_depth = int(round(float(min_defect_depth_px) * 256))
-    return any(int(depth) >= min_depth for _start, _end, _far, depth in defects[:, 0])
+
+def compute_contour_shape_metrics(
+    contour: np.ndarray,
+    image_shape: tuple[int, int] | tuple[int, int, int],
+    *,
+    min_defect_depth_px: float = 1.0,
+) -> _ContourShapeMetrics | None:
+    """Measure compactness, concavity, and lobe scale for one GFP contour."""
+
+    mask = contour_to_mask(contour, image_shape)
+    dense_contour = _dense_outer_contour(mask)
+    if dense_contour is None or len(dense_contour) < 3:
+        return None
+
+    area = float(cv2.contourArea(dense_contour))
+    pixel_area = int(np.count_nonzero(mask))
+    perimeter = float(cv2.arcLength(dense_contour, True))
+    circularity = 0.0
+    if perimeter > 0:
+        circularity = float((4.0 * math.pi * area) / (perimeter * perimeter))
+
+    x, y, width, height = cv2.boundingRect(dense_contour)
+    del x, y
+    short_side = max(1, min(width, height))
+    aspect_ratio = float(max(width, height) / short_side)
+
+    hull = cv2.convexHull(dense_contour)
+    hull_area = float(cv2.contourArea(hull)) if hull is not None and len(hull) >= 3 else 0.0
+    solidity = float(area / hull_area) if hull_area > 0 else 1.0
+
+    dist = ndi.distance_transform_edt(mask > 0)
+    lobe_width_px = float(2.0 * dist.max()) if dist.size else 0.0
+
+    defects = _contour_defects(dense_contour)
+    deep_defect_count = 0
+    max_defect_depth_px = 0.0
+    if defects is not None:
+        for _start, _end, _far, depth in defects[:, 0]:
+            depth_px = float(depth) / 256.0
+            max_defect_depth_px = max(max_defect_depth_px, depth_px)
+            if depth_px >= float(min_defect_depth_px):
+                deep_defect_count += 1
+
+    return _ContourShapeMetrics(
+        contour=dense_contour,
+        mask=mask,
+        area=area,
+        pixel_area=pixel_area,
+        perimeter=perimeter,
+        circularity=circularity,
+        aspect_ratio=aspect_ratio,
+        solidity=solidity,
+        hull_area=hull_area,
+        centroid=_contour_center_from_mask(mask),
+        lobe_width_px=lobe_width_px,
+        deep_defect_count=deep_defect_count,
+        max_defect_depth_px=max_defect_depth_px,
+    )
+
+
+def _sample_profile(
+    image: np.ndarray,
+    point_a: tuple[int, int],
+    point_b: tuple[int, int],
+    *,
+    sample_count: int = PROFILE_SAMPLE_COUNT,
+) -> np.ndarray:
+    height, width = image.shape[:2]
+    xs = np.linspace(float(point_a[0]), float(point_b[0]), int(sample_count))
+    ys = np.linspace(float(point_a[1]), float(point_b[1]), int(sample_count))
+    xs = np.clip(np.rint(xs).astype(np.int32), 0, width - 1)
+    ys = np.clip(np.rint(ys).astype(np.int32), 0, height - 1)
+    return image[ys, xs].astype(np.float32, copy=False)
+
+
+def _sample_profile_with_points(
+    image: np.ndarray,
+    point_a: tuple[int, int],
+    point_b: tuple[int, int],
+    *,
+    sample_count: int = PROFILE_SAMPLE_COUNT,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    height, width = image.shape[:2]
+    xs = np.linspace(float(point_a[0]), float(point_b[0]), int(sample_count))
+    ys = np.linspace(float(point_a[1]), float(point_b[1]), int(sample_count))
+    xs = np.clip(np.rint(xs).astype(np.int32), 0, width - 1)
+    ys = np.clip(np.rint(ys).astype(np.int32), 0, height - 1)
+    return image[ys, xs].astype(np.float32, copy=False), xs, ys
+
+
+def _chord_mask_fraction(
+    mask: np.ndarray,
+    point_a: tuple[int, int],
+    point_b: tuple[int, int],
+) -> float:
+    profile = _sample_profile(mask, point_a, point_b)
+    if profile.size <= 2:
+        return 0.0
+    interior = profile[1:-1]
+    return float(np.count_nonzero(interior > 0) / max(len(interior), 1))
+
+
+def find_convexity_defect_neck_candidates(
+    contour: np.ndarray,
+    mask: np.ndarray,
+    params: dict,
+) -> list[_NeckCandidate]:
+    """Return paired concavity candidates that can form a neck chord."""
+
+    dense_contour = _dense_outer_contour(mask)
+    if dense_contour is None:
+        return []
+    defects = _contour_defects(dense_contour)
+    if defects is None:
+        return []
+
+    min_depth = float(params["min_defect_depth_px"])
+    candidates = []
+    for _start, _end, far_idx, depth in defects[:, 0]:
+        depth_px = float(depth) / 256.0
+        if depth_px < min_depth:
+            continue
+        point = tuple(int(v) for v in dense_contour[int(far_idx)][0])
+        candidates.append((point, depth_px))
+
+    candidates.sort(key=lambda row: row[1], reverse=True)
+    candidates = candidates[:MAX_DEFECT_CANDIDATES]
+    if len(candidates) < 2:
+        return []
+
+    center = _contour_center_from_mask(mask)
+    lobe_width = float(2.0 * ndi.distance_transform_edt(mask > 0).max())
+    if lobe_width <= 0:
+        return []
+
+    necks: list[_NeckCandidate] = []
+    for i in range(len(candidates)):
+        for j in range(i + 1, len(candidates)):
+            point_a, depth_a = candidates[i]
+            point_b, depth_b = candidates[j]
+            width_px = float(math.dist(point_a, point_b))
+            if width_px <= 1.0:
+                continue
+
+            vec_a = np.array([point_a[0] - center[0], point_a[1] - center[1]], dtype=np.float32)
+            vec_b = np.array([point_b[0] - center[0], point_b[1] - center[1]], dtype=np.float32)
+            norm_product = float(np.linalg.norm(vec_a) * np.linalg.norm(vec_b))
+            if norm_product <= 0:
+                continue
+            facing_cos = float(np.dot(vec_a, vec_b) / norm_product)
+            if facing_cos > 0.35:
+                continue
+
+            chord_fraction = _chord_mask_fraction(mask, point_a, point_b)
+            if chord_fraction < float(params["min_chord_mask_fraction"]):
+                continue
+
+            neck_ratio = float(width_px / max(lobe_width, 1e-6))
+            if neck_ratio > float(params["max_neck_width_ratio"]):
+                continue
+            relative_depth = float(min(depth_a, depth_b) / max(lobe_width, 1e-6))
+            if relative_depth < float(params["min_relative_defect_depth"]):
+                continue
+
+            depth_score = depth_a + depth_b
+            ratio_score = max(0.0, 1.0 - neck_ratio) * 8.0
+            score = depth_score + ratio_score + chord_fraction
+            necks.append(
+                _NeckCandidate(
+                    point_a=point_a,
+                    point_b=point_b,
+                    width_px=width_px,
+                    neck_ratio=neck_ratio,
+                    depth_a_px=depth_a,
+                    depth_b_px=depth_b,
+                    chord_mask_fraction=chord_fraction,
+                    score=score,
+                )
+            )
+
+    necks.sort(key=lambda item: item.score, reverse=True)
+    return necks
+
+
+def _as_gray_float(image: np.ndarray | None) -> np.ndarray | None:
+    if image is None:
+        return None
+    gray = np.asarray(image)
+    if gray.ndim == 3:
+        gray = cv2.cvtColor(gray, cv2.COLOR_RGB2GRAY)
+    if gray.ndim != 2:
+        return None
+    return gray.astype(np.float32, copy=False)
+
+
+def _smooth_gfp_image(gfp_image: np.ndarray | None) -> np.ndarray | None:
+    gray = _as_gray_float(gfp_image)
+    if gray is None or gray.size == 0:
+        return None
+    return cv2.GaussianBlur(gray, (3, 3), 0)
+
+
+def find_intensity_peaks_in_contour(
+    mask: np.ndarray,
+    gfp_image: np.ndarray | None,
+    params: dict,
+) -> list[_Peak]:
+    """Find bright GFP centers inside a contour mask."""
+
+    smoothed = _smooth_gfp_image(gfp_image)
+    if smoothed is None:
+        return []
+    inside = mask > 0
+    if not np.any(inside):
+        return []
+    max_value = float(np.max(smoothed[inside]))
+    if max_value <= 0:
+        return []
+
+    coords = peak_local_max(
+        smoothed,
+        min_distance=int(params["min_peak_distance"]),
+        threshold_abs=max_value * float(params["min_intensity_peak_ratio"]),
+        labels=inside,
+        exclude_border=False,
+    )
+    peaks = [
+        _Peak(x=int(x_coord), y=int(y_coord), value=float(smoothed[int(y_coord), int(x_coord)]))
+        for y_coord, x_coord in coords
+    ]
+    peaks.sort(key=lambda peak: peak.value, reverse=True)
+    return peaks[:MAX_PEAK_CANDIDATES]
+
+
+def _find_distance_peaks_in_contour(mask: np.ndarray, params: dict) -> tuple[list[_Peak], np.ndarray]:
+    dist = ndi.distance_transform_edt(mask > 0).astype(np.float32)
+    max_value = float(dist.max())
+    if max_value <= 0:
+        return [], dist
+    coords = peak_local_max(
+        dist,
+        min_distance=int(params["min_peak_distance"]),
+        threshold_abs=max_value * float(params["min_peak_ratio"]),
+        labels=mask > 0,
+        exclude_border=False,
+    )
+    peaks = [
+        _Peak(x=int(x_coord), y=int(y_coord), value=float(dist[int(y_coord), int(x_coord)]))
+        for y_coord, x_coord in coords
+    ]
+    peaks.sort(key=lambda peak: peak.value, reverse=True)
+    return peaks[:MAX_PEAK_CANDIDATES], dist
+
+
+def _best_peak_pair(
+    peaks: list[_Peak],
+    profile_image: np.ndarray,
+    params: dict,
+    *,
+    max_valley_ratio_key: str,
+) -> _PeakPair | None:
+    if len(peaks) < 2:
+        return None
+    best: _PeakPair | None = None
+    min_distance = float(params["min_child_center_distance_px"])
+    min_second_peak_ratio = float(params["min_second_peak_ratio"])
+    max_valley_ratio = float(params[max_valley_ratio_key])
+
+    for i in range(len(peaks)):
+        for j in range(i + 1, len(peaks)):
+            peak_a = peaks[i]
+            peak_b = peaks[j]
+            distance_px = float(math.dist(peak_a.point, peak_b.point))
+            if distance_px < min_distance:
+                continue
+            high_peak = max(peak_a.value, peak_b.value)
+            if high_peak <= 0:
+                continue
+            second_peak_ratio = float(min(peak_a.value, peak_b.value) / high_peak)
+            if second_peak_ratio < min_second_peak_ratio:
+                continue
+            profile = _sample_profile(profile_image, peak_a.point, peak_b.point)
+            if profile.size > 2:
+                valley_value = float(np.min(profile[1:-1]))
+            else:
+                valley_value = float(min(peak_a.value, peak_b.value))
+            valley_ratio = float(valley_value / max(min(peak_a.value, peak_b.value), 1e-6))
+            distance_score = min(distance_px / 12.0, 1.5)
+            valley_score = max(0.0, max_valley_ratio - valley_ratio) * 4.0
+            score = second_peak_ratio + distance_score + valley_score
+            pair = _PeakPair(
+                peak_a=peak_a,
+                peak_b=peak_b,
+                distance_px=distance_px,
+                valley_value=valley_value,
+                valley_ratio=valley_ratio,
+                second_peak_ratio=second_peak_ratio,
+                score=score,
+            )
+            if best is None or pair.score > best.score:
+                best = pair
+    return best
+
+
+def _markers_from_peak_pair(shape: tuple[int, int], peak_pair: _PeakPair) -> np.ndarray:
+    markers = np.zeros(shape, dtype=np.int32)
+    markers[int(peak_pair.peak_a.y), int(peak_pair.peak_a.x)] = 1
+    markers[int(peak_pair.peak_b.y), int(peak_pair.peak_b.x)] = 2
+    return markers
+
+
+def _markers_from_neck(mask: np.ndarray, neck: _NeckCandidate, params: dict) -> np.ndarray | None:
+    working = mask.copy()
+    cv2.line(
+        working,
+        neck.point_a,
+        neck.point_b,
+        0,
+        thickness=int(params["neck_cut_line_thickness"]),
+        lineType=cv2.LINE_8,
+    )
+    num_labels, labels = cv2.connectedComponents((working > 0).astype(np.uint8), connectivity=8)
+    regions = []
+    for label in range(1, num_labels):
+        region = labels == label
+        area = int(np.count_nonzero(region))
+        if area >= int(params["min_split_area_px"]):
+            regions.append((area, region))
+    regions.sort(key=lambda row: row[0], reverse=True)
+    if len(regions) < 2:
+        return None
+
+    markers = np.zeros(mask.shape, dtype=np.int32)
+    for marker_idx, (_area, region) in enumerate(regions[:2], start=1):
+        dist = ndi.distance_transform_edt(region)
+        y_coord, x_coord = np.unravel_index(int(np.argmax(dist)), dist.shape)
+        markers[int(y_coord), int(x_coord)] = marker_idx
+    return markers
+
+
+def _split_score_image(mask: np.ndarray, gfp_image: np.ndarray | None) -> np.ndarray:
+    dist = ndi.distance_transform_edt(mask > 0).astype(np.float32)
+    if dist.max() > 0:
+        dist = dist / float(dist.max())
+
+    smoothed = _smooth_gfp_image(gfp_image)
+    if smoothed is None:
+        return dist
+    inside = mask > 0
+    if not np.any(inside):
+        return dist
+    values = smoothed[inside]
+    min_value = float(values.min())
+    max_value = float(values.max())
+    if max_value <= min_value:
+        return dist
+    intensity = np.zeros(mask.shape, dtype=np.float32)
+    intensity[inside] = (smoothed[inside] - min_value) / (max_value - min_value)
+    return (0.65 * dist) + (0.35 * intensity)
+
+
+def split_contour_with_watershed(
+    mask: np.ndarray,
+    gfp_image: np.ndarray | None,
+    peak_pair: _PeakPair | None,
+    params: dict,
+    *,
+    neck_candidate: _NeckCandidate | None = None,
+) -> np.ndarray | None:
+    """Split a contour mask into two marker-controlled watershed regions."""
+
+    if peak_pair is not None:
+        markers = _markers_from_peak_pair(mask.shape, peak_pair)
+    elif neck_candidate is not None:
+        markers = _markers_from_neck(mask, neck_candidate, params)
+        if markers is None:
+            return None
+    else:
+        return None
+
+    score_image = _split_score_image(mask, gfp_image)
+    labels = watershed(-score_image, markers, mask=mask > 0)
+    if int(labels.max()) != 2:
+        return None
+
+    boundary = _internal_watershed_boundaries(labels)
+    labels = labels.copy()
+    labels[boundary] = 0
+    return labels
+
+
+def _split_contour_with_neck_chord(
+    mask: np.ndarray,
+    neck: _NeckCandidate,
+    params: dict,
+) -> np.ndarray | None:
+    working = mask.copy()
+    cv2.line(
+        working,
+        neck.point_a,
+        neck.point_b,
+        0,
+        thickness=int(params["neck_cut_line_thickness"]),
+        lineType=cv2.LINE_8,
+    )
+    num_labels, labels = cv2.connectedComponents((working > 0).astype(np.uint8), connectivity=8)
+    regions = []
+    for label in range(1, num_labels):
+        region = labels == label
+        area = int(np.count_nonzero(region))
+        if area >= int(params["min_split_area_px"]):
+            regions.append((area, label))
+    regions.sort(key=lambda row: row[0], reverse=True)
+    if len(regions) < 2:
+        return None
+    split_labels = np.zeros_like(labels, dtype=np.int32)
+    for marker_idx, (_area, original_label) in enumerate(regions[:2], start=1):
+        split_labels[labels == original_label] = marker_idx
+    return split_labels
 
 
 def _region_circularity(region: np.ndarray) -> float:
@@ -81,6 +653,148 @@ def _region_circularity(region: np.ndarray) -> float:
     if perimeter <= 0:
         return 0.0
     return float((4.0 * math.pi * area) / (perimeter * perimeter))
+
+
+def _region_solidity(region: np.ndarray) -> float:
+    contours, _ = cv2.findContours(
+        (region.astype(np.uint8) * 255),
+        cv2.RETR_EXTERNAL,
+        cv2.CHAIN_APPROX_SIMPLE,
+    )
+    if not contours:
+        return 0.0
+    contour = max(contours, key=cv2.contourArea)
+    area = float(cv2.contourArea(contour))
+    hull = cv2.convexHull(contour)
+    hull_area = float(cv2.contourArea(hull)) if hull is not None and len(hull) >= 3 else 0.0
+    if hull_area <= 0:
+        return 0.0
+    return float(area / hull_area)
+
+
+def _contour_from_region(region: np.ndarray) -> np.ndarray | None:
+    contours, _ = cv2.findContours(
+        (region.astype(np.uint8) * 255),
+        cv2.RETR_EXTERNAL,
+        cv2.CHAIN_APPROX_SIMPLE,
+    )
+    if not contours:
+        return None
+    return max(contours, key=cv2.contourArea)
+
+
+def _label_at_point(labels: np.ndarray, point: tuple[int, int]) -> int:
+    x_coord, y_coord = int(point[0]), int(point[1])
+    height, width = labels.shape[:2]
+    if x_coord < 0 or y_coord < 0 or x_coord >= width or y_coord >= height:
+        return 0
+    label = int(labels[y_coord, x_coord])
+    if label:
+        return label
+    y0, y1 = max(0, y_coord - 1), min(height, y_coord + 2)
+    x0, x1 = max(0, x_coord - 1), min(width, x_coord + 2)
+    nearby = labels[y0:y1, x0:x1]
+    nearby = nearby[nearby > 0]
+    if nearby.size == 0:
+        return 0
+    values, counts = np.unique(nearby, return_counts=True)
+    return int(values[int(np.argmax(counts))])
+
+
+def validate_split_contours(
+    original_mask: np.ndarray,
+    split_labels: np.ndarray | None,
+    gfp_image: np.ndarray | None,
+    params: dict,
+    *,
+    peak_pair: _PeakPair | None = None,
+    neck_candidate: _NeckCandidate | None = None,
+) -> list[np.ndarray]:
+    """Validate watershed/chord regions before replacing the original contour."""
+
+    if split_labels is None or int(split_labels.max()) != 2:
+        return []
+
+    original_area = int(np.count_nonzero(original_mask))
+    if original_area <= 0:
+        return []
+
+    gray = _as_gray_float(gfp_image)
+    original_max = 0.0
+    if gray is not None and gray.shape[:2] == original_mask.shape:
+        original_values = gray[original_mask > 0]
+        if original_values.size:
+            original_max = float(np.max(original_values))
+
+    child_contours: list[np.ndarray] = []
+    child_areas: list[int] = []
+    child_centers: list[tuple[float, float]] = []
+    for label in (1, 2):
+        region = split_labels == label
+        area = int(np.count_nonzero(region))
+        if area < int(params["min_split_area_px"]):
+            return []
+        contour = _contour_from_region(region)
+        if contour is None or len(contour) < 3:
+            return []
+        if _region_circularity(region) < float(params["min_split_circularity"]):
+            return []
+        if _region_solidity(region) < float(params["min_split_solidity"]):
+            return []
+        _x, _y, width, height = cv2.boundingRect(contour)
+        short_side = max(1, min(width, height))
+        if (max(width, height) / short_side) > float(params["max_child_aspect_ratio"]):
+            return []
+        if original_max > 0 and gray is not None and gray.shape[:2] == original_mask.shape:
+            child_values = gray[region]
+            if child_values.size == 0:
+                return []
+            if float(np.max(child_values)) < original_max * float(params["min_child_peak_ratio"]):
+                return []
+        child_contours.append(contour)
+        child_areas.append(area)
+        child_centers.append(_contour_center_from_mask(region.astype(np.uint8) * 255))
+
+    combined_area_ratio = float(sum(child_areas) / max(original_area, 1))
+    if combined_area_ratio < float(params["min_combined_area_ratio"]):
+        return []
+
+    area_fraction = float(min(child_areas) / max(max(child_areas), 1))
+    if area_fraction < float(params["min_child_area_fraction"]):
+        return []
+
+    center_distance = float(math.dist(child_centers[0], child_centers[1]))
+    if center_distance < float(params["min_child_center_distance_px"]):
+        return []
+
+    if peak_pair is not None:
+        label_a = _label_at_point(split_labels, peak_pair.peak_a.point)
+        label_b = _label_at_point(split_labels, peak_pair.peak_b.point)
+        if label_a == 0 or label_b == 0 or label_a == label_b:
+            return []
+
+    if neck_candidate is not None:
+        center_vec = np.array(
+            [
+                child_centers[1][0] - child_centers[0][0],
+                child_centers[1][1] - child_centers[0][1],
+            ],
+            dtype=np.float32,
+        )
+        neck_vec = np.array(
+            [
+                neck_candidate.point_b[0] - neck_candidate.point_a[0],
+                neck_candidate.point_b[1] - neck_candidate.point_a[1],
+            ],
+            dtype=np.float32,
+        )
+        norm_product = float(np.linalg.norm(center_vec) * np.linalg.norm(neck_vec))
+        if norm_product > 0:
+            alignment = abs(float(np.dot(center_vec, neck_vec) / norm_product))
+            if alignment > float(params["max_neck_alignment_cos"]):
+                return []
+
+    return child_contours
 
 
 def _internal_watershed_boundaries(labels: np.ndarray) -> np.ndarray:
@@ -111,91 +825,599 @@ def _internal_watershed_boundaries(labels: np.ndarray) -> np.ndarray:
     )
 
 
+def _is_round_single_dot(metrics: _ContourShapeMetrics, params: dict) -> bool:
+    return (
+        metrics.circularity >= float(params["max_single_dot_circularity"])
+        and metrics.solidity >= float(params["min_single_dot_solidity"])
+        and metrics.aspect_ratio <= float(params["max_single_dot_aspect_ratio"])
+        and metrics.deep_defect_count == 0
+    )
+
+
+def _shape_is_suspicious(metrics: _ContourShapeMetrics, params: dict) -> bool:
+    return (
+        metrics.aspect_ratio >= float(params["min_suspicious_aspect_ratio"])
+        or metrics.circularity <= float(params["max_suspicious_circularity"])
+        or metrics.solidity <= float(params["max_suspicious_solidity"])
+        or metrics.deep_defect_count >= 2
+    )
+
+
+def _choose_split_peak_pair(
+    intensity_pair: _PeakPair | None,
+    distance_pair: _PeakPair | None,
+    params: dict,
+) -> _PeakPair | None:
+    intensity_ok = (
+        intensity_pair is not None
+        and intensity_pair.valley_ratio <= float(params["max_intensity_valley_ratio"])
+    )
+    distance_ok = (
+        distance_pair is not None
+        and distance_pair.valley_ratio <= float(params["max_distance_valley_ratio"])
+    )
+    if intensity_ok and distance_ok:
+        return intensity_pair if intensity_pair.score >= distance_pair.score else distance_pair
+    if intensity_ok:
+        return intensity_pair
+    if distance_ok:
+        return distance_pair
+    return None
+
+
+def find_single_concavity_candidates(
+    contour: np.ndarray,
+    mask: np.ndarray,
+    params: dict,
+) -> list[_SingleDefectCandidate]:
+    """Return deep single-side concavities for asymmetric split confidence."""
+
+    dense_contour = _dense_outer_contour(mask)
+    if dense_contour is None:
+        return []
+    defects = _contour_defects(dense_contour)
+    if defects is None:
+        return []
+
+    min_depth = float(params.get("asymmetric_min_single_defect_depth_px", 0.75))
+    candidates: list[_SingleDefectCandidate] = []
+    for _start, _end, far_idx, depth in defects[:, 0]:
+        depth_px = float(depth) / 256.0
+        if depth_px < min_depth:
+            continue
+        point = tuple(int(v) for v in dense_contour[int(far_idx)][0])
+        candidates.append(
+            _SingleDefectCandidate(
+                point=point,
+                depth_px=depth_px,
+                score=depth_px,
+            )
+        )
+    candidates.sort(key=lambda item: item.score, reverse=True)
+    return candidates[:MAX_DEFECT_CANDIDATES]
+
+
+def _central_profile_indices(length: int) -> np.ndarray:
+    start = max(1, int(round(float(length) * 0.20)))
+    stop = min(length - 1, int(round(float(length) * 0.80)))
+    if stop <= start:
+        return np.arange(1, max(length - 1, 1), dtype=np.int32)
+    return np.arange(start, stop, dtype=np.int32)
+
+
+def _single_defect_supports_saddle(
+    defects: list[_SingleDefectCandidate],
+    saddle_point: tuple[int, int],
+    params: dict,
+) -> _SingleDefectCandidate | None:
+    max_distance = float(params.get("asymmetric_max_saddle_to_defect_distance_px", 8.0))
+    supported = [
+        defect
+        for defect in defects
+        if math.dist(defect.point, saddle_point) <= max_distance
+    ]
+    if not supported:
+        return None
+    supported.sort(key=lambda defect: defect.score, reverse=True)
+    return supported[0]
+
+
+def find_asymmetric_peak_saddle_candidate(
+    mask: np.ndarray,
+    gfp_image: np.ndarray,
+    params: dict,
+) -> _AsymmetricSplitCandidate | None:
+    """Return two-peak/one-sided-saddle evidence for aggressive fallback."""
+
+    smoothed = _smooth_gfp_image(gfp_image)
+    if smoothed is None or smoothed.shape[:2] != mask.shape:
+        return None
+
+    peaks = find_intensity_peaks_in_contour(mask, smoothed, params)
+    if len(peaks) < 2:
+        return None
+
+    distance_image = ndi.distance_transform_edt(mask > 0).astype(np.float32)
+    if float(distance_image.max()) <= 0:
+        return None
+
+    contour = _dense_outer_contour(mask)
+    defects = find_single_concavity_candidates(contour, mask, params) if contour is not None else []
+    min_peak_distance = float(params.get("asymmetric_min_peak_distance_px", 4.0))
+    min_second_ratio = float(params.get("asymmetric_min_second_peak_ratio", 0.32))
+    max_intensity_valley_ratio = float(
+        params.get("asymmetric_max_intensity_valley_ratio", 0.88)
+    )
+    min_intensity_drop_ratio = float(
+        params.get("asymmetric_min_intensity_drop_ratio", 0.10)
+    )
+    max_distance_saddle_ratio = float(
+        params.get("asymmetric_max_distance_saddle_ratio", 0.88)
+    )
+    min_line_mask_fraction = float(
+        params.get("asymmetric_min_peak_line_mask_fraction", 0.80)
+    )
+
+    best: _AsymmetricSplitCandidate | None = None
+    for i in range(len(peaks)):
+        for j in range(i + 1, len(peaks)):
+            peak_a = peaks[i]
+            peak_b = peaks[j]
+            peak_distance = float(math.dist(peak_a.point, peak_b.point))
+            if peak_distance < min_peak_distance:
+                continue
+
+            high_peak = max(peak_a.value, peak_b.value)
+            peak_floor = min(peak_a.value, peak_b.value)
+            if high_peak <= 0 or peak_floor <= 0:
+                continue
+            second_peak_ratio = float(peak_floor / high_peak)
+            if second_peak_ratio < min_second_ratio:
+                continue
+
+            line_mask_fraction = _chord_mask_fraction(mask, peak_a.point, peak_b.point)
+            if line_mask_fraction < min_line_mask_fraction:
+                continue
+
+            intensity_profile, xs, ys = _sample_profile_with_points(
+                smoothed,
+                peak_a.point,
+                peak_b.point,
+            )
+            distance_profile = _sample_profile(
+                distance_image,
+                peak_a.point,
+                peak_b.point,
+            )
+            if intensity_profile.size < 4 or distance_profile.size != intensity_profile.size:
+                continue
+
+            central_indices = _central_profile_indices(int(intensity_profile.size))
+            if central_indices.size == 0:
+                continue
+
+            peak_distance_floor = min(
+                float(distance_image[int(peak_a.y), int(peak_a.x)]),
+                float(distance_image[int(peak_b.y), int(peak_b.x)]),
+            )
+            if peak_distance_floor <= 0:
+                continue
+
+            intensity_ratios = intensity_profile[central_indices] / max(peak_floor, 1e-6)
+            distance_ratios = distance_profile[central_indices] / max(peak_distance_floor, 1e-6)
+            combined = (0.58 * intensity_ratios) + (0.42 * distance_ratios)
+            profile_idx = int(central_indices[int(np.argmin(combined))])
+
+            valley_value = float(intensity_profile[profile_idx])
+            intensity_valley_ratio = float(valley_value / max(peak_floor, 1e-6))
+            intensity_drop_ratio = float((peak_floor - valley_value) / max(high_peak, 1e-6))
+            distance_saddle_ratio = float(
+                distance_profile[profile_idx] / max(peak_distance_floor, 1e-6)
+            )
+            if intensity_valley_ratio > max_intensity_valley_ratio:
+                continue
+            if intensity_drop_ratio < min_intensity_drop_ratio:
+                continue
+            if distance_saddle_ratio > max_distance_saddle_ratio:
+                continue
+
+            saddle_point = (int(xs[profile_idx]), int(ys[profile_idx]))
+            single_defect = _single_defect_supports_saddle(defects, saddle_point, params)
+            peak_pair = _PeakPair(
+                peak_a=peak_a,
+                peak_b=peak_b,
+                distance_px=peak_distance,
+                valley_value=valley_value,
+                valley_ratio=intensity_valley_ratio,
+                second_peak_ratio=second_peak_ratio,
+                score=0.0,
+            )
+            score = (
+                second_peak_ratio
+                + min(peak_distance / 12.0, 1.5)
+                + max(0.0, 1.0 - intensity_valley_ratio) * 3.0
+                + max(0.0, 1.0 - distance_saddle_ratio) * 3.0
+                + (0.5 if single_defect is not None else 0.0)
+            )
+            peak_pair.score = score
+            candidate = _AsymmetricSplitCandidate(
+                peak_pair=peak_pair,
+                saddle=_SaddleMetrics(
+                    point=saddle_point,
+                    intensity_valley_ratio=intensity_valley_ratio,
+                    intensity_drop_ratio=intensity_drop_ratio,
+                    distance_saddle_ratio=distance_saddle_ratio,
+                ),
+                single_defect=single_defect,
+                score=score,
+            )
+            if best is None or candidate.score > best.score:
+                best = candidate
+
+    return best
+
+
+def split_contour_with_asymmetric_watershed(
+    mask: np.ndarray,
+    gfp_image: np.ndarray,
+    candidate: _AsymmetricSplitCandidate,
+    params: dict,
+) -> np.ndarray | None:
+    """Split a one-sided-neck contour using two intensity peaks as markers."""
+
+    return split_contour_with_watershed(
+        mask,
+        gfp_image,
+        candidate.peak_pair,
+        params,
+    )
+
+
+def _boundary_between_split_labels(
+    original_mask: np.ndarray,
+    split_labels: np.ndarray,
+) -> np.ndarray:
+    label_1_touch = ndi.binary_dilation(
+        split_labels == 1,
+        structure=np.ones((3, 3), dtype=bool),
+        iterations=2,
+    )
+    label_2_touch = ndi.binary_dilation(
+        split_labels == 2,
+        structure=np.ones((3, 3), dtype=bool),
+        iterations=2,
+    )
+    return (
+        (original_mask > 0)
+        & label_1_touch
+        & label_2_touch
+        & ((split_labels == 0) | find_boundaries(split_labels, mode="thick"))
+    )
+
+
+def _boundary_reaches_saddle(
+    boundary: np.ndarray,
+    saddle_point: tuple[int, int],
+    params: dict,
+    peak_distance: float,
+) -> bool:
+    points = np.column_stack(np.nonzero(boundary))
+    if points.size == 0:
+        return False
+    saddle_yx = np.array([saddle_point[1], saddle_point[0]], dtype=np.float32)
+    distances = np.linalg.norm(points.astype(np.float32) - saddle_yx, axis=1)
+    max_distance = max(
+        float(params.get("asymmetric_max_boundary_saddle_distance_px", 6.0)),
+        peak_distance * 0.25,
+    )
+    return bool(float(np.min(distances)) <= max_distance)
+
+
+def validate_asymmetric_split(
+    original_mask: np.ndarray,
+    split_labels: np.ndarray | None,
+    gfp_image: np.ndarray,
+    candidate: _AsymmetricSplitCandidate,
+    params: dict,
+) -> list[np.ndarray]:
+    """Apply extra saddle and child-intensity gates to fallback watershed."""
+
+    child_contours = validate_split_contours(
+        original_mask,
+        split_labels,
+        gfp_image,
+        params,
+        peak_pair=candidate.peak_pair,
+        neck_candidate=None,
+    )
+    if len(child_contours) != 2 or split_labels is None:
+        return []
+
+    gray = _as_gray_float(gfp_image)
+    if gray is None or gray.shape[:2] != original_mask.shape:
+        return []
+    original_values = gray[original_mask > 0]
+    if original_values.size == 0:
+        return []
+    original_max = float(np.max(original_values))
+    if original_max <= 0:
+        return []
+
+    child_areas: list[int] = []
+    child_centers: list[tuple[float, float]] = []
+    for label in (1, 2):
+        region = split_labels == label
+        child_values = gray[region]
+        if child_values.size == 0:
+            return []
+        if float(np.mean(child_values)) < original_max * float(
+            params.get("asymmetric_min_child_mean_ratio", 0.20)
+        ):
+            return []
+        child_areas.append(int(np.count_nonzero(region)))
+        child_centers.append(_contour_center_from_mask(region.astype(np.uint8) * 255))
+
+    if min(child_areas) / max(max(child_areas), 1) < float(
+        params.get("asymmetric_min_child_area_fraction", 0.16)
+    ):
+        return []
+    if math.dist(child_centers[0], child_centers[1]) < float(
+        params.get("asymmetric_min_peak_distance_px", 4.0)
+    ):
+        return []
+
+    boundary = _boundary_between_split_labels(original_mask, split_labels)
+    if not np.any(boundary):
+        return []
+    if not _boundary_reaches_saddle(
+        boundary,
+        candidate.saddle.point,
+        params,
+        candidate.peak_pair.distance_px,
+    ):
+        return []
+
+    smoothed = _smooth_gfp_image(gfp_image)
+    if smoothed is None or smoothed.shape[:2] != original_mask.shape:
+        return []
+    distance_image = ndi.distance_transform_edt(original_mask > 0).astype(np.float32)
+    peak_floor = min(candidate.peak_pair.peak_a.value, candidate.peak_pair.peak_b.value)
+    peak_distance_floor = min(
+        float(distance_image[candidate.peak_pair.peak_a.y, candidate.peak_pair.peak_a.x]),
+        float(distance_image[candidate.peak_pair.peak_b.y, candidate.peak_pair.peak_b.x]),
+    )
+    if peak_floor <= 0 or peak_distance_floor <= 0:
+        return []
+
+    boundary_intensity_ok = smoothed[boundary] <= (
+        peak_floor * float(params.get("asymmetric_max_intensity_valley_ratio", 0.88))
+    )
+    boundary_distance_ok = distance_image[boundary] <= (
+        peak_distance_floor * float(params.get("asymmetric_max_distance_saddle_ratio", 0.88))
+    )
+    low_signal_fraction = float(
+        np.count_nonzero(boundary_intensity_ok | boundary_distance_ok)
+        / max(np.count_nonzero(boundary), 1)
+    )
+    if low_signal_fraction < float(
+        params.get("asymmetric_min_boundary_low_signal_fraction", 0.55)
+    ):
+        return []
+
+    return child_contours
+
+
+def split_asymmetric_gfp_contour_if_needed(
+    metrics: _ContourShapeMetrics,
+    gfp_image: np.ndarray,
+    params: dict,
+    *,
+    debug: bool = False,
+) -> list[np.ndarray]:
+    if not bool(params.get("asymmetric_fallback_enabled", False)):
+        return []
+    if _is_round_single_dot(metrics, params):
+        if debug:
+            logger.debug("Green asymmetric split rejected: contour is compact and round")
+        return []
+
+    candidate = find_asymmetric_peak_saddle_candidate(metrics.mask, gfp_image, params)
+    if candidate is None:
+        if debug:
+            logger.debug("Green asymmetric split rejected: no two-peak saddle")
+        return []
+
+    split_labels = split_contour_with_asymmetric_watershed(
+        metrics.mask,
+        gfp_image,
+        candidate,
+        params,
+    )
+    child_contours = validate_asymmetric_split(
+        metrics.mask,
+        split_labels,
+        gfp_image,
+        candidate,
+        params,
+    )
+    if len(child_contours) == 2:
+        return child_contours
+
+    if debug:
+        logger.debug("Green asymmetric split rejected: watershed failed validation")
+    return []
+
+
+def split_necked_gfp_contour_if_needed(
+    contour: np.ndarray,
+    gfp_image: np.ndarray,
+    config: dict | str | None = None,
+) -> list[np.ndarray]:
+    """Return one original contour or two child contours for a necked GFP blob.
+
+    The splitter is intentionally gated by the existing contour outline. It only
+    attempts a split when the blob has paired concave defects forming a narrow
+    waist, plus either two lobe peaks or strong peanut/dumbbell shape metrics.
+    """
+
+    if contour is None or len(contour) < 3:
+        return []
+
+    if isinstance(config, str):
+        split_mode = config
+        debug = False
+    else:
+        config_payload = dict(config or {})
+        split_mode = config_payload.get("mode", DEFAULT_GREEN_DOT_SPLIT_MODE)
+        debug = bool(config_payload.get("debug", False))
+
+    params = _split_params(split_mode)
+    metrics = compute_contour_shape_metrics(
+        contour,
+        gfp_image.shape,
+        min_defect_depth_px=float(params["min_defect_depth_px"]),
+    )
+    if metrics is None:
+        return [contour]
+    if metrics.pixel_area < int(params["min_original_area_px"]):
+        return [contour]
+
+    neck_candidates = find_convexity_defect_neck_candidates(
+        metrics.contour,
+        metrics.mask,
+        params,
+    )
+    neck = neck_candidates[0] if neck_candidates else None
+
+    intensity_peaks = find_intensity_peaks_in_contour(metrics.mask, gfp_image, params)
+    smoothed = _smooth_gfp_image(gfp_image)
+    intensity_pair = None
+    if smoothed is not None:
+        intensity_pair = _best_peak_pair(
+            intensity_peaks,
+            smoothed,
+            params,
+            max_valley_ratio_key="max_intensity_valley_ratio",
+        )
+
+    distance_peaks, distance_image = _find_distance_peaks_in_contour(metrics.mask, params)
+    distance_pair = _best_peak_pair(
+        distance_peaks,
+        distance_image,
+        params,
+        max_valley_ratio_key="max_distance_valley_ratio",
+    )
+
+    def try_asymmetric_fallback() -> list[np.ndarray]:
+        return split_asymmetric_gfp_contour_if_needed(
+            metrics,
+            gfp_image,
+            params,
+            debug=debug,
+        )
+
+    if neck is None:
+        child_contours = try_asymmetric_fallback()
+        if len(child_contours) == 2:
+            return child_contours
+        if debug:
+            logger.debug("Green neck split rejected: no paired concavity")
+        return [contour]
+    if _is_round_single_dot(metrics, params):
+        if debug:
+            logger.debug("Green neck split rejected: contour is compact and round")
+        return [contour]
+
+    shape_suspicious = _shape_is_suspicious(metrics, params)
+    split_peak_pair = _choose_split_peak_pair(intensity_pair, distance_pair, params)
+    has_peak_evidence = split_peak_pair is not None
+    has_geometry_evidence = shape_suspicious and metrics.deep_defect_count >= 2
+    if not (has_peak_evidence or has_geometry_evidence):
+        child_contours = try_asymmetric_fallback()
+        if len(child_contours) == 2:
+            return child_contours
+        if debug:
+            logger.debug("Green neck split rejected: no two-lobe evidence")
+        return [contour]
+
+    # Watershed is preferred because it lets the split follow the intensity and
+    # distance ridge while staying constrained to the original merged contour.
+    split_labels = split_contour_with_watershed(
+        metrics.mask,
+        gfp_image,
+        split_peak_pair,
+        params,
+        neck_candidate=neck,
+    )
+    child_contours = validate_split_contours(
+        metrics.mask,
+        split_labels,
+        gfp_image,
+        params,
+        peak_pair=split_peak_pair,
+        neck_candidate=neck,
+    )
+    if len(child_contours) == 2:
+        return child_contours
+
+    # If the watershed markers do not pass validation, a strong paired-defect
+    # neck can still be separated by the direct chord between the concave points.
+    chord_labels = _split_contour_with_neck_chord(metrics.mask, neck, params)
+    child_contours = validate_split_contours(
+        metrics.mask,
+        chord_labels,
+        gfp_image,
+        params,
+        peak_pair=None,
+        neck_candidate=neck,
+    )
+    if len(child_contours) == 2:
+        return child_contours
+
+    child_contours = try_asymmetric_fallback()
+    if len(child_contours) == 2:
+        return child_contours
+
+    if debug:
+        logger.debug("Green neck split rejected: candidate split failed validation")
+    return [contour]
+
+
+def postprocess_gfp_contours_for_neck_splits(
+    contours: list[np.ndarray] | tuple[np.ndarray, ...],
+    gfp_image: np.ndarray,
+    config: dict | str | None = None,
+) -> list[np.ndarray]:
+    """Replace merged necked GFP contours with two validated child contours."""
+
+    processed: list[np.ndarray] = []
+    for contour in contours or []:
+        split_contours = split_necked_gfp_contour_if_needed(contour, gfp_image, config)
+        processed.extend(split_contours if split_contours else [contour])
+    return processed
+
+
 def _split_merged_green_contours(
     thresh_green: np.ndarray,
     split_mode: str = DEFAULT_GREEN_DOT_SPLIT_MODE,
 ) -> np.ndarray:
-    """Split obviously-merged GFP blobs using a neck-gated watershed.
+    """Backward-compatible mask wrapper for the contour postprocessor."""
 
-    Distance-transform peaks identify candidate dot centers. A component is only
-    split when its outline also has a real concave neck and the watershed output
-    remains plausible dot-like geometry.
-    """
-
-    mode = normalize_green_dot_split_mode(split_mode)
-    params = GREEN_DOT_SPLIT_PARAMS[mode]
-    binary_green = (thresh_green > 0).astype(np.uint8)
-    num_labels, labels = cv2.connectedComponents(binary_green)
-    if num_labels <= 1:
+    contours, _ = cv2.findContours(
+        (thresh_green > 0).astype(np.uint8) * 255,
+        cv2.RETR_EXTERNAL,
+        cv2.CHAIN_APPROX_SIMPLE,
+    )
+    if not contours:
         return thresh_green
-
-    split_mask = np.zeros_like(thresh_green)
-
-    for label in range(1, num_labels):
-        component = labels == label
-        if np.count_nonzero(component) == 0:
-            continue
-
-        component_dist = ndi.distance_transform_edt(component)
-        local_max = float(component_dist.max())
-        if local_max <= 0:
-            split_mask[component] = 255
-            continue
-
-        peak_coords = peak_local_max(
-            component_dist,
-            min_distance=int(params["min_peak_distance"]),
-            threshold_abs=local_max * float(params["min_peak_ratio"]),
-            labels=component,
-            exclude_border=False,
-        )
-        if len(peak_coords) < 2:
-            split_mask[component] = 255
-            continue
-
-        if not _component_has_neck_defect(
-            component,
-            min_defect_depth_px=float(params["min_defect_depth_px"]),
-        ):
-            split_mask[component] = 255
-            continue
-
-        markers = np.zeros(thresh_green.shape, dtype=np.int32)
-        for marker_idx, (y_coord, x_coord) in enumerate(peak_coords, start=1):
-            markers[int(y_coord), int(x_coord)] = marker_idx
-
-        watershed_labels = watershed(-component_dist, markers, mask=component)
-        regions: list[np.ndarray] = []
-        reject_split = False
-        for marker_idx in range(1, len(peak_coords) + 1):
-            region = watershed_labels == marker_idx
-            if np.count_nonzero(region) < int(params["min_split_area_px"]):
-                reject_split = True
-                break
-            if _region_circularity(region) < float(params["min_split_circularity"]):
-                reject_split = True
-                break
-            regions.append(region)
-
-        if reject_split or len(regions) < 2:
-            split_mask[component] = 255
-            continue
-
-        split_component = (watershed_labels > 0) & ~_internal_watershed_boundaries(
-            watershed_labels
-        )
-        if np.count_nonzero(split_component) == 0:
-            split_mask[component] = 255
-            continue
-        split_component_count, _ = cv2.connectedComponents(
-            split_component.astype(np.uint8),
-            connectivity=8,
-        )
-        if split_component_count <= 2:
-            split_mask[component] = 255
-            continue
-        split_mask[split_component] = 255
-
+    processed = postprocess_gfp_contours_for_neck_splits(
+        contours,
+        thresh_green,
+        {"mode": split_mode},
+    )
+    split_mask = np.zeros_like(thresh_green, dtype=np.uint8)
+    for contour in processed:
+        cv2.drawContours(split_mask, [contour], -1, 255, thickness=-1)
     return split_mask
 
 
@@ -419,16 +1641,17 @@ def find_contours(
         )
         kernel = cv2.getStructuringElement(cv2.MORPH_CROSS, (3, 3))
         thresh_green = cv2.morphologyEx(thresh_green, cv2.MORPH_CLOSE, kernel)
-        if green_dot_split_enabled:
-            thresh_green = _split_merged_green_contours(
-                thresh_green,
-                split_mode=green_dot_split_mode,
-            )
         contours_green, _ = cv2.findContours(
             thresh_green,
             cv2.RETR_LIST,
             cv2.CHAIN_APPROX_SIMPLE,
         )
+        if green_dot_split_enabled:
+            contours_green = postprocess_gfp_contours_for_neck_splits(
+                contours_green,
+                gray_green,
+                {"mode": green_dot_split_mode},
+            )
         if green_contour_filter_enabled:
             contours_green = filterContours(contours_green)
 

--- a/cytocv/core/tests/test_accounts_preferences.py
+++ b/cytocv/core/tests/test_accounts_preferences.py
@@ -1474,6 +1474,35 @@ class ChannelVisibilityPreferenceTests(TestCase):
         )
         return str(file_uuid)
 
+    def _build_experiment_workflow_defaults_payload(self) -> dict[str, object]:
+        return {
+            "selected_plugins": ["PunctaDistance", "GreenRedIntensity"],
+            "module_enabled": True,
+            "enforce_layer_count": True,
+            "enforce_wavelengths": False,
+            "show_legacy_plugins": False,
+            "manual_required_channels": ["channel_blue"],
+            "green_contour_filter_enabled": True,
+            "green_dot_split_enabled": False,
+            "green_dot_split_mode": "aggressive",
+            "alternate_red_detection": True,
+            "puncta_line_width": 2.5,
+            "puncta_line_width_unit": "um",
+            "cen_dot_distance": 11.2,
+            "cen_dot_distance_unit": "px",
+            "cen_dot_proximity_radius": 6.5,
+            "cen_dot_proximity_radius_unit": "um",
+            "biorientation_red_min_distance": 1.5,
+            "biorientation_red_min_distance_unit": "px",
+            "biorientation_red_max_distance": 44.5,
+            "biorientation_red_max_distance_unit": "um",
+            "biorientation_collinearity_threshold": 77,
+            "puncta_line_mode": "green_puncta",
+            "nuclear_cell_pair_mode": "red_nucleus",
+            "microns_per_pixel": 0.25,
+            "use_metadata_scale": False,
+        }
+
     def test_preferences_page_renders_review_modal_and_form_review_hooks(self):
         response = self.client.get(reverse("workflow_defaults"))
         self.assertEqual(response.status_code, 200)
@@ -1539,6 +1568,126 @@ class ChannelVisibilityPreferenceTests(TestCase):
         self.assertContains(response, "Keep Old")
         self.assertContains(response, "Confirm Changes")
         self.assertContains(response, "Confirm New")
+
+    def test_experiment_page_renders_workflow_default_save_controls(self):
+        response = self.client.get(reverse("experiment"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="saveWorkflowDefaultsPrimary"', html=False)
+        self.assertContains(response, 'id="saveWorkflowDefaultsAdvanced"', html=False)
+        self.assertContains(response, 'id="saveWorkflowDefaultsBackdrop"', html=False)
+        self.assertContains(response, 'id="saveWorkflowDefaultsConfirm"', html=False)
+        self.assertContains(response, "Save as Workflow Default")
+        self.assertContains(response, "Save as workflow default?")
+        self.assertContains(response, "Keep Old Settings")
+        self.assertContains(response, "Keep New Changes")
+
+    def test_experiment_workflow_defaults_endpoint_persists_popup_settings(self):
+        payload = self._build_experiment_workflow_defaults_payload()
+
+        response = self.client.post(
+            reverse("experiment_workflow_defaults"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()["message"],
+            "Workflow default updated. Future experiments will start with this configuration.",
+        )
+
+        self.user.refresh_from_db()
+        defaults = get_user_preferences(self.user)["experiment_defaults"]
+        self.assertEqual(defaults["selected_plugins"], ["PunctaDistance", "GreenRedIntensity"])
+        self.assertTrue(defaults["module_enabled"])
+        self.assertTrue(defaults["enforce_layer_count"])
+        self.assertFalse(defaults["enforce_wavelengths"])
+        self.assertFalse(defaults["show_legacy_plugins"])
+        self.assertEqual(defaults["manual_required_channels"], ["channel_blue"])
+        self.assertTrue(defaults["green_contour_filter_enabled"])
+        self.assertFalse(defaults["green_dot_split_enabled"])
+        self.assertEqual(defaults["green_dot_split_mode"], "aggressive")
+        self.assertTrue(defaults["alternate_red_detection"])
+        self.assertEqual(defaults["puncta_line_width"], 2.5)
+        self.assertEqual(defaults["puncta_line_width_unit"], "um")
+        self.assertEqual(defaults["cen_dot_distance"], 11.2)
+        self.assertEqual(defaults["cen_dot_distance_unit"], "px")
+        self.assertEqual(defaults["cen_dot_proximity_radius"], 6.5)
+        self.assertEqual(defaults["cen_dot_proximity_radius_unit"], "um")
+        self.assertEqual(defaults["biorientation_red_min_distance"], 1.5)
+        self.assertEqual(defaults["biorientation_red_min_distance_unit"], "px")
+        self.assertEqual(defaults["biorientation_red_max_distance"], 44.5)
+        self.assertEqual(defaults["biorientation_red_max_distance_unit"], "um")
+        self.assertEqual(defaults["biorientation_collinearity_threshold"], 77)
+        self.assertEqual(defaults["puncta_line_mode"], "green_puncta")
+        self.assertEqual(defaults["nuclear_cell_pair_mode"], "red_nucleus")
+        self.assertEqual(defaults["microns_per_pixel"], 0.25)
+        self.assertFalse(defaults["use_metadata_scale"])
+        self.assertEqual(defaults["spatial_stats_unit"], "px")
+
+    def test_experiment_workflow_defaults_endpoint_preserves_non_popup_preferences(self):
+        preferences = get_user_preferences(self.user)
+        preferences["auto_save_experiments"] = False
+        preferences["show_saved_file_channels"] = False
+        preferences["show_saved_file_scales"] = False
+        preferences["sidebar_starts_open"] = False
+        preferences["sidebar_spatial_stats_unit"] = "um"
+        preferences["experiment_defaults"]["spatial_stats_unit"] = "um"
+        update_user_preferences(self.user, preferences)
+
+        response = self.client.post(
+            reverse("experiment_workflow_defaults"),
+            data=json.dumps(self._build_experiment_workflow_defaults_payload()),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        updated = get_user_preferences(self.user)
+        self.assertFalse(updated["auto_save_experiments"])
+        self.assertFalse(updated["show_saved_file_channels"])
+        self.assertFalse(updated["show_saved_file_scales"])
+        self.assertFalse(updated["sidebar_starts_open"])
+        self.assertEqual(updated["sidebar_spatial_stats_unit"], "um")
+        self.assertEqual(updated["experiment_defaults"]["spatial_stats_unit"], "um")
+
+    def test_experiment_workflow_defaults_endpoint_rejects_invalid_payload(self):
+        baseline = get_user_preferences(self.user)
+        cases = (
+            {"selected_plugins": ["UnknownPlugin"]},
+            {"puncta_line_width_unit": "bad"},
+            {"green_dot_split_mode": "invalid"},
+            {"manual_required_channels": ["DIC"]},
+        )
+
+        for overrides in cases:
+            payload = self._build_experiment_workflow_defaults_payload()
+            payload.update(overrides)
+            response = self.client.post(
+                reverse("experiment_workflow_defaults"),
+                data=json.dumps(payload),
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertTrue(response.json()["errors"])
+            self.user.refresh_from_db()
+            self.assertEqual(get_user_preferences(self.user), baseline)
+
+    def test_experiment_page_uses_updated_saved_workflow_defaults(self):
+        response = self.client.post(
+            reverse("experiment_workflow_defaults"),
+            data=json.dumps(self._build_experiment_workflow_defaults_payload()),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        experiment_response = self.client.get(reverse("experiment"))
+        self.assertEqual(experiment_response.status_code, 200)
+        rendered_defaults = json.loads(experiment_response.context["user_preference_defaults_json"])
+        self.assertEqual(rendered_defaults["selected_plugins"], ["PunctaDistance", "GreenRedIntensity"])
+        self.assertEqual(rendered_defaults["cen_dot_proximity_radius"], 6.5)
+        self.assertEqual(rendered_defaults["green_dot_split_mode"], "aggressive")
+        self.assertEqual(rendered_defaults["nuclear_cell_pair_mode"], "red_nucleus")
 
     def test_preferences_plugin_payload_includes_exclusive_and_dependency_fields(self):
         response = self.client.get(reverse("workflow_defaults"))

--- a/cytocv/core/tests/test_core_app.py
+++ b/cytocv/core/tests/test_core_app.py
@@ -260,6 +260,10 @@ class RouteSurfaceRefactorTests(TestCase):
         self.assertEqual(reverse("workflow_defaults"), "/workflow-defaults/")
         self.assertEqual(reverse("experiment"), "/experiment/")
         self.assertEqual(
+            reverse("experiment_workflow_defaults"),
+            "/api/experiment/workflow-defaults/",
+        )
+        self.assertEqual(
             reverse("pre_process", args=[uuid_value]),
             f"/experiment/{uuid_value}/pre-process/",
         )

--- a/cytocv/core/tests/test_green_dot_split.py
+++ b/cytocv/core/tests/test_green_dot_split.py
@@ -6,7 +6,13 @@ import cv2
 import numpy as np
 from django.test import SimpleTestCase
 
-from core.contour_processing.contour_operations import _split_merged_green_contours
+from core.contour_processing.contour_operations import (
+    _split_merged_green_contours,
+    _split_params,
+    compute_contour_shape_metrics,
+    find_convexity_defect_neck_candidates,
+    postprocess_gfp_contours_for_neck_splits,
+)
 
 
 def _dumbbell(radius_a: int, radius_b: int, center_distance: int, shape=(80, 100)) -> np.ndarray:
@@ -21,6 +27,63 @@ def _dumbbell(radius_a: int, radius_b: int, center_distance: int, shape=(80, 100
 def _contour_count(mask: np.ndarray, *, min_area: float = 8.0) -> int:
     contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
     return sum(1 for contour in contours if cv2.contourArea(contour) >= min_area)
+
+
+def _contours_from_mask(mask: np.ndarray) -> list[np.ndarray]:
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    return list(contours)
+
+
+def _contour_list_count(contours: list[np.ndarray], *, min_area: float = 8.0) -> int:
+    return sum(1 for contour in contours if cv2.contourArea(contour) >= min_area)
+
+
+def _gaussian_pair_image(
+    *,
+    center_a=(48, 48),
+    center_b=(66, 48),
+    sigma: float = 4.0,
+    bridge_intensity: float = 45.0,
+    amplitude_a: float = 220.0,
+    amplitude_b: float = 220.0,
+    shape=(96, 128),
+) -> np.ndarray:
+    y_grid, x_grid = np.mgrid[0 : shape[0], 0 : shape[1]]
+    dot_a = amplitude_a * np.exp(
+        -(
+            ((x_grid - center_a[0]) ** 2 + (y_grid - center_a[1]) ** 2)
+            / (2.0 * sigma * sigma)
+        )
+    )
+    dot_b = amplitude_b * np.exp(
+        -(
+            ((x_grid - center_b[0]) ** 2 + (y_grid - center_b[1]) ** 2)
+            / (2.0 * sigma * sigma)
+        )
+    )
+    image = np.maximum(dot_a, dot_b)
+    cv2.line(image, center_a, center_b, bridge_intensity, 3)
+    return np.clip(image, 0, 255).astype(np.uint8)
+
+
+def _one_sided_notch_mask(shape=(96, 128)) -> np.ndarray:
+    mask = np.zeros(shape, dtype=np.uint8)
+    cv2.circle(mask, (54, 48), 13, 255, -1)
+    cv2.circle(mask, (74, 48), 13, 255, -1)
+    # Fill the upper waist so only the lower side has a real inward bite.
+    cv2.rectangle(mask, (54, 35), (74, 48), 255, -1)
+    return mask
+
+
+def _single_gaussian_image(*, center=(50, 40), sigma: float = 4.5, shape=(80, 100)) -> np.ndarray:
+    y_grid, x_grid = np.mgrid[0 : shape[0], 0 : shape[1]]
+    image = 220.0 * np.exp(
+        -(
+            ((x_grid - center[0]) ** 2 + (y_grid - center[1]) ** 2)
+            / (2.0 * sigma * sigma)
+        )
+    )
+    return np.clip(image, 0, 255).astype(np.uint8)
 
 
 class GreenDotSplitTests(SimpleTestCase):
@@ -55,3 +118,156 @@ class GreenDotSplitTests(SimpleTestCase):
 
         self.assertEqual(_contour_count(balanced), 1)
         self.assertEqual(_contour_count(aggressive), 2)
+
+    def test_aggressive_postprocessor_splits_gaussian_pair_with_dim_bridge(self):
+        image = _gaussian_pair_image(bridge_intensity=40.0)
+        mask = (image > 32).astype(np.uint8) * 255
+        contours = _contours_from_mask(mask)
+
+        split = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            image,
+            {"mode": "aggressive"},
+        )
+
+        self.assertEqual(len(contours), 1)
+        self.assertEqual(_contour_list_count(split), 2)
+
+    def test_aggressive_postprocessor_splits_binary_peanut_shape(self):
+        mask = np.zeros((96, 128), dtype=np.uint8)
+        cv2.circle(mask, (54, 48), 13, 255, -1)
+        cv2.circle(mask, (74, 48), 13, 255, -1)
+        contours = _contours_from_mask(mask)
+
+        split = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            mask,
+            {"mode": "aggressive"},
+        )
+
+        self.assertEqual(len(contours), 1)
+        self.assertEqual(_contour_list_count(split), 2)
+
+    def test_aggressive_postprocessor_keeps_slightly_irregular_single_dot(self):
+        mask = np.zeros((80, 100), dtype=np.uint8)
+        cv2.circle(mask, (50, 40), 11, 255, -1)
+        cv2.circle(mask, (58, 37), 3, 0, -1)
+        cv2.circle(mask, (44, 45), 2, 0, -1)
+        contours = _contours_from_mask(mask)
+
+        split = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            mask,
+            {"mode": "aggressive"},
+        )
+
+        self.assertEqual(_contour_list_count(split), 1)
+
+    def test_aggressive_postprocessor_splits_close_pair_with_strong_bridge(self):
+        image = _gaussian_pair_image(bridge_intensity=90.0)
+        mask = (image > 30).astype(np.uint8) * 255
+        contours = _contours_from_mask(mask)
+
+        split = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            image,
+            {"mode": "aggressive"},
+        )
+
+        self.assertEqual(len(contours), 1)
+        self.assertEqual(_contour_list_count(split), 2)
+
+    def test_aggressive_fallback_splits_one_sided_notch_that_has_no_paired_neck(self):
+        mask = _one_sided_notch_mask()
+        image = _gaussian_pair_image(
+            center_a=(54, 48),
+            center_b=(74, 48),
+            bridge_intensity=42.0,
+            shape=mask.shape,
+        )
+        contours = _contours_from_mask(mask)
+        contour = max(contours, key=cv2.contourArea)
+        params = _split_params("aggressive")
+        metrics = compute_contour_shape_metrics(
+            contour,
+            mask.shape,
+            min_defect_depth_px=params["min_defect_depth_px"],
+        )
+
+        self.assertIsNotNone(metrics)
+        self.assertEqual(
+            find_convexity_defect_neck_candidates(metrics.contour, metrics.mask, params),
+            [],
+        )
+
+        balanced = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            image,
+            {"mode": "balanced"},
+        )
+        aggressive = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            image,
+            {"mode": "aggressive"},
+        )
+
+        self.assertEqual(_contour_list_count(balanced), 1)
+        self.assertEqual(_contour_list_count(aggressive), 2)
+
+    def test_aggressive_fallback_splits_asymmetric_two_gaussian_pair(self):
+        image = _gaussian_pair_image(
+            center_a=(48, 48),
+            center_b=(66, 48),
+            bridge_intensity=38.0,
+            amplitude_a=230.0,
+            amplitude_b=130.0,
+        )
+        mask = (image > 28).astype(np.uint8) * 255
+        kernel = cv2.getStructuringElement(cv2.MORPH_CROSS, (3, 3))
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
+        contours = _contours_from_mask(mask)
+
+        split = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            image,
+            {"mode": "aggressive"},
+        )
+
+        self.assertEqual(len(contours), 1)
+        self.assertEqual(_contour_list_count(split), 2)
+
+    def test_aggressive_fallback_keeps_single_crescent_dot_with_one_peak(self):
+        mask = np.zeros((80, 100), dtype=np.uint8)
+        cv2.circle(mask, (50, 40), 12, 255, -1)
+        cv2.circle(mask, (58, 40), 7, 0, -1)
+        contours = _contours_from_mask(mask)
+        image = _single_gaussian_image(center=(47, 40), shape=mask.shape)
+
+        split = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            image,
+            {"mode": "aggressive"},
+        )
+
+        self.assertEqual(len(contours), 1)
+        self.assertEqual(_contour_list_count(split), 1)
+
+    def test_two_bright_spots_inside_broad_convex_background_are_not_split(self):
+        shape = (120, 140)
+        mask = np.zeros(shape, dtype=np.uint8)
+        cv2.ellipse(mask, (70, 60), (38, 24), 0, 0, 360, 255, -1)
+        image = np.zeros(shape, dtype=np.float32)
+        image[mask > 0] = 28.0
+        y_grid, x_grid = np.mgrid[0 : shape[0], 0 : shape[1]]
+        image += 120.0 * np.exp(-(((x_grid - 54) ** 2 + (y_grid - 56) ** 2) / 32.0))
+        image += 110.0 * np.exp(-(((x_grid - 86) ** 2 + (y_grid - 64) ** 2) / 32.0))
+        image = np.clip(image, 0, 255).astype(np.uint8)
+        contours = _contours_from_mask(mask)
+
+        split = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            image,
+            {"mode": "aggressive"},
+        )
+
+        self.assertEqual(_contour_list_count(split), 1)

--- a/cytocv/core/views/experiment.py
+++ b/cytocv/core/views/experiment.py
@@ -17,7 +17,12 @@ from ..stats_plugins import (
     normalize_selected_plugins,
 )
 import uuid as uuid_lib
-from accounts.preferences import get_user_preferences
+from accounts.preferences import (
+    PreferenceValidationError,
+    build_experiment_defaults_from_popup_payload,
+    get_user_preferences,
+    update_user_preferences,
+)
 from core.scale import (
     DEFAULT_MICRONS_PER_PIXEL,
     convert_length_to_pixels,
@@ -592,6 +597,40 @@ def experiment(request):
             user_preference_defaults=user_preferences.get("experiment_defaults", {}),
             upload_quota_payload=upload_quota_payload,
         ),
+    )
+
+
+@require_POST
+def save_experiment_workflow_defaults(request):
+    """Persist experiment-popup settings as the user's workflow defaults."""
+
+    try:
+        raw_payload = json.loads(request.body.decode("utf-8") or "{}")
+    except (TypeError, ValueError, UnicodeDecodeError):
+        return JsonResponse(
+            {"errors": ["Request body must be valid JSON."]},
+            status=400,
+        )
+
+    preferences = get_user_preferences(request.user)
+    try:
+        next_defaults = build_experiment_defaults_from_popup_payload(
+            raw_payload,
+            current_defaults=preferences.get("experiment_defaults", {}),
+        )
+    except PreferenceValidationError as exc:
+        return JsonResponse({"errors": [str(exc)]}, status=400)
+
+    next_payload = dict(preferences)
+    next_payload["experiment_defaults"] = next_defaults
+    updated_preferences = update_user_preferences(request.user, next_payload)
+    return JsonResponse(
+        {
+            "message": (
+                "Workflow default updated. Future experiments will start with this configuration."
+            ),
+            "defaults": updated_preferences.get("experiment_defaults", {}),
+        }
     )
 
 

--- a/cytocv/cytocv/urls.py
+++ b/cytocv/cytocv/urls.py
@@ -41,6 +41,7 @@ from core.views.experiment import (
     cancel_upload_preparation,
     enqueue_upload_preparation,
     experiment,
+    save_experiment_workflow_defaults,
     upload_file_batch,
     upload_preparation_status,
 )
@@ -86,6 +87,11 @@ urlpatterns = [
         'api/experiment/uploads/',
         login_required(upload_file_batch),
         name="experiment_upload_batch",
+    ),
+    path(
+        'api/experiment/workflow-defaults/',
+        login_required(save_experiment_workflow_defaults),
+        name="experiment_workflow_defaults",
     ),
     path(
         'api/experiment/upload-prep/',

--- a/cytocv/templates/form/experiment.html
+++ b/cytocv/templates/form/experiment.html
@@ -754,7 +754,10 @@
         }
         .stats-view-footer {
             display: flex;
-            justify-content: flex-end;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+            flex-wrap: wrap;
             margin-top: auto;
             padding-top: 8px;
         }
@@ -763,7 +766,9 @@
             font-weight: 600;
             letter-spacing: 0.2px;
         }
-        .advanced-btn {
+        .advanced-btn,
+        .workflow-default-btn,
+        .back-btn {
             border: 1px solid var(--panel-border);
             border-radius: 8px;
             background: var(--surface-muted);
@@ -772,8 +777,14 @@
             padding: 7px 10px;
             cursor: pointer;
         }
-        .advanced-btn:hover {
+        .advanced-btn:hover,
+        .workflow-default-btn:hover,
+        .back-btn:hover {
             background: var(--surface-hover-strong);
+        }
+        .workflow-default-btn:disabled {
+            opacity: 0.68;
+            cursor: not-allowed;
         }
         .stats-divider {
             height: 1px;
@@ -1405,7 +1416,9 @@
         .advanced-header {
             display: flex;
             align-items: center;
-            justify-content: flex-start;
+            justify-content: space-between;
+            gap: 10px;
+            flex-wrap: wrap;
             margin-top: auto;
             padding-top: 8px;
         }
@@ -1439,18 +1452,6 @@
         #statsAdvancedView .advanced-header {
             flex: 0 0 auto;
             margin-top: 0;
-        }
-        .back-btn {
-            border: 1px solid var(--panel-border);
-            background: var(--surface-muted);
-            color: #fff;
-            border-radius: 8px;
-            padding: 7px 10px;
-            cursor: pointer;
-            font-size: 12px;
-        }
-        .back-btn:hover {
-            background: var(--surface-hover-strong);
         }
         .advanced-channel-group {
             display: flex;
@@ -1735,6 +1736,12 @@
                     <div class="measurement-scale-card" id="measurementScaleGroup"></div>
                 </div>
                 <div class="stats-view-footer">
+                    <button
+                        type="button"
+                        class="workflow-default-btn"
+                        id="saveWorkflowDefaultsPrimary"
+                        data-save-workflow-default="1"
+                    >Save as Workflow Default</button>
                     <button type="button" class="advanced-btn" id="openAdvancedSettings">Advanced Settings</button>
                 </div>
             </div>
@@ -1889,6 +1896,12 @@
                     </div>
                 </div>
                 <div class="advanced-header">
+                    <button
+                        type="button"
+                        class="workflow-default-btn"
+                        id="saveWorkflowDefaultsAdvanced"
+                        data-save-workflow-default="1"
+                    >Save as Workflow Default</button>
                     <button type="button" class="back-btn" id="advancedBackButton" aria-label="Back To Stats Settings">Back</button>
                 </div>
             </div>
@@ -1997,6 +2010,19 @@
         <div class="nav-exit-actions">
             <button type="button" class="nav-exit-btn confirm" id="statsUnsavedKeepOld">Keep Old Settings</button>
             <button type="button" class="nav-exit-btn cancel" id="statsUnsavedKeepNew">Keep New Changes</button>
+        </div>
+    </div>
+</div>
+
+<div class="nav-exit-backdrop popup-backdrop" id="saveWorkflowDefaultsBackdrop" aria-hidden="true">
+    <div class="nav-exit-modal popup-surface" role="dialog" aria-modal="true" aria-labelledby="saveWorkflowDefaultsTitle">
+        <div class="nav-exit-title" id="saveWorkflowDefaultsTitle">Save as workflow default?</div>
+        <div class="nav-exit-body" id="saveWorkflowDefaultsBody">
+            Use the current plugin, advanced-setting, and measurement-scale configuration as the default for future experiments? This does not start analysis or change saved results.
+        </div>
+        <div class="nav-exit-actions">
+            <button type="button" class="nav-exit-btn confirm" id="saveWorkflowDefaultsCancel">Cancel</button>
+            <button type="button" class="nav-exit-btn cancel" id="saveWorkflowDefaultsConfirm">Save as Workflow Default</button>
         </div>
     </div>
 </div>
@@ -4512,12 +4538,118 @@
         });
     }
 
+    function commitStatsStateFromInputs() {
+        persistSelectedPlugins();
+        persistAdvancedSettings();
+        persistLengthUnitSettings();
+
+        if (micronsPerPixelInput) {
+            statsState.micronsPerPixel = sanitizeMicronsPerPixel(micronsPerPixelInput.value);
+            micronsPerPixelInput.value = formatNumericInputValue(statsState.micronsPerPixel);
+            localStorage.setItem(micronsPerPixelKey, String(statsState.micronsPerPixel));
+        }
+        if (useMetadataScaleInput) {
+            statsState.useMetadataScale = !!useMetadataScaleInput.checked;
+            localStorage.setItem(useMetadataScaleKey, String(statsState.useMetadataScale));
+        }
+        if (punctaLineWidthInput) {
+            const fallback = defaultWidthForUnit(statsState.punctaLineWidthUnit);
+            const minimum = statsState.punctaLineWidthUnit === 'um' ? 0.01 : 1;
+            statsState.punctaLineWidth = parseLengthValue(
+                punctaLineWidthInput.value,
+                statsState.punctaLineWidthUnit,
+                fallback,
+                minimum
+            );
+            punctaLineWidthInput.value = formatNumericInputValue(statsState.punctaLineWidth);
+            localStorage.setItem(widthKey, String(statsState.punctaLineWidth));
+        }
+        if (cenDotDistanceInput) {
+            const fallback = defaultDistanceForUnit(statsState.cenDotDistanceUnit);
+            statsState.cenDotDistance = parseLengthValue(
+                cenDotDistanceInput.value,
+                statsState.cenDotDistanceUnit,
+                fallback,
+                0
+            );
+            cenDotDistanceInput.value = formatNumericInputValue(statsState.cenDotDistance);
+            localStorage.setItem(distanceKey, String(statsState.cenDotDistance));
+        }
+        if (cenDotProximityRadiusInput) {
+            const fallback = defaultProximityRadiusForUnit(statsState.cenDotProximityRadiusUnit);
+            statsState.cenDotProximityRadius = parseLengthValue(
+                cenDotProximityRadiusInput.value,
+                statsState.cenDotProximityRadiusUnit,
+                fallback,
+                0
+            );
+            cenDotProximityRadiusInput.value = formatNumericInputValue(statsState.cenDotProximityRadius);
+            localStorage.setItem(proximityRadiusKey, String(statsState.cenDotProximityRadius));
+        }
+        if (biorientationRedMinDistanceInput) {
+            statsState.biorientationRedMinDistance = parseLengthValue(
+                biorientationRedMinDistanceInput.value,
+                statsState.biorientationRedMinDistanceUnit,
+                defaultBiorientationMinDistanceForUnit(),
+                0
+            );
+            biorientationRedMinDistanceInput.value = formatNumericInputValue(statsState.biorientationRedMinDistance);
+            localStorage.setItem(biorientationRedMinDistanceKey, String(statsState.biorientationRedMinDistance));
+        }
+        if (biorientationRedMaxDistanceInput) {
+            statsState.biorientationRedMaxDistance = parseLengthValue(
+                biorientationRedMaxDistanceInput.value,
+                statsState.biorientationRedMaxDistanceUnit,
+                defaultBiorientationMaxDistanceForUnit(statsState.biorientationRedMaxDistanceUnit),
+                0
+            );
+            biorientationRedMaxDistanceInput.value = formatNumericInputValue(statsState.biorientationRedMaxDistance);
+            localStorage.setItem(biorientationRedMaxDistanceKey, String(statsState.biorientationRedMaxDistance));
+        }
+        if (biorientationCollinearityThresholdInput) {
+            const parsed = parseInt(biorientationCollinearityThresholdInput.value, 10);
+            statsState.biorientationCollinearityThreshold = Number.isFinite(parsed) && parsed >= 0 ? parsed : 66;
+            biorientationCollinearityThresholdInput.value = String(statsState.biorientationCollinearityThreshold);
+            localStorage.setItem(
+                biorientationThresholdKey,
+                String(statsState.biorientationCollinearityThreshold)
+            );
+        }
+        if (punctaLineModeSelect) {
+            statsState.punctaLineMode = punctaLineModeSelect.value === 'green_puncta'
+                ? 'green_puncta'
+                : 'red_puncta';
+            localStorage.setItem(punctaModeKey, statsState.punctaLineMode);
+        }
+        if (nuclearModeSelect) {
+            statsState.nuclearCellPairMode = nuclearModeSelect.value === 'red_nucleus'
+                ? 'red_nucleus'
+                : 'green_nucleus';
+            localStorage.setItem(nuclearModeKey, statsState.nuclearCellPairMode);
+        }
+
+        const usingMicrometers = statsState.punctaLineWidthUnit === 'um'
+            || statsState.cenDotDistanceUnit === 'um'
+            || statsState.cenDotProximityRadiusUnit === 'um'
+            || statsState.biorientationRedMinDistanceUnit === 'um'
+            || statsState.biorientationRedMaxDistanceUnit === 'um';
+        if (usingMicrometers && !(Number.isFinite(statsState.micronsPerPixel) && statsState.micronsPerPixel > 0)) {
+            return {
+                ok: false,
+                errors: ['Micrometers-per-pixel must be greater than 0 when using micrometer input.'],
+            };
+        }
+
+        return { ok: true };
+    }
+
     function setupSettingsModal() {
         const settingsButton = document.getElementById('settingsButton');
         const backdrop = document.getElementById('settingsBackdrop');
         const closeButton = document.getElementById('settingsClose');
         const openAdvanced = document.getElementById('openAdvancedSettings');
         const backButton = document.getElementById('advancedBackButton');
+        const saveDefaultButtons = Array.from(document.querySelectorAll('[data-save-workflow-default]'));
         const primaryView = document.getElementById('statsPrimaryView');
         const advancedView = document.getElementById('statsAdvancedView');
         const modalPanel = backdrop ? backdrop.querySelector('.settings-modal') : null;
@@ -4525,6 +4657,10 @@
         const keepOldButton = document.getElementById('statsUnsavedKeepOld');
         const keepNewButton = document.getElementById('statsUnsavedKeepNew');
         const unsavedPanel = unsavedBackdrop ? unsavedBackdrop.querySelector('.nav-exit-modal') : null;
+        const saveDefaultsBackdrop = document.getElementById('saveWorkflowDefaultsBackdrop');
+        const saveDefaultsCancelButton = document.getElementById('saveWorkflowDefaultsCancel');
+        const saveDefaultsConfirmButton = document.getElementById('saveWorkflowDefaultsConfirm');
+        const saveDefaultsPanel = saveDefaultsBackdrop ? saveDefaultsBackdrop.querySelector('.nav-exit-modal') : null;
 
         if (!settingsButton || !backdrop || !closeButton || !primaryView || !advancedView) {
             return;
@@ -4725,6 +4861,166 @@
                 document.addEventListener('keydown', onKeydown);
             });
         };
+        saveDefaultButtons.forEach((button) => {
+            if (!button.dataset.defaultLabel) {
+                button.dataset.defaultLabel = button.textContent.trim() || 'Save as Workflow Default';
+            }
+        });
+
+        const setWorkflowDefaultButtonsPending = (pending) => {
+            saveDefaultButtons.forEach((button) => {
+                button.disabled = pending;
+                button.textContent = pending
+                    ? 'Saving...'
+                    : (button.dataset.defaultLabel || 'Save as Workflow Default');
+            });
+        };
+
+        const showWorkflowDefaultError = (message) => {
+            if (window.showGlobalMessage) {
+                window.showGlobalMessage(
+                    message || 'Could not save workflow default. Please try again.',
+                    'error'
+                );
+                return;
+            }
+            showErrors([message || 'Could not save workflow default. Please try again.']);
+        };
+
+        const promptWorkflowDefaultConfirmation = () => {
+            if (
+                !saveDefaultsBackdrop
+                || !saveDefaultsCancelButton
+                || !saveDefaultsConfirmButton
+            ) {
+                return Promise.resolve(true);
+            }
+            openPopupModal(saveDefaultsBackdrop, saveDefaultsPanel);
+
+            return new Promise((resolve) => {
+                let settled = false;
+                const closePrompt = (decision) => {
+                    if (settled) return;
+                    settled = true;
+                    cleanup();
+                    closePopupModal(saveDefaultsBackdrop, saveDefaultsPanel, () => resolve(decision));
+                };
+                const onCancel = () => closePrompt(false);
+                const onConfirm = () => closePrompt(true);
+                const onBackdrop = (event) => {
+                    if (event.target === saveDefaultsBackdrop) {
+                        closePrompt(false);
+                    }
+                };
+                const onKeydown = (event) => {
+                    if (event.key === 'Escape') {
+                        closePrompt(false);
+                    }
+                };
+                const cleanup = () => {
+                    saveDefaultsCancelButton.removeEventListener('click', onCancel);
+                    saveDefaultsConfirmButton.removeEventListener('click', onConfirm);
+                    saveDefaultsBackdrop.removeEventListener('click', onBackdrop);
+                    document.removeEventListener('keydown', onKeydown);
+                };
+
+                saveDefaultsCancelButton.addEventListener('click', onCancel);
+                saveDefaultsConfirmButton.addEventListener('click', onConfirm);
+                saveDefaultsBackdrop.addEventListener('click', onBackdrop);
+                document.addEventListener('keydown', onKeydown);
+            });
+        };
+
+        const buildWorkflowDefaultPayload = () => {
+            const snapshot = captureStatsSnapshot();
+            return {
+                selected_plugins: snapshot.selectedPlugins,
+                module_enabled: snapshot.moduleEnabled,
+                enforce_layer_count: snapshot.enforceLayerCount,
+                enforce_wavelengths: snapshot.enforceAllWavelengths,
+                show_legacy_plugins: snapshot.showLegacyPlugins,
+                manual_required_channels: snapshot.manualRequiredChannels,
+                green_contour_filter_enabled: snapshot.greenContourFilterEnabled,
+                green_dot_split_enabled: snapshot.greenDotSplitEnabled,
+                green_dot_split_mode: snapshot.greenDotSplitMode,
+                alternate_red_detection: snapshot.alternateRedDetection,
+                puncta_line_width: snapshot.punctaLineWidth,
+                puncta_line_width_unit: snapshot.punctaLineWidthUnit,
+                cen_dot_distance: snapshot.cenDotDistance,
+                cen_dot_distance_unit: snapshot.cenDotDistanceUnit,
+                cen_dot_proximity_radius: snapshot.cenDotProximityRadius,
+                cen_dot_proximity_radius_unit: snapshot.cenDotProximityRadiusUnit,
+                biorientation_red_min_distance: snapshot.biorientationRedMinDistance,
+                biorientation_red_min_distance_unit: snapshot.biorientationRedMinDistanceUnit,
+                biorientation_red_max_distance: snapshot.biorientationRedMaxDistance,
+                biorientation_red_max_distance_unit: snapshot.biorientationRedMaxDistanceUnit,
+                biorientation_collinearity_threshold: snapshot.biorientationCollinearityThreshold,
+                puncta_line_mode: snapshot.punctaLineMode,
+                nuclear_cell_pair_mode: snapshot.nuclearCellPairMode,
+                microns_per_pixel: snapshot.micronsPerPixel,
+                use_metadata_scale: snapshot.useMetadataScale,
+            };
+        };
+
+        const saveCurrentWorkflowDefaults = async () => {
+            const syncResult = commitStatsStateFromInputs();
+            if (!syncResult.ok) {
+                showErrors(syncResult.errors || ['Could not save workflow default. Please try again.']);
+                return;
+            }
+
+            const confirmed = await promptWorkflowDefaultConfirmation();
+            if (!confirmed) {
+                return;
+            }
+
+            setWorkflowDefaultButtonsPending(true);
+            try {
+                const csrfTokenInput = document.querySelector('[name=csrfmiddlewaretoken]');
+                const response = await fetch('{% url "experiment_workflow_defaults" %}', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': csrfTokenInput ? csrfTokenInput.value : '',
+                        'X-Requested-With': 'XMLHttpRequest',
+                    },
+                    credentials: 'same-origin',
+                    body: JSON.stringify(buildWorkflowDefaultPayload()),
+                });
+                const contentType = response.headers.get('content-type') || '';
+                const responsePayload = contentType.includes('application/json')
+                    ? await response.json()
+                    : {};
+                if (!response.ok) {
+                    const errorMessage = Array.isArray(responsePayload.errors) && responsePayload.errors.length
+                        ? responsePayload.errors.join('\n')
+                        : (responsePayload.error || 'Could not save workflow default. Please try again.');
+                    throw new Error(errorMessage);
+                }
+
+                if (responsePayload.defaults && typeof responsePayload.defaults === 'object') {
+                    serverPreferenceDefaults = responsePayload.defaults;
+                    if (serverPreferenceDefaultsElement) {
+                        serverPreferenceDefaultsElement.textContent = JSON.stringify(responsePayload.defaults);
+                    }
+                }
+                if (window.showGlobalMessage) {
+                    window.showGlobalMessage(
+                        responsePayload.message
+                            || 'Workflow default updated. Future experiments will start with this configuration.',
+                        'success'
+                    );
+                }
+            } catch (error) {
+                showWorkflowDefaultError(
+                    error && error.message
+                        ? error.message
+                        : 'Could not save workflow default. Please try again.'
+                );
+            } finally {
+                setWorkflowDefaultButtonsPending(false);
+            }
+        };
 
         const switchToView = (target, animate = false) => {
             hideInfoTooltip();
@@ -4847,13 +5143,21 @@
                 showPrimary(true);
             });
         }
+        saveDefaultButtons.forEach((button) => {
+            button.addEventListener('click', (event) => {
+                event.preventDefault();
+                saveCurrentWorkflowDefaults();
+            });
+        });
         backdrop.addEventListener('click', (event) => {
             if (event.target === backdrop) {
                 attemptCloseModal();
             }
         });
         document.addEventListener('keydown', (event) => {
-            if (event.key === 'Escape' && backdrop.style.display === 'flex') {
+            const saveConfirmOpen = saveDefaultsBackdrop && saveDefaultsBackdrop.style.display === 'flex';
+            const unsavedPromptOpen = unsavedBackdrop && unsavedBackdrop.style.display === 'flex';
+            if (event.key === 'Escape' && backdrop.style.display === 'flex' && !saveConfirmOpen && !unsavedPromptOpen) {
                 attemptCloseModal();
             }
         });
@@ -5360,69 +5664,9 @@
                 return;
             }
 
-            persistSelectedPlugins();
-            persistAdvancedSettings();
-            persistLengthUnitSettings();
-            if (punctaLineWidthInput) {
-                const fallback = defaultWidthForUnit(statsState.punctaLineWidthUnit);
-                const minimum = statsState.punctaLineWidthUnit === 'um' ? 0.01 : 1;
-                statsState.punctaLineWidth = parseLengthValue(punctaLineWidthInput.value, statsState.punctaLineWidthUnit, fallback, minimum);
-                punctaLineWidthInput.value = formatNumericInputValue(statsState.punctaLineWidth);
-                localStorage.setItem(widthKey, String(statsState.punctaLineWidth));
-            }
-            if (cenDotDistanceInput) {
-                const fallback = defaultDistanceForUnit(statsState.cenDotDistanceUnit);
-                statsState.cenDotDistance = parseLengthValue(cenDotDistanceInput.value, statsState.cenDotDistanceUnit, fallback, 0);
-                cenDotDistanceInput.value = formatNumericInputValue(statsState.cenDotDistance);
-                localStorage.setItem(distanceKey, String(statsState.cenDotDistance));
-            }
-            if (cenDotProximityRadiusInput) {
-                const fallback = defaultProximityRadiusForUnit(statsState.cenDotProximityRadiusUnit);
-                statsState.cenDotProximityRadius = parseLengthValue(cenDotProximityRadiusInput.value, statsState.cenDotProximityRadiusUnit, fallback, 0);
-                cenDotProximityRadiusInput.value = formatNumericInputValue(statsState.cenDotProximityRadius);
-                localStorage.setItem(proximityRadiusKey, String(statsState.cenDotProximityRadius));
-            }
-            if (biorientationRedMinDistanceInput) {
-                statsState.biorientationRedMinDistance = parseLengthValue(
-                    biorientationRedMinDistanceInput.value,
-                    statsState.biorientationRedMinDistanceUnit,
-                    defaultBiorientationMinDistanceForUnit(),
-                    0
-                );
-                biorientationRedMinDistanceInput.value = formatNumericInputValue(statsState.biorientationRedMinDistance);
-                localStorage.setItem(biorientationRedMinDistanceKey, String(statsState.biorientationRedMinDistance));
-            }
-            if (biorientationRedMaxDistanceInput) {
-                statsState.biorientationRedMaxDistance = parseLengthValue(
-                    biorientationRedMaxDistanceInput.value,
-                    statsState.biorientationRedMaxDistanceUnit,
-                    defaultBiorientationMaxDistanceForUnit(statsState.biorientationRedMaxDistanceUnit),
-                    0
-                );
-                biorientationRedMaxDistanceInput.value = formatNumericInputValue(statsState.biorientationRedMaxDistance);
-                localStorage.setItem(biorientationRedMaxDistanceKey, String(statsState.biorientationRedMaxDistance));
-            }
-            if (biorientationCollinearityThresholdInput) {
-                const parsed = parseInt(biorientationCollinearityThresholdInput.value, 10);
-                statsState.biorientationCollinearityThreshold = Number.isFinite(parsed) && parsed >= 0 ? parsed : 66;
-                biorientationCollinearityThresholdInput.value = String(statsState.biorientationCollinearityThreshold);
-                localStorage.setItem(biorientationThresholdKey, String(statsState.biorientationCollinearityThreshold));
-            }
-            if (punctaLineModeSelect) {
-                statsState.punctaLineMode = punctaLineModeSelect.value === 'green_puncta' ? 'green_puncta' : 'red_puncta';
-            }
-            localStorage.setItem(punctaModeKey, statsState.punctaLineMode);
-            if (nuclearModeSelect) {
-                statsState.nuclearCellPairMode = nuclearModeSelect.value === 'red_nucleus' ? 'red_nucleus' : 'green_nucleus';
-            }
-            localStorage.setItem(nuclearModeKey, statsState.nuclearCellPairMode);
-            const usingMicrometers = statsState.punctaLineWidthUnit === 'um'
-                || statsState.cenDotDistanceUnit === 'um'
-                || statsState.cenDotProximityRadiusUnit === 'um'
-                || statsState.biorientationRedMinDistanceUnit === 'um'
-                || statsState.biorientationRedMaxDistanceUnit === 'um';
-            if (usingMicrometers && !(Number.isFinite(statsState.micronsPerPixel) && statsState.micronsPerPixel > 0)) {
-                showErrors([
+            const syncResult = commitStatsStateFromInputs();
+            if (!syncResult.ok) {
+                showErrors(syncResult.errors || [
                     'Micrometers-per-pixel must be greater than 0 when using micrometer input.',
                 ]);
                 return;
@@ -5446,7 +5690,7 @@
             };
 
             const controls = document.querySelectorAll(
-                '.upload-btn, .submit-btn, .settings-btn, .settings-close, .advanced-btn, .back-btn, .upload-page-back-btn, .folder-issue-btn, input[type="file"], input[type="checkbox"], input[type="number"], .remove-btn'
+                '.upload-btn, .submit-btn, .settings-btn, .settings-close, .advanced-btn, .back-btn, .workflow-default-btn, .upload-page-back-btn, .folder-issue-btn, input[type="file"], input[type="checkbox"], input[type="number"], .remove-btn'
             );
             controls.forEach((el) => {
                 el.disabled = true;


### PR DESCRIPTION
This pull request adds robust backend support and comprehensive tests for saving and validating experiment workflow default settings via a new API endpoint. The main changes include introducing strict validation for workflow default payloads, adding a new normalization function, and extending the test suite to cover the new logic and endpoint.

**Experiment Workflow Defaults Support**

* Added the `build_experiment_defaults_from_popup_payload` function to strictly validate and normalize experiment workflow default payloads, including type checks, allowed values, and error handling for all supported fields.
* Introduced helper validation functions (e.g., `_strict_bool`, `_strict_float`, `_strict_int`, `_strict_unit`, `_strict_mode`) and the custom `PreferenceValidationError` exception for clear error reporting on invalid input. [[1]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379R116-R170) [[2]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379L17-R33)

**Testing and Endpoint Integration**

* Added tests for the new experiment workflow defaults API endpoint, covering persistence, field validation, error cases, and ensuring unrelated preferences are preserved.
* Added a helper method to build valid workflow defaults payloads for use in tests.
* Updated route tests to include the new `/api/experiment/workflow-defaults/` endpoint.

**Green Dot Split Utilities (Testing Only)**

* Added utility functions and imports to `test_green_dot_split.py` to support more flexible and realistic test data generation for contour splitting. [[1]](diffhunk://#diff-c16eef68457100cea1a6a79a8bf1a51dc28c1abaca687dbf8aa4b3d15ca3c179L9-R15) [[2]](diffhunk://#diff-c16eef68457100cea1a6a79a8bf1a51dc28c1abaca687dbf8aa4b3d15ca3c179R32-R88)