### PR TITLE
Enhance Green merge-fix splitting and default settings for workflows

### DIFF
--- a/cytocv/accounts/preferences.py
+++ b/cytocv/accounts/preferences.py
@@ -12,7 +12,6 @@ from core.services.puncta_line_mode import (
     normalize_puncta_line_mode,
 )
 from core.services.green_dot_split import (
-    DEFAULT_GREEN_DOT_SPLIT_MODE,
     normalize_green_dot_split_mode,
 )
 from core.stats_plugins import (
@@ -52,7 +51,7 @@ DEFAULT_USER_PREFERENCES: dict[str, Any] = {
         "biorientation_red_max_distance": 37,
         "biorientation_collinearity_threshold": 66,
         "green_dot_split_enabled": True,
-        "green_dot_split_mode": DEFAULT_GREEN_DOT_SPLIT_MODE,
+        "green_dot_split_mode": "aggressive",
         "puncta_line_mode": DEFAULT_PUNCTA_LINE_MODE,
         "nuclear_cell_pair_mode": "green_nucleus",
         "green_contour_filter_enabled": False,
@@ -328,12 +327,18 @@ def normalize_preferences_payload(raw_payload: Any) -> dict[str, Any]:
         ),
         default=True,
     )
-    normalized["experiment_defaults"]["green_dot_split_mode"] = normalize_green_dot_split_mode(
-        defaults_payload.get(
-            "green_dot_split_mode",
-            defaults_payload.get("greenDotSplitMode"),
-        )
+    raw_green_dot_split_mode = _first_present(
+        defaults_payload.get("green_dot_split_mode"),
+        defaults_payload.get("greenDotSplitMode"),
     )
+    if raw_green_dot_split_mode is None:
+        normalized["experiment_defaults"]["green_dot_split_mode"] = normalized[
+            "experiment_defaults"
+        ]["green_dot_split_mode"]
+    else:
+        normalized["experiment_defaults"]["green_dot_split_mode"] = (
+            normalize_green_dot_split_mode(raw_green_dot_split_mode)
+        )
     normalized["experiment_defaults"]["puncta_line_mode"] = normalize_puncta_line_mode(
         defaults_payload.get("puncta_line_mode"),
         default=DEFAULT_PUNCTA_LINE_MODE,

--- a/cytocv/core/contour_processing/contour_operations.py
+++ b/cytocv/core/contour_processing/contour_operations.py
@@ -106,6 +106,11 @@ GREEN_DOT_SPLIT_PARAMS = {
 MAX_DEFECT_CANDIDATES = 8
 MAX_PEAK_CANDIDATES = 8
 PROFILE_SAMPLE_COUNT = 48
+MIN_GREEN_CONTOUR_AREA = 8
+GREEN_RING_KERNEL_SIZE = (11, 11)
+GREEN_RING_P90_FLOOR = 1.0
+GREEN_STRONG_PEAK_MAX_RATIO = 3.0
+GREEN_STRONG_PEAK_P90_RATIO = 2.5
 
 
 @dataclass(slots=True)
@@ -187,6 +192,20 @@ class _AggressiveSplitDecision:
     original_contour: np.ndarray
     output_contours: list[np.ndarray]
     accepted_split: bool
+
+
+@dataclass(slots=True, frozen=True)
+class _GreenContourFilterDecision:
+    bbox: tuple[int, int, int, int]
+    area: float
+    closed_open_ratio: float | None
+    inside_max: float | None
+    inside_p90: float | None
+    ring_p90: float | None
+    max_over_ring_p90: float | None
+    p90_over_ring_p90: float | None
+    ring_pixel_count: int
+    decision_reason: str
 
 
 def _split_params(split_mode: str) -> dict:
@@ -1627,7 +1646,10 @@ def _postprocess_and_filter_aggressive_green_contours(
     for contour in contours or []:
         decision = _aggressive_split_decision_for_contour(contour, gfp_image, config)
         if decision.accepted_split:
-            filtered_children = filterContours(decision.output_contours)
+            filtered_children, _ = _filter_green_contours_with_image(
+                decision.output_contours,
+                gfp_image,
+            )
             if len(filtered_children) == 2:
                 processed.extend(filtered_children)
             else:
@@ -1635,7 +1657,11 @@ def _postprocess_and_filter_aggressive_green_contours(
                 # original merged contour instead of returning one child.
                 processed.append(decision.original_contour)
             continue
-        processed.extend(filterContours(decision.output_contours))
+        filtered_contours, _ = _filter_green_contours_with_image(
+            decision.output_contours,
+            gfp_image,
+        )
+        processed.extend(filtered_contours)
     return processed
 
 
@@ -1902,9 +1928,15 @@ def find_contours(
                 {"mode": green_dot_split_mode},
             )
             if green_contour_filter_enabled:
-                contours_green = filterContours(contours_green)
+                contours_green, _ = _filter_green_contours_with_image(
+                    contours_green,
+                    gray_green,
+                )
         elif green_contour_filter_enabled:
-            contours_green = filterContours(contours_green)
+            contours_green, _ = _filter_green_contours_with_image(
+                contours_green,
+                gray_green,
+            )
 
     return {
         "best_contours": best_contours,
@@ -1974,6 +2006,145 @@ def merge_contour(bestContours, contours):
     if len(bestContours) == 1:
         logger.debug("Only one contour found while merging contour candidates")
     return best_contour
+
+
+def _closed_open_ratio(contour: np.ndarray) -> float | None:
+    closed = cv2.arcLength(contour, True)
+    opened = cv2.arcLength(contour, False)
+    if opened <= 0:
+        return None
+    return float(closed / opened)
+
+
+def _log_green_contour_filter_decisions(
+    decisions: list[_GreenContourFilterDecision],
+) -> None:
+    for decision in decisions:
+        logger.debug(
+            "Green contour filter decision: bbox=%s area=%.3f "
+            "closed_open_ratio=%s inside_max=%s inside_p90=%s ring_p90=%s "
+            "max_over_ring_p90=%s p90_over_ring_p90=%s ring_pixel_count=%d "
+            "decision_reason=%s",
+            decision.bbox,
+            decision.area,
+            decision.closed_open_ratio,
+            decision.inside_max,
+            decision.inside_p90,
+            decision.ring_p90,
+            decision.max_over_ring_p90,
+            decision.p90_over_ring_p90,
+            decision.ring_pixel_count,
+            decision.decision_reason,
+        )
+
+
+def _filter_green_contours_with_image(
+    contours: list[np.ndarray] | tuple[np.ndarray, ...],
+    gray_green: np.ndarray,
+) -> tuple[list[np.ndarray], list[_GreenContourFilterDecision]]:
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, GREEN_RING_KERNEL_SIZE)
+    accepted: list[np.ndarray] = []
+    decisions: list[_GreenContourFilterDecision] = []
+
+    for contour in contours or []:
+        area = float(cv2.contourArea(contour))
+        bbox = tuple(int(value) for value in cv2.boundingRect(contour))
+
+        if area < MIN_GREEN_CONTOUR_AREA:
+            decisions.append(
+                _GreenContourFilterDecision(
+                    bbox=bbox,
+                    area=area,
+                    closed_open_ratio=None,
+                    inside_max=None,
+                    inside_p90=None,
+                    ring_p90=None,
+                    max_over_ring_p90=None,
+                    p90_over_ring_p90=None,
+                    ring_pixel_count=0,
+                    decision_reason="rejected_area",
+                )
+            )
+            continue
+
+        closed_open_ratio = _closed_open_ratio(contour)
+        legacy_shape_pass = closed_open_ratio is not None and (
+            closed_open_ratio <= 0.9 or closed_open_ratio >= 1.06
+        )
+        if legacy_shape_pass:
+            accepted.append(contour)
+            decisions.append(
+                _GreenContourFilterDecision(
+                    bbox=bbox,
+                    area=area,
+                    closed_open_ratio=closed_open_ratio,
+                    inside_max=None,
+                    inside_p90=None,
+                    ring_p90=None,
+                    max_over_ring_p90=None,
+                    p90_over_ring_p90=None,
+                    ring_pixel_count=0,
+                    decision_reason="accepted_shape",
+                )
+            )
+            continue
+
+        filled_mask = contour_to_mask(contour, gray_green.shape)
+        ring_mask = cv2.dilate(filled_mask, kernel, iterations=1)
+        ring_mask = cv2.subtract(ring_mask, filled_mask)
+        ring_pixel_count = int(np.count_nonzero(ring_mask))
+        if ring_pixel_count == 0:
+            decisions.append(
+                _GreenContourFilterDecision(
+                    bbox=bbox,
+                    area=area,
+                    closed_open_ratio=closed_open_ratio,
+                    inside_max=None,
+                    inside_p90=None,
+                    ring_p90=None,
+                    max_over_ring_p90=None,
+                    p90_over_ring_p90=None,
+                    ring_pixel_count=0,
+                    decision_reason="rejected_shape",
+                )
+            )
+            continue
+
+        inside_values = gray_green[filled_mask > 0]
+        ring_values = gray_green[ring_mask > 0]
+        inside_max = float(np.max(inside_values))
+        inside_p90 = float(np.percentile(inside_values, 90))
+        ring_p90 = float(np.percentile(ring_values, 90))
+        ring_reference = max(ring_p90, GREEN_RING_P90_FLOOR)
+        max_over_ring_p90 = inside_max / ring_reference
+        p90_over_ring_p90 = inside_p90 / ring_reference
+
+        if (
+            max_over_ring_p90 >= GREEN_STRONG_PEAK_MAX_RATIO
+            and p90_over_ring_p90 >= GREEN_STRONG_PEAK_P90_RATIO
+        ):
+            accepted.append(contour)
+            decision_reason = "accepted_strong_peak"
+        else:
+            decision_reason = "rejected_shape"
+
+        decisions.append(
+            _GreenContourFilterDecision(
+                bbox=bbox,
+                area=area,
+                closed_open_ratio=closed_open_ratio,
+                inside_max=inside_max,
+                inside_p90=inside_p90,
+                ring_p90=ring_p90,
+                max_over_ring_p90=max_over_ring_p90,
+                p90_over_ring_p90=p90_over_ring_p90,
+                ring_pixel_count=ring_pixel_count,
+                decision_reason=decision_reason,
+            )
+        )
+
+    _log_green_contour_filter_decisions(decisions)
+    return accepted, decisions
 
 
 def filterContours(contours):

--- a/cytocv/core/contour_processing/contour_operations.py
+++ b/cytocv/core/contour_processing/contour_operations.py
@@ -18,36 +18,6 @@ logger = logging.getLogger(__name__)
 
 GREEN_DOT_SPLIT_PARAMS = {
     "balanced": {
-        "min_original_area_px": 14,
-        "min_peak_distance": 3,
-        "min_peak_ratio": 0.42,
-        "min_intensity_peak_ratio": 0.42,
-        "min_second_peak_ratio": 0.50,
-        "max_intensity_valley_ratio": 0.82,
-        "max_distance_valley_ratio": 0.86,
-        "min_defect_depth_px": 1.0,
-        "min_relative_defect_depth": 0.10,
-        "max_neck_width_ratio": 0.84,
-        "min_chord_mask_fraction": 0.72,
-        "max_single_dot_circularity": 0.84,
-        "min_single_dot_solidity": 0.96,
-        "max_single_dot_aspect_ratio": 1.28,
-        "min_suspicious_aspect_ratio": 1.18,
-        "max_suspicious_circularity": 0.74,
-        "max_suspicious_solidity": 0.96,
-        "min_split_circularity": 0.22,
-        "min_split_solidity": 0.72,
-        "min_split_area_px": 8,
-        "min_child_area_fraction": 0.16,
-        "min_combined_area_ratio": 0.72,
-        "min_child_center_distance_px": 3.0,
-        "max_child_aspect_ratio": 3.2,
-        "min_child_peak_ratio": 0.38,
-        "max_neck_alignment_cos": 0.78,
-        "neck_cut_line_thickness": 1,
-        "asymmetric_fallback_enabled": False,
-    },
-    "aggressive": {
         "min_original_area_px": 10,
         "min_peak_distance": 2,
         "min_peak_ratio": 0.25,
@@ -88,6 +58,48 @@ GREEN_DOT_SPLIT_PARAMS = {
         "asymmetric_min_child_mean_ratio": 0.16,
         "asymmetric_min_boundary_low_signal_fraction": 0.55,
         "asymmetric_max_boundary_saddle_distance_px": 6.0,
+    },
+    "aggressive": {
+        "min_original_area_px": 8,
+        "min_peak_distance": 1,
+        "min_peak_ratio": 0.18,
+        "min_intensity_peak_ratio": 0.20,
+        "min_second_peak_ratio": 0.20,
+        "max_intensity_valley_ratio": 0.96,
+        "max_distance_valley_ratio": 0.97,
+        "min_defect_depth_px": 0.25,
+        "min_relative_defect_depth": 0.04,
+        "max_neck_width_ratio": 1.00,
+        "min_chord_mask_fraction": 0.45,
+        "max_single_dot_circularity": 0.92,
+        "min_single_dot_solidity": 0.99,
+        "max_single_dot_aspect_ratio": 1.12,
+        "min_suspicious_aspect_ratio": 1.04,
+        "max_suspicious_circularity": 0.88,
+        "max_suspicious_solidity": 0.99,
+        "min_split_circularity": 0.10,
+        "min_split_solidity": 0.45,
+        "min_split_area_px": 4,
+        "min_child_area_fraction": 0.06,
+        "min_combined_area_ratio": 0.58,
+        "min_child_center_distance_px": 1.0,
+        "max_child_aspect_ratio": 5.5,
+        "min_child_peak_ratio": 0.15,
+        "max_neck_alignment_cos": 0.94,
+        "neck_cut_line_thickness": 1,
+        "asymmetric_fallback_enabled": True,
+        "asymmetric_min_peak_distance_px": 2.0,
+        "asymmetric_min_second_peak_ratio": 0.20,
+        "asymmetric_max_intensity_valley_ratio": 0.94,
+        "asymmetric_min_intensity_drop_ratio": 0.04,
+        "asymmetric_max_distance_saddle_ratio": 0.94,
+        "asymmetric_min_peak_line_mask_fraction": 0.60,
+        "asymmetric_min_single_defect_depth_px": 0.35,
+        "asymmetric_max_saddle_to_defect_distance_px": 10.0,
+        "asymmetric_min_child_area_fraction": 0.08,
+        "asymmetric_min_child_mean_ratio": 0.08,
+        "asymmetric_min_boundary_low_signal_fraction": 0.40,
+        "asymmetric_max_boundary_saddle_distance_px": 8.0,
     },
 }
 
@@ -168,6 +180,13 @@ class _AsymmetricSplitCandidate:
     saddle: _SaddleMetrics
     single_defect: _SingleDefectCandidate | None
     score: float
+
+
+@dataclass(slots=True)
+class _AggressiveSplitDecision:
+    original_contour: np.ndarray
+    output_contours: list[np.ndarray]
+    accepted_split: bool
 
 
 def _split_params(split_mode: str) -> dict:
@@ -638,6 +657,93 @@ def _split_contour_with_neck_chord(
     return split_labels
 
 
+def _neck_chord_side_labels(
+    mask: np.ndarray,
+    neck: _NeckCandidate,
+) -> np.ndarray:
+    """Partition a contour mask by the two sides of the candidate neck chord."""
+
+    labels = np.zeros(mask.shape, dtype=np.int32)
+    ys, xs = np.nonzero(mask > 0)
+    if xs.size == 0:
+        return labels
+
+    point_a = np.array(neck.point_a, dtype=np.float32)
+    point_b = np.array(neck.point_b, dtype=np.float32)
+    chord = point_b - point_a
+    chord_norm = float(np.linalg.norm(chord))
+    if chord_norm <= 0:
+        return labels
+
+    points = np.column_stack((xs, ys)).astype(np.float32, copy=False)
+    relative = points - point_a
+    signed = (chord[0] * relative[:, 1]) - (chord[1] * relative[:, 0])
+
+    positive = signed > 1e-3
+    negative = signed < -1e-3
+    labels[ys[positive], xs[positive]] = 1
+    labels[ys[negative], xs[negative]] = 2
+
+    on_line = ~(positive | negative)
+    if np.any(on_line):
+        dist_a = np.sum((points[on_line] - point_a) ** 2, axis=1)
+        dist_b = np.sum((points[on_line] - point_b) ** 2, axis=1)
+        side_labels = np.where(dist_a <= dist_b, 1, 2)
+        labels[ys[on_line], xs[on_line]] = side_labels
+
+    return labels
+
+
+def _markers_from_neck_geometry(
+    mask: np.ndarray,
+    neck: _NeckCandidate,
+    params: dict,
+) -> np.ndarray | None:
+    """Seed each side of a neck chord without requiring the chord to disconnect the mask."""
+
+    side_labels = _neck_chord_side_labels(mask, neck)
+    dist = ndi.distance_transform_edt(mask > 0).astype(np.float32)
+    markers = np.zeros(mask.shape, dtype=np.int32)
+    min_area = int(params["min_split_area_px"])
+
+    for label in (1, 2):
+        region = side_labels == label
+        if int(np.count_nonzero(region)) < min_area:
+            return None
+        region_dist = np.where(region, dist, -1.0)
+        max_index = int(np.argmax(region_dist))
+        if float(region_dist.flat[max_index]) <= 0:
+            return None
+        y_coord, x_coord = np.unravel_index(max_index, region_dist.shape)
+        markers[int(y_coord), int(x_coord)] = label
+
+    return markers if int(markers.max()) == 2 else None
+
+
+def split_contour_with_geometry_first_watershed(
+    mask: np.ndarray,
+    gfp_image: np.ndarray | None,
+    neck: _NeckCandidate,
+    params: dict,
+) -> np.ndarray | None:
+    """Split a contour from neck geometry even when peak-based markers are unavailable."""
+
+    markers = _markers_from_neck_geometry(mask, neck, params)
+    if markers is None:
+        return None
+
+    score_image = _split_score_image(mask, gfp_image)
+    labels = watershed(-score_image, markers, mask=mask > 0)
+    if int(labels.max()) == 2:
+        boundary = _internal_watershed_boundaries(labels)
+        labels = labels.copy()
+        labels[boundary] = 0
+        return labels
+
+    side_labels = _neck_chord_side_labels(mask, neck)
+    return side_labels if int(side_labels.max()) == 2 else None
+
+
 def _region_circularity(region: np.ndarray) -> float:
     contours, _ = cv2.findContours(
         (region.astype(np.uint8) * 255),
@@ -709,6 +815,7 @@ def validate_split_contours(
     *,
     peak_pair: _PeakPair | None = None,
     neck_candidate: _NeckCandidate | None = None,
+    require_child_peak_ratio: bool = True,
 ) -> list[np.ndarray]:
     """Validate watershed/chord regions before replacing the original contour."""
 
@@ -745,7 +852,12 @@ def validate_split_contours(
         short_side = max(1, min(width, height))
         if (max(width, height) / short_side) > float(params["max_child_aspect_ratio"]):
             return []
-        if original_max > 0 and gray is not None and gray.shape[:2] == original_mask.shape:
+        if (
+            require_child_peak_ratio
+            and original_max > 0
+            and gray is not None
+            and gray.shape[:2] == original_mask.shape
+        ):
             child_values = gray[region]
             if child_values.size == 0:
                 return []
@@ -794,6 +906,52 @@ def validate_split_contours(
             if alignment > float(params["max_neck_alignment_cos"]):
                 return []
 
+    return child_contours
+
+
+def _boundary_intersects_neck_chord(
+    original_mask: np.ndarray,
+    split_labels: np.ndarray,
+    neck_candidate: _NeckCandidate,
+) -> bool:
+    boundary = _boundary_between_split_labels(original_mask, split_labels)
+    if not np.any(boundary):
+        return False
+
+    chord_mask = np.zeros(original_mask.shape, dtype=np.uint8)
+    cv2.line(
+        chord_mask,
+        neck_candidate.point_a,
+        neck_candidate.point_b,
+        1,
+        thickness=1,
+        lineType=cv2.LINE_8,
+    )
+    chord_region = ndi.binary_dilation(chord_mask.astype(bool), iterations=1)
+    return bool(np.any(boundary & chord_region))
+
+
+def validate_geometry_first_split(
+    original_mask: np.ndarray,
+    split_labels: np.ndarray | None,
+    params: dict,
+    neck_candidate: _NeckCandidate,
+) -> list[np.ndarray]:
+    """Validate an aggressive geometry-first split that does not rely on peak evidence."""
+
+    child_contours = validate_split_contours(
+        original_mask,
+        split_labels,
+        None,
+        params,
+        peak_pair=None,
+        neck_candidate=neck_candidate,
+        require_child_peak_ratio=False,
+    )
+    if len(child_contours) != 2 or split_labels is None:
+        return []
+    if not _boundary_intersects_neck_chord(original_mask, split_labels, neck_candidate):
+        return []
     return child_contours
 
 
@@ -1032,12 +1190,14 @@ def find_asymmetric_peak_saddle_candidate(
                 second_peak_ratio=second_peak_ratio,
                 score=0.0,
             )
+            single_defect_bonus = 0.5 if single_defect is not None else 0.0
+
             score = (
                 second_peak_ratio
                 + min(peak_distance / 12.0, 1.5)
                 + max(0.0, 1.0 - intensity_valley_ratio) * 3.0
                 + max(0.0, 1.0 - distance_saddle_ratio) * 3.0
-                + (0.5 if single_defect is not None else 0.0)
+                + single_defect_bonus
             )
             peak_pair.score = score
             candidate = _AsymmetricSplitCandidate(
@@ -1212,6 +1372,8 @@ def split_asymmetric_gfp_contour_if_needed(
     gfp_image: np.ndarray,
     params: dict,
     *,
+    has_paired_neck: bool = False,
+    split_mode: str = DEFAULT_GREEN_DOT_SPLIT_MODE,
     debug: bool = False,
 ) -> list[np.ndarray]:
     if not bool(params.get("asymmetric_fallback_enabled", False)):
@@ -1270,6 +1432,7 @@ def split_necked_gfp_contour_if_needed(
         config_payload = dict(config or {})
         split_mode = config_payload.get("mode", DEFAULT_GREEN_DOT_SPLIT_MODE)
         debug = bool(config_payload.get("debug", False))
+    split_mode = normalize_green_dot_split_mode(split_mode)
 
     params = _split_params(split_mode)
     metrics = compute_contour_shape_metrics(
@@ -1313,6 +1476,8 @@ def split_necked_gfp_contour_if_needed(
             metrics,
             gfp_image,
             params,
+            has_paired_neck=neck is not None,
+            split_mode=split_mode,
             debug=debug,
         )
 
@@ -1330,6 +1495,18 @@ def split_necked_gfp_contour_if_needed(
 
     shape_suspicious = _shape_is_suspicious(metrics, params)
     split_peak_pair = _choose_split_peak_pair(intensity_pair, distance_pair, params)
+    if (
+        split_mode == "aggressive"
+        and split_peak_pair is None
+        and metrics.aspect_ratio >= 2.0
+        and metrics.solidity >= 0.94
+        and neck.neck_ratio >= 0.68
+    ):
+        if debug:
+            logger.debug(
+                "Green neck split rejected: smooth convex contour lacks peak-supported split evidence"
+            )
+        return [contour]
     has_peak_evidence = split_peak_pair is not None
     has_geometry_evidence = shape_suspicious and metrics.deep_defect_count >= 2
     if not (has_peak_evidence or has_geometry_evidence):
@@ -1374,6 +1551,27 @@ def split_necked_gfp_contour_if_needed(
     if len(child_contours) == 2:
         return child_contours
 
+    if (
+        split_mode == "aggressive"
+        and shape_suspicious
+        and metrics.aspect_ratio >= 1.35
+        and neck.neck_ratio <= 0.60
+    ):
+        geometry_labels = split_contour_with_geometry_first_watershed(
+            metrics.mask,
+            gfp_image,
+            neck,
+            params,
+        )
+        child_contours = validate_geometry_first_split(
+            metrics.mask,
+            geometry_labels,
+            params,
+            neck,
+        )
+        if len(child_contours) == 2:
+            return child_contours
+
     child_contours = try_asymmetric_fallback()
     if len(child_contours) == 2:
         return child_contours
@@ -1394,6 +1592,50 @@ def postprocess_gfp_contours_for_neck_splits(
     for contour in contours or []:
         split_contours = split_necked_gfp_contour_if_needed(contour, gfp_image, config)
         processed.extend(split_contours if split_contours else [contour])
+    return processed
+
+
+def _aggressive_split_decision_for_contour(
+    contour: np.ndarray,
+    gfp_image: np.ndarray,
+    config: dict | str | None = None,
+) -> _AggressiveSplitDecision:
+    """Return the aggressive split result for one contour without filtering."""
+
+    split_contours = split_necked_gfp_contour_if_needed(contour, gfp_image, config)
+    if len(split_contours) == 2:
+        return _AggressiveSplitDecision(
+            original_contour=contour,
+            output_contours=split_contours,
+            accepted_split=True,
+        )
+    return _AggressiveSplitDecision(
+        original_contour=contour,
+        output_contours=split_contours if split_contours else [contour],
+        accepted_split=False,
+    )
+
+
+def _postprocess_and_filter_aggressive_green_contours(
+    contours: list[np.ndarray] | tuple[np.ndarray, ...],
+    gfp_image: np.ndarray,
+    config: dict | str | None = None,
+) -> list[np.ndarray]:
+    """Preserve aggressive splits atomically through the legacy contour filter."""
+
+    processed: list[np.ndarray] = []
+    for contour in contours or []:
+        decision = _aggressive_split_decision_for_contour(contour, gfp_image, config)
+        if decision.accepted_split:
+            filtered_children = filterContours(decision.output_contours)
+            if len(filtered_children) == 2:
+                processed.extend(filtered_children)
+            else:
+                # If the legacy filter collapses an accepted split, keep the
+                # original merged contour instead of returning one child.
+                processed.append(decision.original_contour)
+            continue
+        processed.extend(filterContours(decision.output_contours))
     return processed
 
 
@@ -1437,6 +1679,7 @@ def find_contours(
     gray_blue_3 = images.get_image("gray_blue_3")
     gray_blue = images.get_image("gray_blue")
     gray_green = images.get_image("green")
+    green_dot_split_mode = normalize_green_dot_split_mode(green_dot_split_mode)
 
     dot_contours = []
     contours = []
@@ -1646,13 +1889,21 @@ def find_contours(
             cv2.RETR_LIST,
             cv2.CHAIN_APPROX_SIMPLE,
         )
-        if green_dot_split_enabled:
+        if green_dot_split_enabled and green_contour_filter_enabled and green_dot_split_mode == "aggressive":
+            contours_green = _postprocess_and_filter_aggressive_green_contours(
+                contours_green,
+                gray_green,
+                {"mode": green_dot_split_mode},
+            )
+        elif green_dot_split_enabled:
             contours_green = postprocess_gfp_contours_for_neck_splits(
                 contours_green,
                 gray_green,
                 {"mode": green_dot_split_mode},
             )
-        if green_contour_filter_enabled:
+            if green_contour_filter_enabled:
+                contours_green = filterContours(contours_green)
+        elif green_contour_filter_enabled:
             contours_green = filterContours(contours_green)
 
     return {

--- a/cytocv/core/services/overlay_rendering.py
+++ b/cytocv/core/services/overlay_rendering.py
@@ -38,7 +38,7 @@ from core.stats_plugins import build_stats_execution_plan
 
 logger = logging.getLogger(__name__)
 
-OVERLAY_RENDER_SCHEMA_VERSION = 2
+OVERLAY_RENDER_SCHEMA_VERSION = 3
 OVERLAY_RENDER_CONFIG_FILENAME = "overlay-render-config.json"
 OVERLAY_CACHE_DIRNAME = f"overlay-cache-v{OVERLAY_RENDER_SCHEMA_VERSION}"
 OVERLAY_CHANNEL_LABELS = {

--- a/cytocv/core/tests/test_accounts_preferences.py
+++ b/cytocv/core/tests/test_accounts_preferences.py
@@ -49,7 +49,7 @@ class PreferenceNormalizationTests(TestCase):
         self.assertEqual(defaults["puncta_line_mode"], "red_puncta")
         self.assertEqual(defaults["nuclear_cell_pair_mode"], "green_nucleus")
         self.assertTrue(defaults["green_dot_split_enabled"])
-        self.assertEqual(defaults["green_dot_split_mode"], "balanced")
+        self.assertEqual(defaults["green_dot_split_mode"], "aggressive")
         self.assertTrue(defaults["use_metadata_scale"])
         self.assertEqual(defaults["spatial_stats_unit"], "px")
         self.assertTrue(normalized["show_saved_file_channels"])
@@ -1934,7 +1934,7 @@ class ChannelVisibilityPreferenceTests(TestCase):
         self.assertEqual(defaults["puncta_line_mode"], "red_puncta")
         self.assertEqual(defaults["nuclear_cell_pair_mode"], "green_nucleus")
         self.assertTrue(defaults["green_dot_split_enabled"])
-        self.assertEqual(defaults["green_dot_split_mode"], "balanced")
+        self.assertEqual(defaults["green_dot_split_mode"], "aggressive")
 
     def test_plugin_settings_form_persists_measurement_defaults(self):
         response = self.client.post(

--- a/cytocv/core/tests/test_core_app.py
+++ b/cytocv/core/tests/test_core_app.py
@@ -630,10 +630,10 @@ class RouteSurfaceRefactorTests(TestCase):
         )
         self.assertEqual(int(np.count_nonzero(cyan_like)), 0)
 
-    def test_overlay_cache_path_uses_schema_v2_directory(self):
+    def test_overlay_cache_path_uses_schema_v3_directory(self):
         uuid_value = str(uuid4())
         cache_path = overlay_cache_image_path(uuid_value, 1, "green")
-        self.assertIn("overlay-cache-v2", str(cache_path))
+        self.assertIn("overlay-cache-v3", str(cache_path))
 
     def test_overlay_endpoint_returns_404_for_unauthorized_user(self):
         other_user = get_user_model().objects.create_user(

--- a/cytocv/core/tests/test_green_dot_split.py
+++ b/cytocv/core/tests/test_green_dot_split.py
@@ -8,6 +8,7 @@ from django.test import SimpleTestCase
 from unittest.mock import patch
 
 from core.contour_processing.contour_operations import (
+    _filter_green_contours_with_image,
     _split_merged_green_contours,
     _markers_from_neck,
     _split_params,
@@ -118,6 +119,42 @@ def _tip_connected_pair_image(shape=(72, 96)) -> np.ndarray:
     cv2.line(image, (50, 38), (53, 36), 70.0, 1)
     image = cv2.GaussianBlur(image, (0, 0), 1.0)
     return np.clip(image, 0, 255).astype(np.uint8)
+
+
+def _add_gaussian(
+    image: np.ndarray,
+    *,
+    center: tuple[int, int],
+    amplitude: float,
+    sigma: float,
+) -> np.ndarray:
+    y_grid, x_grid = np.mgrid[0 : image.shape[0], 0 : image.shape[1]]
+    blob = amplitude * np.exp(
+        -(
+            ((x_grid - center[0]) ** 2 + (y_grid - center[1]) ** 2)
+            / (2.0 * sigma * sigma)
+        )
+    )
+    return image + blob
+
+
+def _real_failure_like_green_image(shape=(80, 96)) -> np.ndarray:
+    image = np.zeros(shape, dtype=np.float32)
+    image = _add_gaussian(image, center=(46, 38), amplitude=248.0, sigma=2.6)
+    image = _add_gaussian(image, center=(57, 37), amplitude=255.0, sigma=2.4)
+    image = _add_gaussian(image, center=(61, 49), amplitude=80.0, sigma=4.0)
+    image = _add_gaussian(image, center=(30, 41), amplitude=35.0, sigma=7.5)
+    cv2.line(image, (47, 38), (56, 37), 52.0, 3)
+    image = cv2.GaussianBlur(image, (0, 0), 0.9)
+    return np.clip(image, 0, 255).astype(np.uint8)
+
+
+def _contour_centroid(contour: np.ndarray) -> tuple[float, float]:
+    moments = cv2.moments(contour)
+    if moments["m00"] == 0:
+        x, y, width, height = cv2.boundingRect(contour)
+        return x + width / 2.0, y + height / 2.0
+    return moments["m10"] / moments["m00"], moments["m01"] / moments["m00"]
 
 
 def _green_only_images(image: np.ndarray) -> GrayImage:
@@ -440,3 +477,108 @@ class GreenDotSplitTests(SimpleTestCase):
             sorted(cv2.contourArea(contour) for contour in aggressive),
             sorted(cv2.contourArea(contour) for contour in aggressive_filtered),
         )
+
+    def test_real_failure_like_geometry_keeps_two_bright_children_and_lower_blob(self):
+        image = _real_failure_like_green_image()
+
+        preprocessed = _green_pre_postprocess_contours_from_image(image)
+        aggressive = _split_green_contours_from_image(image, "aggressive")
+        aggressive_filtered = _split_green_contours_from_image(
+            image,
+            "aggressive",
+            green_contour_filter_enabled=True,
+        )
+
+        self.assertEqual(len(preprocessed), 2)
+        self.assertEqual(len(aggressive), 3)
+        self.assertEqual(len(aggressive_filtered), 3)
+
+        centroids = [_contour_centroid(contour) for contour in aggressive_filtered]
+        self.assertTrue(any(x < 52 and y < 42 for x, y in centroids))
+        self.assertTrue(any(x > 52 and y < 42 for x, y in centroids))
+        self.assertTrue(any(x > 54 and y > 44 for x, y in centroids))
+
+    def test_green_filter_rescues_strong_peak_that_fails_legacy_shape_rule(self):
+        mask = np.zeros((64, 64), dtype=np.uint8)
+        cv2.circle(mask, (32, 32), 8, 255, -1)
+        contour = _contours_from_mask(mask)[0]
+        image = np.zeros(mask.shape, dtype=np.float32)
+        image = _add_gaussian(image, center=(32, 32), amplitude=210.0, sigma=3.0)
+        image = np.clip(image, 0, 255).astype(np.uint8)
+
+        accepted, decisions = _filter_green_contours_with_image([contour], image)
+
+        self.assertEqual(len(accepted), 1)
+        self.assertEqual(len(decisions), 1)
+        decision = decisions[0]
+        self.assertEqual(decision.decision_reason, "accepted_strong_peak")
+        self.assertIsNotNone(decision.closed_open_ratio)
+        self.assertGreater(decision.closed_open_ratio, 0.9)
+        self.assertLess(decision.closed_open_ratio, 1.06)
+        self.assertGreaterEqual(decision.max_over_ring_p90, 3.0)
+        self.assertGreaterEqual(decision.p90_over_ring_p90, 2.5)
+
+    def test_green_filter_rejects_weak_shape_failed_contour_without_strong_peak(self):
+        mask = np.zeros((64, 64), dtype=np.uint8)
+        cv2.circle(mask, (32, 32), 8, 255, -1)
+        contour = _contours_from_mask(mask)[0]
+        image = np.full(mask.shape, 35, dtype=np.float32)
+        image = _add_gaussian(image, center=(32, 32), amplitude=25.0, sigma=4.0)
+        image = np.clip(image, 0, 255).astype(np.uint8)
+
+        accepted, decisions = _filter_green_contours_with_image([contour], image)
+
+        self.assertEqual(len(accepted), 0)
+        self.assertEqual(decisions[0].decision_reason, "rejected_shape")
+        self.assertLess(decisions[0].max_over_ring_p90, 3.0)
+        self.assertLess(decisions[0].p90_over_ring_p90, 2.5)
+
+    def test_green_filter_uses_ring_floor_when_ring_percentile_is_zero(self):
+        mask = np.zeros((64, 64), dtype=np.uint8)
+        cv2.circle(mask, (32, 32), 8, 255, -1)
+        contour = _contours_from_mask(mask)[0]
+        image = np.zeros(mask.shape, dtype=np.uint8)
+        image[mask > 0] = 160
+
+        accepted, decisions = _filter_green_contours_with_image([contour], image)
+
+        self.assertEqual(len(accepted), 1)
+        self.assertEqual(decisions[0].decision_reason, "accepted_strong_peak")
+        self.assertEqual(decisions[0].ring_p90, 0.0)
+        self.assertTrue(np.isfinite(decisions[0].max_over_ring_p90))
+        self.assertTrue(np.isfinite(decisions[0].p90_over_ring_p90))
+
+    def test_green_filter_handles_contour_touching_image_edge(self):
+        mask = np.zeros((48, 48), dtype=np.uint8)
+        cv2.circle(mask, (4, 4), 6, 255, -1)
+        contour = _contours_from_mask(mask)[0]
+        image = np.zeros(mask.shape, dtype=np.float32)
+        image = _add_gaussian(image, center=(4, 4), amplitude=190.0, sigma=2.5)
+        image = np.clip(image, 0, 255).astype(np.uint8)
+
+        accepted, decisions = _filter_green_contours_with_image([contour], image)
+
+        self.assertEqual(len(accepted), 1)
+        self.assertIn(
+            decisions[0].decision_reason,
+            {"accepted_shape", "accepted_strong_peak"},
+        )
+        self.assertLessEqual(decisions[0].bbox[0], 1)
+        self.assertLessEqual(decisions[0].bbox[1], 1)
+        if decisions[0].decision_reason == "accepted_strong_peak":
+            self.assertGreater(decisions[0].ring_pixel_count, 0)
+
+    def test_green_filter_stays_conservative_when_neighbor_contaminates_ring(self):
+        mask = np.zeros((72, 72), dtype=np.uint8)
+        cv2.circle(mask, (28, 36), 8, 255, -1)
+        contour = _contours_from_mask(mask)[0]
+        image = np.full(mask.shape, 8, dtype=np.float32)
+        image = _add_gaussian(image, center=(28, 36), amplitude=70.0, sigma=3.0)
+        image = _add_gaussian(image, center=(39, 36), amplitude=120.0, sigma=3.0)
+        image = np.clip(image, 0, 255).astype(np.uint8)
+
+        accepted, decisions = _filter_green_contours_with_image([contour], image)
+
+        self.assertEqual(len(accepted), 0)
+        self.assertEqual(decisions[0].decision_reason, "rejected_shape")
+        self.assertLess(decisions[0].max_over_ring_p90, 3.0)

--- a/cytocv/core/tests/test_green_dot_split.py
+++ b/cytocv/core/tests/test_green_dot_split.py
@@ -5,14 +5,20 @@ from __future__ import annotations
 import cv2
 import numpy as np
 from django.test import SimpleTestCase
+from unittest.mock import patch
 
 from core.contour_processing.contour_operations import (
     _split_merged_green_contours,
+    _markers_from_neck,
     _split_params,
+    _split_contour_with_neck_chord,
     compute_contour_shape_metrics,
+    find_contours,
     find_convexity_defect_neck_candidates,
+    find_intensity_peaks_in_contour,
     postprocess_gfp_contours_for_neck_splits,
 )
+from core.image_processing import GrayImage
 
 
 def _dumbbell(radius_a: int, radius_b: int, center_distance: int, shape=(80, 100)) -> np.ndarray:
@@ -68,10 +74,8 @@ def _gaussian_pair_image(
 
 def _one_sided_notch_mask(shape=(96, 128)) -> np.ndarray:
     mask = np.zeros(shape, dtype=np.uint8)
-    cv2.circle(mask, (54, 48), 13, 255, -1)
-    cv2.circle(mask, (74, 48), 13, 255, -1)
-    # Fill the upper waist so only the lower side has a real inward bite.
-    cv2.rectangle(mask, (54, 35), (74, 48), 255, -1)
+    cv2.ellipse(mask, (64, 48), (26, 10), 0, 0, 360, 255, -1)
+    cv2.circle(mask, (63, 38), 1, 0, -1)
     return mask
 
 
@@ -86,6 +90,89 @@ def _single_gaussian_image(*, center=(50, 40), sigma: float = 4.5, shape=(80, 10
     return np.clip(image, 0, 255).astype(np.uint8)
 
 
+def _geometry_first_neck_mask(shape=(96, 128)) -> np.ndarray:
+    mask = np.zeros(shape, dtype=np.uint8)
+    cv2.circle(mask, (55, 48), 11, 255, -1)
+    cv2.circle(mask, (72, 48), 8, 255, -1)
+    cv2.rectangle(mask, (55, 43), (72, 51), 255, -1)
+    cv2.circle(mask, (63, 56), 3, 0, -1)
+    return mask
+
+
+def _geometry_first_single_peak_image(mask: np.ndarray) -> np.ndarray:
+    y_grid, x_grid = np.mgrid[0 : mask.shape[0], 0 : mask.shape[1]]
+    image = 220.0 * np.exp(
+        -(
+            ((x_grid - 54) ** 2 + (y_grid - 48) ** 2)
+            / (2.0 * 3.2 * 3.2)
+        )
+    )
+    image += 18.0 * (mask > 0)
+    return np.clip(image, 0, 255).astype(np.uint8)
+
+
+def _tip_connected_pair_image(shape=(72, 96)) -> np.ndarray:
+    image = np.zeros(shape, dtype=np.float32)
+    cv2.circle(image, (46, 40), 7, 230.0, -1)
+    cv2.circle(image, (56, 35), 4, 130.0, -1)
+    cv2.line(image, (50, 38), (53, 36), 70.0, 1)
+    image = cv2.GaussianBlur(image, (0, 0), 1.0)
+    return np.clip(image, 0, 255).astype(np.uint8)
+
+
+def _green_only_images(image: np.ndarray) -> GrayImage:
+    return GrayImage(
+        {
+            "gray_red_3": None,
+            "gray_red": None,
+            "gray_blue_3": None,
+            "gray_blue": None,
+            "green": image,
+            "green_no_bg": None,
+            "red_no_bg": None,
+        }
+    )
+
+
+def _green_pre_postprocess_contours_from_image(image: np.ndarray) -> list[np.ndarray]:
+    low_val, _ = cv2.threshold(
+        image,
+        0.65,
+        255,
+        cv2.THRESH_BINARY + cv2.THRESH_OTSU,
+    )
+    _, thresh_green = cv2.threshold(
+        image,
+        low_val + 13,
+        255,
+        cv2.THRESH_BINARY,
+    )
+    kernel = cv2.getStructuringElement(cv2.MORPH_CROSS, (3, 3))
+    thresh_green = cv2.morphologyEx(thresh_green, cv2.MORPH_CLOSE, kernel)
+    contours, _ = cv2.findContours(
+        thresh_green,
+        cv2.RETR_LIST,
+        cv2.CHAIN_APPROX_SIMPLE,
+    )
+    return list(contours)
+
+
+def _split_green_contours_from_image(
+    image: np.ndarray,
+    split_mode: str,
+    *,
+    green_contour_filter_enabled: bool = False,
+) -> list[np.ndarray]:
+    contours_data = find_contours(
+        _green_only_images(image),
+        green_contour_filter_enabled=green_contour_filter_enabled,
+        alternate_red_detection=False,
+        green_dot_split_enabled=True,
+        green_dot_split_mode=split_mode,
+    )
+    return list(contours_data.get("contours_green", []))
+
+
 class GreenDotSplitTests(SimpleTestCase):
     def test_balanced_mode_splits_overlapping_green_dots(self):
         mask = _dumbbell(8, 8, center_distance=10)
@@ -98,107 +185,89 @@ class GreenDotSplitTests(SimpleTestCase):
         mask = np.zeros((80, 100), dtype=np.uint8)
         cv2.circle(mask, (50, 40), 10, 255, -1)
 
-        split = _split_merged_green_contours(mask, split_mode="aggressive")
-
-        self.assertEqual(_contour_count(split), 1)
+        for split_mode in ("balanced", "aggressive"):
+            split = _split_merged_green_contours(mask, split_mode=split_mode)
+            self.assertEqual(_contour_count(split), 1)
 
     def test_convex_elongated_blob_is_not_split_despite_multiple_peaks(self):
         mask = np.zeros((80, 100), dtype=np.uint8)
         cv2.ellipse(mask, (50, 40), (16, 6), 0, 0, 360, 255, -1)
 
-        split = _split_merged_green_contours(mask, split_mode="aggressive")
+        for split_mode in ("balanced", "aggressive"):
+            split = _split_merged_green_contours(mask, split_mode=split_mode)
+            self.assertEqual(_contour_count(split), 1)
 
-        self.assertEqual(_contour_count(split), 1)
-
-    def test_aggressive_mode_splits_close_unequal_pair_that_balanced_keeps_merged(self):
+    def test_balanced_and_aggressive_split_close_unequal_pair(self):
         mask = _dumbbell(8, 5, center_distance=8)
 
         balanced = _split_merged_green_contours(mask, split_mode="balanced")
         aggressive = _split_merged_green_contours(mask, split_mode="aggressive")
 
-        self.assertEqual(_contour_count(balanced), 1)
+        self.assertEqual(_contour_count(balanced), 2)
         self.assertEqual(_contour_count(aggressive), 2)
 
-    def test_aggressive_postprocessor_splits_gaussian_pair_with_dim_bridge(self):
+    def test_balanced_and_aggressive_postprocessor_split_gaussian_pair_with_dim_bridge(self):
         image = _gaussian_pair_image(bridge_intensity=40.0)
         mask = (image > 32).astype(np.uint8) * 255
         contours = _contours_from_mask(mask)
 
-        split = postprocess_gfp_contours_for_neck_splits(
-            contours,
-            image,
-            {"mode": "aggressive"},
-        )
-
         self.assertEqual(len(contours), 1)
-        self.assertEqual(_contour_list_count(split), 2)
+        for split_mode in ("balanced", "aggressive"):
+            split = postprocess_gfp_contours_for_neck_splits(
+                contours,
+                image,
+                {"mode": split_mode},
+            )
+            self.assertEqual(_contour_list_count(split), 2)
 
-    def test_aggressive_postprocessor_splits_binary_peanut_shape(self):
+    def test_balanced_and_aggressive_postprocessor_split_binary_peanut_shape(self):
         mask = np.zeros((96, 128), dtype=np.uint8)
         cv2.circle(mask, (54, 48), 13, 255, -1)
         cv2.circle(mask, (74, 48), 13, 255, -1)
         contours = _contours_from_mask(mask)
 
-        split = postprocess_gfp_contours_for_neck_splits(
-            contours,
-            mask,
-            {"mode": "aggressive"},
-        )
-
         self.assertEqual(len(contours), 1)
-        self.assertEqual(_contour_list_count(split), 2)
+        for split_mode in ("balanced", "aggressive"):
+            split = postprocess_gfp_contours_for_neck_splits(
+                contours,
+                mask,
+                {"mode": split_mode},
+            )
+            self.assertEqual(_contour_list_count(split), 2)
 
-    def test_aggressive_postprocessor_keeps_slightly_irregular_single_dot(self):
+    def test_postprocessor_keeps_slightly_irregular_single_dot(self):
         mask = np.zeros((80, 100), dtype=np.uint8)
         cv2.circle(mask, (50, 40), 11, 255, -1)
         cv2.circle(mask, (58, 37), 3, 0, -1)
         cv2.circle(mask, (44, 45), 2, 0, -1)
         contours = _contours_from_mask(mask)
 
-        split = postprocess_gfp_contours_for_neck_splits(
-            contours,
-            mask,
-            {"mode": "aggressive"},
-        )
+        for split_mode in ("balanced", "aggressive"):
+            split = postprocess_gfp_contours_for_neck_splits(
+                contours,
+                mask,
+                {"mode": split_mode},
+            )
+            self.assertEqual(_contour_list_count(split), 1)
 
-        self.assertEqual(_contour_list_count(split), 1)
-
-    def test_aggressive_postprocessor_splits_close_pair_with_strong_bridge(self):
+    def test_balanced_and_aggressive_postprocessor_split_close_pair_with_strong_bridge(self):
         image = _gaussian_pair_image(bridge_intensity=90.0)
         mask = (image > 30).astype(np.uint8) * 255
         contours = _contours_from_mask(mask)
 
-        split = postprocess_gfp_contours_for_neck_splits(
-            contours,
-            image,
-            {"mode": "aggressive"},
-        )
-
         self.assertEqual(len(contours), 1)
-        self.assertEqual(_contour_list_count(split), 2)
+        for split_mode in ("balanced", "aggressive"):
+            split = postprocess_gfp_contours_for_neck_splits(
+                contours,
+                image,
+                {"mode": split_mode},
+            )
+            self.assertEqual(_contour_list_count(split), 2)
 
-    def test_aggressive_fallback_splits_one_sided_notch_that_has_no_paired_neck(self):
-        mask = _one_sided_notch_mask()
-        image = _gaussian_pair_image(
-            center_a=(54, 48),
-            center_b=(74, 48),
-            bridge_intensity=42.0,
-            shape=mask.shape,
-        )
+    def test_geometry_first_aggressive_splits_necked_single_peak_shape_that_balanced_keeps_merged(self):
+        mask = _geometry_first_neck_mask()
+        image = _geometry_first_single_peak_image(mask)
         contours = _contours_from_mask(mask)
-        contour = max(contours, key=cv2.contourArea)
-        params = _split_params("aggressive")
-        metrics = compute_contour_shape_metrics(
-            contour,
-            mask.shape,
-            min_defect_depth_px=params["min_defect_depth_px"],
-        )
-
-        self.assertIsNotNone(metrics)
-        self.assertEqual(
-            find_convexity_defect_neck_candidates(metrics.contour, metrics.mask, params),
-            [],
-        )
 
         balanced = postprocess_gfp_contours_for_neck_splits(
             contours,
@@ -214,7 +283,7 @@ class GreenDotSplitTests(SimpleTestCase):
         self.assertEqual(_contour_list_count(balanced), 1)
         self.assertEqual(_contour_list_count(aggressive), 2)
 
-    def test_aggressive_fallback_splits_asymmetric_two_gaussian_pair(self):
+    def test_balanced_and_aggressive_fallback_split_asymmetric_two_gaussian_pair(self):
         image = _gaussian_pair_image(
             center_a=(48, 48),
             center_b=(66, 48),
@@ -227,30 +296,30 @@ class GreenDotSplitTests(SimpleTestCase):
         mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
         contours = _contours_from_mask(mask)
 
-        split = postprocess_gfp_contours_for_neck_splits(
-            contours,
-            image,
-            {"mode": "aggressive"},
-        )
-
         self.assertEqual(len(contours), 1)
-        self.assertEqual(_contour_list_count(split), 2)
+        for split_mode in ("balanced", "aggressive"):
+            split = postprocess_gfp_contours_for_neck_splits(
+                contours,
+                image,
+                {"mode": split_mode},
+            )
+            self.assertEqual(_contour_list_count(split), 2)
 
-    def test_aggressive_fallback_keeps_single_crescent_dot_with_one_peak(self):
+    def test_fallback_keeps_single_crescent_dot_with_one_peak(self):
         mask = np.zeros((80, 100), dtype=np.uint8)
         cv2.circle(mask, (50, 40), 12, 255, -1)
         cv2.circle(mask, (58, 40), 7, 0, -1)
         contours = _contours_from_mask(mask)
         image = _single_gaussian_image(center=(47, 40), shape=mask.shape)
 
-        split = postprocess_gfp_contours_for_neck_splits(
-            contours,
-            image,
-            {"mode": "aggressive"},
-        )
-
         self.assertEqual(len(contours), 1)
-        self.assertEqual(_contour_list_count(split), 1)
+        for split_mode in ("balanced", "aggressive"):
+            split = postprocess_gfp_contours_for_neck_splits(
+                contours,
+                image,
+                {"mode": split_mode},
+            )
+            self.assertEqual(_contour_list_count(split), 1)
 
     def test_two_bright_spots_inside_broad_convex_background_are_not_split(self):
         shape = (120, 140)
@@ -264,10 +333,110 @@ class GreenDotSplitTests(SimpleTestCase):
         image = np.clip(image, 0, 255).astype(np.uint8)
         contours = _contours_from_mask(mask)
 
+        for split_mode in ("balanced", "aggressive"):
+            split = postprocess_gfp_contours_for_neck_splits(
+                contours,
+                image,
+                {"mode": split_mode},
+            )
+            self.assertEqual(_contour_list_count(split), 1)
+
+    def test_geometry_first_fixture_neck_markers_and_chord_fail_but_aggressive_still_splits(self):
+        mask = _geometry_first_neck_mask()
+        image = _geometry_first_single_peak_image(mask)
+        contours = _contours_from_mask(mask)
+        contour = max(contours, key=cv2.contourArea)
+        params = _split_params("aggressive")
+        metrics = compute_contour_shape_metrics(
+            contour,
+            mask.shape,
+            min_defect_depth_px=params["min_defect_depth_px"],
+        )
+
+        self.assertIsNotNone(metrics)
+        neck_candidates = find_convexity_defect_neck_candidates(
+            metrics.contour,
+            metrics.mask,
+            params,
+        )
+        self.assertTrue(neck_candidates)
+        self.assertEqual(len(find_intensity_peaks_in_contour(metrics.mask, image, params)), 1)
+        self.assertIsNone(_markers_from_neck(metrics.mask, neck_candidates[0], params))
+        self.assertIsNone(_split_contour_with_neck_chord(metrics.mask, neck_candidates[0], params))
         split = postprocess_gfp_contours_for_neck_splits(
             contours,
             image,
             {"mode": "aggressive"},
         )
 
-        self.assertEqual(_contour_list_count(split), 1)
+        self.assertEqual(_contour_list_count(split), 2)
+
+    def test_aggressive_find_contours_splits_tiny_tip_connected_merge_that_balanced_keeps_merged(self):
+        image = _tip_connected_pair_image()
+
+        balanced = _split_green_contours_from_image(image, "balanced")
+        aggressive = _split_green_contours_from_image(image, "aggressive")
+
+        self.assertEqual(_contour_list_count(balanced, min_area=4.0), 1)
+        self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
+
+    def test_find_contours_passes_identical_pre_postprocess_green_contours_to_balanced_and_aggressive(self):
+        image = _tip_connected_pair_image()
+        captured: dict[str, list[np.ndarray]] = {}
+
+        def capture(contours, gfp_image, config=None):
+            del gfp_image
+            mode = (config or {}).get("mode", "balanced")
+            captured[mode] = [contour.copy() for contour in contours]
+            return list(contours)
+
+        with patch(
+            "core.contour_processing.contour_operations.postprocess_gfp_contours_for_neck_splits",
+            side_effect=capture,
+        ):
+            _split_green_contours_from_image(image, "balanced")
+            _split_green_contours_from_image(image, "aggressive")
+
+        expected = _green_pre_postprocess_contours_from_image(image)
+        self.assertEqual(len(captured["balanced"]), len(expected))
+        self.assertEqual(len(captured["aggressive"]), len(expected))
+        for expected_contour, balanced_contour, aggressive_contour in zip(
+            expected,
+            captured["balanced"],
+            captured["aggressive"],
+        ):
+            self.assertTrue(np.array_equal(expected_contour, balanced_contour))
+            self.assertTrue(np.array_equal(expected_contour, aggressive_contour))
+
+    def test_aggressive_filtered_find_contours_restores_original_when_filter_would_drop_one_child(self):
+        image = _tip_connected_pair_image()
+
+        aggressive = _split_green_contours_from_image(image, "aggressive")
+        aggressive_filtered = _split_green_contours_from_image(
+            image,
+            "aggressive",
+            green_contour_filter_enabled=True,
+        )
+        original = _green_pre_postprocess_contours_from_image(image)
+
+        self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
+        self.assertEqual(len(original), 1)
+        self.assertEqual(_contour_list_count(aggressive_filtered, min_area=4.0), 1)
+        self.assertEqual(cv2.contourArea(aggressive_filtered[0]), cv2.contourArea(original[0]))
+
+    def test_aggressive_filtered_find_contours_preserves_clean_two_child_split(self):
+        image = _gaussian_pair_image(bridge_intensity=90.0)
+
+        aggressive = _split_green_contours_from_image(image, "aggressive")
+        aggressive_filtered = _split_green_contours_from_image(
+            image,
+            "aggressive",
+            green_contour_filter_enabled=True,
+        )
+
+        self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
+        self.assertEqual(_contour_list_count(aggressive_filtered, min_area=4.0), 2)
+        self.assertEqual(
+            sorted(cv2.contourArea(contour) for contour in aggressive),
+            sorted(cv2.contourArea(contour) for contour in aggressive_filtered),
+        )

--- a/cytocv/templates/form/experiment.html
+++ b/cytocv/templates/form/experiment.html
@@ -1800,7 +1800,7 @@
                                     type="button"
                                     class="info-dot compact advanced-info-dot"
                                     id="greenDotSplitInfoDot"
-                                    data-info-text="Split connected multi-peak Green signal into separate dot contours before statistics are calculated.&#10;&#10;Modes:&#10;- Balanced: default mode with standard split sensitivity.&#10;- Aggressive: attempts harder splits for very close or unequal Green dots."
+                                    data-info-text="Split connected multi-peak Green signal into separate dot contours before statistics are calculated.&#10;&#10;Modes:&#10;- Balanced: standard split sensitivity, now stronger than the old balanced mode.&#10;- Aggressive: highest-recall split mode for tiny, very close, unequal, or tip-connected merged Green dots."
                                     aria-label="Split merged Green dots info"
                                 >i</button>
                             </span>
@@ -2239,7 +2239,7 @@
         greenFilterExperimentalDot: 'Experimental setting: behavior can vary across image quality, exposure, and channel mapping. Validate outputs before using results for conclusions.',
         greenDotSplitInfoDot: buildInfoSections([
             'Splits connected multi-peak Green signal into separate dot contours before statistics are calculated. Use it when two nearby Green dots are detected as one merged contour.',
-            'Green Dot Split Mode: Balanced uses standard split sensitivity; Aggressive attempts harder splits for very close or unequal Green dots.',
+            'Green Dot Split Mode: Balanced uses standard split sensitivity, now stronger than the old balanced mode; Aggressive is the highest-recall split mode for tiny, very close, unequal, or tip-connected merged Green dots.',
             'Availability: enabled only when a selected statistic requires the Green channel.',
             'Required channels: Green.',
         ]),

--- a/cytocv/templates/workflow_defaults.html
+++ b/cytocv/templates/workflow_defaults.html
@@ -1581,7 +1581,7 @@ main.main > section.panel > form.panel > .card {
             <div class="row-sub{% if preferences.experiment_defaults.green_dot_split_enabled %} is-active{% endif %}" id="greenDotSplitModeRow" aria-hidden="{% if preferences.experiment_defaults.green_dot_split_enabled %}false{% else %}true{% endif %}">
               <div class="row-copy">
                 <span class="row-label-line"><label for="green_dot_split_mode">Green Dot Split Mode</label></span>
-                <p class="module-help">Balanced uses standard split sensitivity. Aggressive attempts harder splits for very close or unequal Green dots.</p>
+                <p class="module-help">Balanced uses standard split sensitivity, now stronger than the old balanced mode. Aggressive is the highest-recall split mode for tiny, very close, unequal, or tip-connected merged Green dots.</p>
               </div>
               <div class="mode-select-group plugin-measure-right compact-control"><select id="green_dot_split_mode" name="green_dot_split_mode"><option value="balanced" {% if preferences.experiment_defaults.green_dot_split_mode != 'aggressive' %}selected{% endif %}>Balanced</option><option value="aggressive" {% if preferences.experiment_defaults.green_dot_split_mode == 'aggressive' %}selected{% endif %}>Aggressive</option></select></div>
             </div>


### PR DESCRIPTION
This pull request updates the default behavior and documentation for the "Green Dot Split Mode" feature, making "aggressive" the new default mode and clarifying its description throughout the codebase and UI. It also increments the overlay render schema version to ensure cache separation for this change. The most important changes are:

**Default Behavior Changes:**
* The default value for `green_dot_split_mode` is now `"aggressive"` instead of `"balanced"` in user preferences and tests. [[1]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379L55-R54) [[2]](diffhunk://#diff-5975815911a31d142ebee61979d45315aa015a6ea81fef83b26168776c2774f2L52-R52) [[3]](diffhunk://#diff-5975815911a31d142ebee61979d45315aa015a6ea81fef83b26168776c2774f2L1937-R1937)
* The normalization logic for preferences was updated to handle the new default correctly if no value is provided.

**Overlay Rendering and Caching:**
* The overlay render schema version is incremented from 2 to 3, and all related cache directory and test references are updated to use the new version. [[1]](diffhunk://#diff-fef90c7f659bbbec01c491c55a19fe49407cecef117e02858bb1d4ec7daff174L41-R41) [[2]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267L633-R636)

**User Interface and Documentation:**
* All user-facing descriptions for "Green Dot Split Mode" in templates and info tooltips are updated to clarify that "Balanced" is now stronger than before, and "Aggressive" is the highest-recall mode for challenging cases. [[1]](diffhunk://#diff-3d324e96c0072d465b4d4d33d19ff3ab041f4927bae3eba23f96fbbb234761aaL1803-R1803) [[2]](diffhunk://#diff-3d324e96c0072d465b4d4d33d19ff3ab041f4927bae3eba23f96fbbb234761aaL2242-R2242) [[3]](diffhunk://#diff-e7486b1f5373eb06d5ec5de66395fc5df8a2986c4458f096ceb1b516740f99aaL1584-R1584)