### PR TITLE
Enhance aggressive green contour handling and overlay cache logic

### DIFF
--- a/cytocv/accounts/preferences.py
+++ b/cytocv/accounts/preferences.py
@@ -54,7 +54,7 @@ DEFAULT_USER_PREFERENCES: dict[str, Any] = {
         "biorientation_red_max_distance": 37,
         "biorientation_collinearity_threshold": 66,
         "green_dot_split_enabled": True,
-        "green_dot_split_mode": "aggressive",
+        "green_dot_split_mode": "balanced",
         "puncta_line_mode": DEFAULT_PUNCTA_LINE_MODE,
         "nuclear_cell_pair_mode": "green_nucleus",
         "green_contour_filter_enabled": False,

--- a/cytocv/accounts/preferences.py
+++ b/cytocv/accounts/preferences.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 import math
 from typing import Any
 
-from core.channel_roles import CHANNEL_ROLE_ORDER
+from core.channel_roles import CHANNEL_ROLE_ORDER, channel_role_from_slug, channel_slug
 from core.services.puncta_line_mode import (
     DEFAULT_PUNCTA_LINE_MODE,
     normalize_puncta_line_mode,
@@ -25,6 +25,9 @@ from core.stats_plugins import (
 NUCLEAR_CELL_PAIR_MODES = {"green_nucleus", "red_nucleus"}
 LENGTH_UNITS = {"px", "um"}
 DEFAULT_MICRONS_PER_PIXEL = 0.1
+MAIN_IMAGE_CHANNEL_SLUGS = frozenset(
+    channel_slug(channel_role) for channel_role in CHANNEL_ROLE_ORDER
+)
 
 
 class PreferenceValidationError(ValueError):
@@ -70,6 +73,7 @@ DEFAULT_USER_PREFERENCES: dict[str, Any] = {
     "show_saved_file_scales": True,
     "sidebar_starts_open": True,
     "sidebar_spatial_stats_unit": "px",
+    "main_image_channel": "",
 }
 
 
@@ -110,6 +114,15 @@ def _normalize_unit(value: Any, default: str) -> str:
     if unit not in LENGTH_UNITS:
         return default
     return unit
+
+
+def normalize_main_image_channel(value: Any, default: str = "") -> str:
+    slug = str(value or "").strip().lower()
+    if not slug:
+        return default
+    if not channel_role_from_slug(slug):
+        return default
+    return slug
 
 
 def _strict_bool(value: Any, *, field: str) -> bool:
@@ -374,6 +387,10 @@ def normalize_preferences_payload(raw_payload: Any) -> dict[str, Any]:
     normalized["sidebar_spatial_stats_unit"] = _normalize_unit(
         raw_payload.get("sidebar_spatial_stats_unit"),
         default=normalized["experiment_defaults"]["spatial_stats_unit"],
+    )
+    normalized["main_image_channel"] = normalize_main_image_channel(
+        raw_payload.get("main_image_channel"),
+        default="",
     )
     return normalized
 

--- a/cytocv/accounts/views/profile.py
+++ b/cytocv/accounts/views/profile.py
@@ -24,6 +24,8 @@ from django_tables2.export.export import TableExport
 
 from accounts.preferences import (
     get_user_preferences,
+    normalize_main_image_channel,
+    MAIN_IMAGE_CHANNEL_SLUGS,
     should_auto_save_experiments,
     update_user_preferences,
 )
@@ -621,6 +623,10 @@ def _build_dashboard_payload(user: Any) -> dict[str, Any]:
         preferences.get("sidebar_spatial_stats_unit"),
         default=default_spatial_stats_unit,
     )
+    main_image_channel = normalize_main_image_channel(
+        preferences.get("main_image_channel"),
+        default="",
+    )
 
     files_data: dict[str, Any] = {}
     file_list: list[dict[str, Any]] = []
@@ -845,6 +851,7 @@ def _build_dashboard_payload(user: Any) -> dict[str, Any]:
         "sidebar_starts_open": sidebar_starts_open,
         "default_spatial_stats_unit": default_spatial_stats_unit,
         "sidebar_spatial_stats_unit": sidebar_spatial_stats_unit,
+        "main_image_channel": main_image_channel,
     }
 
 
@@ -1020,9 +1027,10 @@ def dashboard_channel_visibility_view(request: HttpRequest) -> HttpResponse:
     has_channels = "show_saved_file_channels" in payload
     has_scales = "show_saved_file_scales" in payload
     has_sidebar_unit = "sidebar_spatial_stats_unit" in payload
-    if not has_channels and not has_scales and not has_sidebar_unit:
+    has_main_image_channel = "main_image_channel" in payload
+    if not has_channels and not has_scales and not has_sidebar_unit and not has_main_image_channel:
         return JsonResponse(
-            {"error": "At least one sidebar preference is required."},
+            {"error": "At least one preference is required."},
             status=400,
         )
 
@@ -1050,6 +1058,16 @@ def dashboard_channel_visibility_view(request: HttpRequest) -> HttpResponse:
             status=400,
         )
 
+    raw_main_image_channel = payload.get("main_image_channel")
+    main_image_channel = normalize_main_image_channel(raw_main_image_channel, default="")
+    if has_main_image_channel and main_image_channel not in MAIN_IMAGE_CHANNEL_SLUGS:
+        return JsonResponse(
+            {
+                "error": "main_image_channel must be one of: dic, blue, red, green.",
+            },
+            status=400,
+        )
+
     current = get_user_preferences(request.user)
     next_payload = dict(current)
     if has_channels:
@@ -1058,6 +1076,8 @@ def dashboard_channel_visibility_view(request: HttpRequest) -> HttpResponse:
         next_payload["show_saved_file_scales"] = show_saved_file_scales
     if has_sidebar_unit:
         next_payload["sidebar_spatial_stats_unit"] = sidebar_spatial_stats_unit
+    if has_main_image_channel:
+        next_payload["main_image_channel"] = main_image_channel
     updated = update_user_preferences(request.user, next_payload)
     return JsonResponse(
         {
@@ -1073,6 +1093,10 @@ def dashboard_channel_visibility_view(request: HttpRequest) -> HttpResponse:
                     updated.get("experiment_defaults", {}).get("spatial_stats_unit"),
                     default="px",
                 ),
+            ),
+            "main_image_channel": normalize_main_image_channel(
+                updated.get("main_image_channel"),
+                default="",
             ),
         }
     )

--- a/cytocv/accounts/views/profile.py
+++ b/cytocv/accounts/views/profile.py
@@ -48,7 +48,7 @@ from core.services.artifact_storage import (
 )
 from core.services.cell_statistics_payload import serialize_cell_statistics_payload
 from core.services.main_image_urls import build_main_image_paths
-from core.services.overlay_rendering import build_overlay_image_url, overlay_render_config_exists
+from core.services.overlay_rendering import build_overlay_image_url, overlay_image_available
 from core.services.puncta_line_mode import (
     DEFAULT_PUNCTA_LINE_MODE,
     VALID_PUNCTA_LINE_MODES,
@@ -646,7 +646,6 @@ def _build_dashboard_payload(user: Any) -> dict[str, Any]:
         debug_images, outlined_images, no_outline_images = _scan_segmented_assets(
             segmented_dir
         )
-        has_overlay_render_config = overlay_render_config_exists(uuid)
         output_frames = _scan_output_frames(output_dir)
         detected_channels = [
             channel_display_label(channel)
@@ -717,7 +716,7 @@ def _build_dashboard_payload(user: Any) -> dict[str, Any]:
                 if (
                     channel_name in {CHANNEL_ROLE_RED, CHANNEL_ROLE_GREEN, CHANNEL_ROLE_BLUE}
                     and cell_stat is not None
-                    and (has_overlay_render_config or debug_images.get((cell_id, channel_name), ""))
+                    and overlay_image_available(uuid, cell_id, channel_name)
                 ):
                     outlined_url = build_overlay_image_url(uuid, cell_id, channel_name)
                 else:

--- a/cytocv/core/contour_processing/contour_operations.py
+++ b/cytocv/core/contour_processing/contour_operations.py
@@ -1627,15 +1627,24 @@ def split_necked_gfp_contour_if_needed(
 
     shape_suspicious = _shape_is_suspicious(metrics, params)
     split_peak_pair = _choose_split_peak_pair(intensity_pair, distance_pair, params)
+    aggressive_peak_backed_geometry_evidence = (
+        split_peak_pair is not None
+        and shape_suspicious
+        and neck.neck_ratio <= 0.80
+    )
+    aggressive_peakless_geometry_evidence = (
+        shape_suspicious
+        and metrics.deep_defect_count >= 1
+        and metrics.aspect_ratio > float(params["max_single_dot_aspect_ratio"])
+        and metrics.max_defect_depth_px >= 1.0
+        and neck.neck_ratio <= 0.80
+    )
     if (
         split_mode == "aggressive"
         and split_peak_pair is None
         and metrics.aspect_ratio >= 2.0
         and metrics.solidity >= 0.94
-        and (
-            metrics.max_defect_depth_px < 1.0
-            or neck.neck_ratio > 0.80
-        )
+        and not aggressive_peakless_geometry_evidence
     ):
         if debug:
             logger.debug(
@@ -1643,7 +1652,11 @@ def split_necked_gfp_contour_if_needed(
             )
         return [contour]
     has_peak_evidence = split_peak_pair is not None
-    has_geometry_evidence = shape_suspicious and metrics.deep_defect_count >= 2
+    has_geometry_evidence = (
+        aggressive_peakless_geometry_evidence
+        if split_mode == "aggressive"
+        else shape_suspicious and metrics.deep_defect_count >= 2
+    )
     if not (has_peak_evidence or has_geometry_evidence):
         child_contours = try_asymmetric_fallback()
         if len(child_contours) == 2:
@@ -1700,14 +1713,9 @@ def split_necked_gfp_contour_if_needed(
 
     if (
         split_mode == "aggressive"
-        and metrics.max_defect_depth_px >= 1.0
-        and neck.neck_ratio <= 0.80
         and (
-            split_peak_pair is not None
-            or (
-                shape_suspicious
-                and metrics.aspect_ratio >= 1.35
-            )
+            aggressive_peak_backed_geometry_evidence
+            or aggressive_peakless_geometry_evidence
         )
     ):
         geometry_labels = split_contour_with_geometry_first_watershed(

--- a/cytocv/core/contour_processing/contour_operations.py
+++ b/cytocv/core/contour_processing/contour_operations.py
@@ -974,6 +974,106 @@ def validate_geometry_first_split(
     return child_contours
 
 
+def _tighten_aggressive_split_children(
+    child_contours: list[np.ndarray],
+    tightening_image: np.ndarray | None,
+    params: dict,
+    *,
+    peak_pair: _PeakPair | None = None,
+) -> list[np.ndarray]:
+    """Tighten accepted aggressive split children around their brighter cores."""
+
+    if len(child_contours) != 2:
+        return child_contours
+
+    gray = _as_gray_float(tightening_image)
+    if gray is None or gray.size == 0:
+        return child_contours
+
+    tightened_regions: list[np.ndarray] = []
+    tightened_contours: list[np.ndarray] = []
+    for child_contour in child_contours:
+        child_mask = contour_to_mask(child_contour, gray.shape) > 0
+        if not np.any(child_mask):
+            return child_contours
+
+        original_child_area = int(np.count_nonzero(child_mask))
+        ys, xs = np.nonzero(child_mask)
+        child_values = gray[ys, xs]
+        if child_values.size == 0:
+            return child_contours
+
+        peak_index = int(np.argmax(child_values))
+        peak_y = int(ys[peak_index])
+        peak_x = int(xs[peak_index])
+        child_peak = float(child_values[peak_index])
+        percentile_70 = float(np.percentile(child_values, 70))
+        tightening_threshold = max(child_peak * 0.55, percentile_70)
+
+        core_mask = child_mask & (gray >= tightening_threshold)
+        if not np.any(core_mask):
+            return child_contours
+
+        core_labels, _component_count = ndi.label(core_mask)
+        peak_label = int(core_labels[peak_y, peak_x])
+        if peak_label == 0:
+            return child_contours
+
+        peak_component = core_labels == peak_label
+        tightened_region = ndi.binary_dilation(
+            peak_component,
+            structure=np.ones((3, 3), dtype=bool),
+            iterations=1,
+        )
+        tightened_region &= child_mask
+
+        tightened_area = int(np.count_nonzero(tightened_region))
+        min_tightened_area = max(4, int(math.ceil(original_child_area * 0.25)))
+        if tightened_area < min_tightened_area:
+            return child_contours
+        if not tightened_region[peak_y, peak_x]:
+            return child_contours
+
+        tightened_contour = _contour_from_region(tightened_region.astype(np.uint8))
+        if tightened_contour is None or len(tightened_contour) < 3:
+            return child_contours
+
+        tightened_regions.append(tightened_region)
+        tightened_contours.append(tightened_contour)
+
+    if np.any(tightened_regions[0] & tightened_regions[1]):
+        return child_contours
+
+    if peak_pair is not None:
+        tightened_labels = np.zeros(gray.shape, dtype=np.uint8)
+        tightened_labels[tightened_regions[0]] = 1
+        tightened_labels[tightened_regions[1]] = 2
+        label_a = _label_at_point(tightened_labels, peak_pair.peak_a.point)
+        label_b = _label_at_point(tightened_labels, peak_pair.peak_b.point)
+        if label_a == 0 or label_b == 0 or label_a == label_b:
+            return child_contours
+
+    return tightened_contours
+
+
+def _finalize_accepted_split_children(
+    child_contours: list[np.ndarray],
+    tightening_image: np.ndarray | None,
+    params: dict,
+    split_mode: str,
+    *,
+    peak_pair: _PeakPair | None = None,
+) -> list[np.ndarray]:
+    if split_mode != "aggressive" or len(child_contours) != 2:
+        return child_contours
+    return _tighten_aggressive_split_children(
+        child_contours,
+        tightening_image,
+        params,
+        peak_pair=peak_pair,
+    )
+
+
 def _internal_watershed_boundaries(labels: np.ndarray) -> np.ndarray:
     """Return boundary pixels between positive watershed regions only."""
 
@@ -1391,6 +1491,7 @@ def split_asymmetric_gfp_contour_if_needed(
     gfp_image: np.ndarray,
     params: dict,
     *,
+    tightening_image: np.ndarray | None = None,
     has_paired_neck: bool = False,
     split_mode: str = DEFAULT_GREEN_DOT_SPLIT_MODE,
     debug: bool = False,
@@ -1422,7 +1523,13 @@ def split_asymmetric_gfp_contour_if_needed(
         params,
     )
     if len(child_contours) == 2:
-        return child_contours
+        return _finalize_accepted_split_children(
+            child_contours,
+            tightening_image,
+            params,
+            split_mode,
+            peak_pair=candidate.peak_pair,
+        )
 
     if debug:
         logger.debug("Green asymmetric split rejected: watershed failed validation")
@@ -1447,13 +1554,18 @@ def split_necked_gfp_contour_if_needed(
     if isinstance(config, str):
         split_mode = config
         debug = False
+        tightening_image = None
     else:
         config_payload = dict(config or {})
         split_mode = config_payload.get("mode", DEFAULT_GREEN_DOT_SPLIT_MODE)
         debug = bool(config_payload.get("debug", False))
+        tightening_image = config_payload.get("tightening_image")
     split_mode = normalize_green_dot_split_mode(split_mode)
 
     params = _split_params(split_mode)
+    tightening_gray = _as_gray_float(tightening_image)
+    if tightening_gray is None or tightening_gray.shape[:2] != gfp_image.shape[:2]:
+        tightening_gray = _as_gray_float(gfp_image)
     metrics = compute_contour_shape_metrics(
         contour,
         gfp_image.shape,
@@ -1495,6 +1607,7 @@ def split_necked_gfp_contour_if_needed(
             metrics,
             gfp_image,
             params,
+            tightening_image=tightening_gray,
             has_paired_neck=neck is not None,
             split_mode=split_mode,
             debug=debug,
@@ -1557,7 +1670,13 @@ def split_necked_gfp_contour_if_needed(
         neck_candidate=neck,
     )
     if len(child_contours) == 2:
-        return child_contours
+        return _finalize_accepted_split_children(
+            child_contours,
+            tightening_gray,
+            params,
+            split_mode,
+            peak_pair=split_peak_pair,
+        )
 
     # If the watershed markers do not pass validation, a strong paired-defect
     # neck can still be separated by the direct chord between the concave points.
@@ -1571,7 +1690,13 @@ def split_necked_gfp_contour_if_needed(
         neck_candidate=neck,
     )
     if len(child_contours) == 2:
-        return child_contours
+        return _finalize_accepted_split_children(
+            child_contours,
+            tightening_gray,
+            params,
+            split_mode,
+            peak_pair=split_peak_pair,
+        )
 
     if (
         split_mode == "aggressive"
@@ -1598,7 +1723,13 @@ def split_necked_gfp_contour_if_needed(
             neck,
         )
         if len(child_contours) == 2:
-            return child_contours
+            return _finalize_accepted_split_children(
+                child_contours,
+                tightening_gray,
+                params,
+                split_mode,
+                peak_pair=split_peak_pair,
+            )
 
     child_contours = try_asymmetric_fallback()
     if len(child_contours) == 2:
@@ -1714,6 +1845,7 @@ def find_contours(
     gray_blue_3 = images.get_image("gray_blue_3")
     gray_blue = images.get_image("gray_blue")
     gray_green = images.get_image("green")
+    gray_green_no_bg = images.get_image("green_no_bg")
     green_dot_split_mode = normalize_green_dot_split_mode(green_dot_split_mode)
 
     dot_contours = []
@@ -1924,17 +2056,23 @@ def find_contours(
             cv2.RETR_LIST,
             cv2.CHAIN_APPROX_SIMPLE,
         )
+        split_config = {
+            "mode": green_dot_split_mode,
+            "tightening_image": (
+                gray_green_no_bg if gray_green_no_bg is not None else gray_green
+            ),
+        }
         if green_dot_split_enabled and green_contour_filter_enabled and green_dot_split_mode == "aggressive":
             contours_green = _postprocess_and_filter_aggressive_green_contours(
                 contours_green,
                 gray_green,
-                {"mode": green_dot_split_mode},
+                split_config,
             )
         elif green_dot_split_enabled:
             contours_green = postprocess_gfp_contours_for_neck_splits(
                 contours_green,
                 gray_green,
-                {"mode": green_dot_split_mode},
+                split_config,
             )
             if green_contour_filter_enabled:
                 contours_green, _ = _filter_green_contours_with_image(

--- a/cytocv/core/contour_processing/contour_operations.py
+++ b/cytocv/core/contour_processing/contour_operations.py
@@ -18,46 +18,46 @@ logger = logging.getLogger(__name__)
 
 GREEN_DOT_SPLIT_PARAMS = {
     "balanced": {
-        "min_original_area_px": 10,
-        "min_peak_distance": 2,
-        "min_peak_ratio": 0.25,
-        "min_intensity_peak_ratio": 0.28,
-        "min_second_peak_ratio": 0.32,
-        "max_intensity_valley_ratio": 0.92,
-        "max_distance_valley_ratio": 0.94,
-        "min_defect_depth_px": 0.45,
-        "min_relative_defect_depth": 0.07,
-        "max_neck_width_ratio": 0.94,
-        "min_chord_mask_fraction": 0.58,
-        "max_single_dot_circularity": 0.90,
-        "min_single_dot_solidity": 0.985,
-        "max_single_dot_aspect_ratio": 1.18,
-        "min_suspicious_aspect_ratio": 1.08,
-        "max_suspicious_circularity": 0.84,
-        "max_suspicious_solidity": 0.985,
-        "min_split_circularity": 0.16,
-        "min_split_solidity": 0.58,
-        "min_split_area_px": 6,
-        "min_child_area_fraction": 0.10,
-        "min_combined_area_ratio": 0.66,
-        "min_child_center_distance_px": 2.0,
-        "max_child_aspect_ratio": 4.0,
-        "min_child_peak_ratio": 0.25,
-        "max_neck_alignment_cos": 0.88,
+        "min_original_area_px": 8,
+        "min_peak_distance": 1,
+        "min_peak_ratio": 0.18,
+        "min_intensity_peak_ratio": 0.20,
+        "min_second_peak_ratio": 0.20,
+        "max_intensity_valley_ratio": 0.96,
+        "max_distance_valley_ratio": 0.97,
+        "min_defect_depth_px": 0.25,
+        "min_relative_defect_depth": 0.04,
+        "max_neck_width_ratio": 1.00,
+        "min_chord_mask_fraction": 0.45,
+        "max_single_dot_circularity": 0.92,
+        "min_single_dot_solidity": 0.99,
+        "max_single_dot_aspect_ratio": 1.12,
+        "min_suspicious_aspect_ratio": 1.04,
+        "max_suspicious_circularity": 0.88,
+        "max_suspicious_solidity": 0.99,
+        "min_split_circularity": 0.10,
+        "min_split_solidity": 0.45,
+        "min_split_area_px": 4,
+        "min_child_area_fraction": 0.06,
+        "min_combined_area_ratio": 0.58,
+        "min_child_center_distance_px": 1.0,
+        "max_child_aspect_ratio": 5.5,
+        "min_child_peak_ratio": 0.15,
+        "max_neck_alignment_cos": 0.94,
         "neck_cut_line_thickness": 1,
         "asymmetric_fallback_enabled": True,
-        "asymmetric_min_peak_distance_px": 4.0,
-        "asymmetric_min_second_peak_ratio": 0.32,
-        "asymmetric_max_intensity_valley_ratio": 0.88,
-        "asymmetric_min_intensity_drop_ratio": 0.10,
-        "asymmetric_max_distance_saddle_ratio": 0.88,
-        "asymmetric_min_peak_line_mask_fraction": 0.80,
-        "asymmetric_min_single_defect_depth_px": 0.75,
-        "asymmetric_max_saddle_to_defect_distance_px": 8.0,
-        "asymmetric_min_child_area_fraction": 0.16,
-        "asymmetric_min_child_mean_ratio": 0.16,
-        "asymmetric_min_boundary_low_signal_fraction": 0.55,
-        "asymmetric_max_boundary_saddle_distance_px": 6.0,
+        "asymmetric_min_peak_distance_px": 2.0,
+        "asymmetric_min_second_peak_ratio": 0.20,
+        "asymmetric_max_intensity_valley_ratio": 0.94,
+        "asymmetric_min_intensity_drop_ratio": 0.04,
+        "asymmetric_max_distance_saddle_ratio": 0.94,
+        "asymmetric_min_peak_line_mask_fraction": 0.60,
+        "asymmetric_min_single_defect_depth_px": 0.35,
+        "asymmetric_max_saddle_to_defect_distance_px": 10.0,
+        "asymmetric_min_child_area_fraction": 0.08,
+        "asymmetric_min_child_mean_ratio": 0.08,
+        "asymmetric_min_boundary_low_signal_fraction": 0.40,
+        "asymmetric_max_boundary_saddle_distance_px": 8.0,
     },
     "aggressive": {
         "min_original_area_px": 8,
@@ -676,27 +676,30 @@ def _split_contour_with_neck_chord(
     return split_labels
 
 
-def _neck_chord_side_labels(
+def _separator_side_labels(
     mask: np.ndarray,
-    neck: _NeckCandidate,
+    line_point: tuple[float, float] | np.ndarray,
+    line_direction: tuple[float, float] | np.ndarray,
+    label_1_reference: tuple[float, float] | np.ndarray,
+    label_2_reference: tuple[float, float] | np.ndarray,
 ) -> np.ndarray:
-    """Partition a contour mask by the two sides of the candidate neck chord."""
+    """Partition a mask by the two sides of a separator line."""
 
     labels = np.zeros(mask.shape, dtype=np.int32)
     ys, xs = np.nonzero(mask > 0)
     if xs.size == 0:
         return labels
 
-    point_a = np.array(neck.point_a, dtype=np.float32)
-    point_b = np.array(neck.point_b, dtype=np.float32)
-    chord = point_b - point_a
-    chord_norm = float(np.linalg.norm(chord))
-    if chord_norm <= 0:
+    line_origin = np.asarray(line_point, dtype=np.float32)
+    direction = np.asarray(line_direction, dtype=np.float32)
+    if float(np.linalg.norm(direction)) <= 0:
         return labels
 
+    ref_1 = np.asarray(label_1_reference, dtype=np.float32)
+    ref_2 = np.asarray(label_2_reference, dtype=np.float32)
     points = np.column_stack((xs, ys)).astype(np.float32, copy=False)
-    relative = points - point_a
-    signed = (chord[0] * relative[:, 1]) - (chord[1] * relative[:, 0])
+    relative = points - line_origin
+    signed = (direction[0] * relative[:, 1]) - (direction[1] * relative[:, 0])
 
     positive = signed > 1e-3
     negative = signed < -1e-3
@@ -705,12 +708,86 @@ def _neck_chord_side_labels(
 
     on_line = ~(positive | negative)
     if np.any(on_line):
-        dist_a = np.sum((points[on_line] - point_a) ** 2, axis=1)
-        dist_b = np.sum((points[on_line] - point_b) ** 2, axis=1)
-        side_labels = np.where(dist_a <= dist_b, 1, 2)
+        dist_1 = np.sum((points[on_line] - ref_1) ** 2, axis=1)
+        dist_2 = np.sum((points[on_line] - ref_2) ** 2, axis=1)
+        side_labels = np.where(dist_1 <= dist_2, 1, 2)
         labels[ys[on_line], xs[on_line]] = side_labels
 
     return labels
+
+
+def _neck_chord_side_labels(
+    mask: np.ndarray,
+    neck: _NeckCandidate,
+) -> np.ndarray:
+    """Partition a contour mask by the two sides of the candidate neck chord."""
+
+    point_a = np.array(neck.point_a, dtype=np.float32)
+    point_b = np.array(neck.point_b, dtype=np.float32)
+    return _separator_side_labels(mask, point_a, point_b - point_a, point_a, point_b)
+
+
+def _peak_pair_bisector_labels(
+    mask: np.ndarray,
+    peak_pair: _PeakPair,
+) -> np.ndarray:
+    point_a = np.array(peak_pair.peak_a.point, dtype=np.float32)
+    point_b = np.array(peak_pair.peak_b.point, dtype=np.float32)
+    peak_axis = point_b - point_a
+    if float(np.linalg.norm(peak_axis)) <= 0:
+        return np.zeros(mask.shape, dtype=np.int32)
+    midpoint = (point_a + point_b) / 2.0
+    separator_direction = np.array([-peak_axis[1], peak_axis[0]], dtype=np.float32)
+    return _separator_side_labels(mask, midpoint, separator_direction, point_a, point_b)
+
+
+def _asymmetric_candidate_axis_labels(
+    mask: np.ndarray,
+    candidate: _AsymmetricSplitCandidate,
+) -> np.ndarray:
+    point_a = np.array(candidate.peak_pair.peak_a.point, dtype=np.float32)
+    point_b = np.array(candidate.peak_pair.peak_b.point, dtype=np.float32)
+    peak_axis = point_b - point_a
+    if float(np.linalg.norm(peak_axis)) <= 0:
+        return np.zeros(mask.shape, dtype=np.int32)
+    separator_direction = np.array([-peak_axis[1], peak_axis[0]], dtype=np.float32)
+    return _separator_side_labels(
+        mask,
+        candidate.saddle.point,
+        separator_direction,
+        point_a,
+        point_b,
+    )
+
+
+def _principal_axis_bridge_labels(
+    mask: np.ndarray,
+    neck_candidate: _NeckCandidate | None = None,
+) -> np.ndarray:
+    ys, xs = np.nonzero(mask > 0)
+    if xs.size < 2:
+        return np.zeros(mask.shape, dtype=np.int32)
+
+    points = np.column_stack((xs, ys)).astype(np.float32, copy=False)
+    center = np.mean(points, axis=0)
+    centered = points - center
+    covariance = np.cov(centered, rowvar=False)
+    eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+    major_axis = eigenvectors[:, int(np.argmax(eigenvalues))]
+    if float(np.linalg.norm(major_axis)) <= 0:
+        return np.zeros(mask.shape, dtype=np.int32)
+
+    anchor = center
+    if neck_candidate is not None:
+        anchor = (
+            np.array(neck_candidate.point_a, dtype=np.float32)
+            + np.array(neck_candidate.point_b, dtype=np.float32)
+        ) / 2.0
+    separator_direction = np.array([-major_axis[1], major_axis[0]], dtype=np.float32)
+    reference_distance = max(4.0, float(np.sqrt(max(np.max(eigenvalues), 1e-6))))
+    ref_1 = anchor - (major_axis * reference_distance)
+    ref_2 = anchor + (major_axis * reference_distance)
+    return _separator_side_labels(mask, anchor, separator_direction, ref_1, ref_2)
 
 
 def _markers_from_neck_geometry(
@@ -974,6 +1051,208 @@ def validate_geometry_first_split(
     return child_contours
 
 
+def _boundary_has_low_signal_support(
+    original_mask: np.ndarray,
+    split_labels: np.ndarray,
+    gfp_image: np.ndarray | None,
+    params: dict,
+    *,
+    peak_pair: _PeakPair | None = None,
+    saddle_point: tuple[int, int] | None = None,
+    peak_distance_px: float | None = None,
+) -> bool:
+    boundary = _boundary_between_split_labels(original_mask, split_labels)
+    if not np.any(boundary):
+        return False
+
+    if saddle_point is not None and not _boundary_reaches_saddle(
+        boundary,
+        saddle_point,
+        params,
+        peak_distance_px or 0.0,
+    ):
+        return False
+
+    if peak_pair is None or gfp_image is None:
+        return True
+
+    smoothed = _smooth_gfp_image(gfp_image)
+    if smoothed is None or smoothed.shape[:2] != original_mask.shape:
+        return False
+    distance_image = ndi.distance_transform_edt(original_mask > 0).astype(np.float32)
+
+    peak_floor = min(peak_pair.peak_a.value, peak_pair.peak_b.value)
+    peak_distance_floor = min(
+        float(distance_image[peak_pair.peak_a.y, peak_pair.peak_a.x]),
+        float(distance_image[peak_pair.peak_b.y, peak_pair.peak_b.x]),
+    )
+    if peak_floor <= 0 or peak_distance_floor <= 0:
+        return False
+
+    intensity_limit = peak_floor * float(
+        params.get("asymmetric_max_intensity_valley_ratio", params["max_intensity_valley_ratio"])
+    )
+    distance_limit = peak_distance_floor * float(
+        params.get("asymmetric_max_distance_saddle_ratio", params["max_distance_valley_ratio"])
+    )
+    boundary_intensity_ok = smoothed[boundary] <= intensity_limit
+    boundary_distance_ok = distance_image[boundary] <= distance_limit
+    low_signal_fraction = float(
+        np.count_nonzero(boundary_intensity_ok | boundary_distance_ok)
+        / max(np.count_nonzero(boundary), 1)
+    )
+    return low_signal_fraction >= float(
+        params.get("asymmetric_min_boundary_low_signal_fraction", 0.40)
+    )
+
+
+def _validate_peak_backed_deterministic_split(
+    original_mask: np.ndarray,
+    split_labels: np.ndarray | None,
+    gfp_image: np.ndarray,
+    params: dict,
+    *,
+    peak_pair: _PeakPair,
+    neck_candidate: _NeckCandidate | None = None,
+    saddle_point: tuple[int, int] | None = None,
+    peak_distance_px: float | None = None,
+) -> list[np.ndarray]:
+    child_contours = validate_split_contours(
+        original_mask,
+        split_labels,
+        gfp_image,
+        params,
+        peak_pair=peak_pair,
+        neck_candidate=neck_candidate,
+    )
+    if len(child_contours) != 2 or split_labels is None:
+        return []
+    if neck_candidate is not None and not _boundary_intersects_neck_chord(
+        original_mask,
+        split_labels,
+        neck_candidate,
+    ):
+        return []
+    if not _boundary_has_low_signal_support(
+        original_mask,
+        split_labels,
+        gfp_image,
+        params,
+        peak_pair=peak_pair,
+        saddle_point=saddle_point,
+        peak_distance_px=peak_distance_px,
+    ):
+        return []
+    return child_contours
+
+
+def _try_deterministic_aggressive_split(
+    metrics: _ContourShapeMetrics,
+    gfp_image: np.ndarray,
+    params: dict,
+    *,
+    split_peak_pair: _PeakPair | None,
+    neck_candidate: _NeckCandidate | None,
+    asymmetric_candidate: _AsymmetricSplitCandidate | None,
+    tightening_image: np.ndarray | None,
+    split_mode: str,
+) -> list[np.ndarray]:
+    if neck_candidate is not None:
+        neck_side_labels = _neck_chord_side_labels(metrics.mask, neck_candidate)
+        if split_peak_pair is not None:
+            child_contours = _validate_peak_backed_deterministic_split(
+                metrics.mask,
+                neck_side_labels,
+                gfp_image,
+                params,
+                peak_pair=split_peak_pair,
+                neck_candidate=neck_candidate,
+            )
+        else:
+            child_contours = validate_geometry_first_split(
+                metrics.mask,
+                neck_side_labels,
+                params,
+                neck_candidate,
+            )
+        if len(child_contours) == 2:
+            return _finalize_accepted_split_children(
+                child_contours,
+                tightening_image,
+                params,
+                split_mode,
+                peak_pair=split_peak_pair,
+            )
+
+    if split_peak_pair is not None and neck_candidate is not None:
+        peak_axis_labels = _peak_pair_bisector_labels(metrics.mask, split_peak_pair)
+        child_contours = _validate_peak_backed_deterministic_split(
+            metrics.mask,
+            peak_axis_labels,
+            gfp_image,
+            params,
+            peak_pair=split_peak_pair,
+        )
+        if len(child_contours) == 2:
+            return _finalize_accepted_split_children(
+                child_contours,
+                tightening_image,
+                params,
+                split_mode,
+                peak_pair=split_peak_pair,
+            )
+
+    if asymmetric_candidate is not None:
+        asymmetric_axis_labels = _asymmetric_candidate_axis_labels(
+            metrics.mask,
+            asymmetric_candidate,
+        )
+        child_contours = validate_asymmetric_split(
+            metrics.mask,
+            asymmetric_axis_labels,
+            gfp_image,
+            asymmetric_candidate,
+            params,
+        )
+        if len(child_contours) == 2:
+            return _finalize_accepted_split_children(
+                child_contours,
+                tightening_image,
+                params,
+                split_mode,
+                peak_pair=asymmetric_candidate.peak_pair,
+            )
+
+    if neck_candidate is not None:
+        bridge_axis_labels = _principal_axis_bridge_labels(metrics.mask, neck_candidate)
+        if split_peak_pair is not None:
+            child_contours = _validate_peak_backed_deterministic_split(
+                metrics.mask,
+                bridge_axis_labels,
+                gfp_image,
+                params,
+                peak_pair=split_peak_pair,
+                neck_candidate=neck_candidate,
+            )
+        else:
+            child_contours = validate_geometry_first_split(
+                metrics.mask,
+                bridge_axis_labels,
+                params,
+                neck_candidate,
+            )
+        if len(child_contours) == 2:
+            return _finalize_accepted_split_children(
+                child_contours,
+                tightening_image,
+                params,
+                split_mode,
+                peak_pair=split_peak_pair,
+            )
+
+    return []
+
+
 def _tighten_aggressive_split_children(
     child_contours: list[np.ndarray],
     tightening_image: np.ndarray | None,
@@ -998,6 +1277,7 @@ def _tighten_aggressive_split_children(
             return child_contours
 
         original_child_area = int(np.count_nonzero(child_mask))
+        original_child_contour_area = float(cv2.contourArea(child_contour))
         ys, xs = np.nonzero(child_mask)
         child_values = gray[ys, xs]
         if child_values.size == 0:
@@ -1037,6 +1317,9 @@ def _tighten_aggressive_split_children(
         tightened_contour = _contour_from_region(tightened_region.astype(np.uint8))
         if tightened_contour is None or len(tightened_contour) < 3:
             return child_contours
+        min_tightened_contour_area = max(4.0, original_child_contour_area * 0.25)
+        if float(cv2.contourArea(tightened_contour)) < min_tightened_contour_area:
+            return child_contours
 
         tightened_regions.append(tightened_region)
         tightened_contours.append(tightened_contour)
@@ -1064,7 +1347,7 @@ def _finalize_accepted_split_children(
     *,
     peak_pair: _PeakPair | None = None,
 ) -> list[np.ndarray]:
-    if split_mode != "aggressive" or len(child_contours) != 2:
+    if len(child_contours) != 2:
         return child_contours
     return _tighten_aggressive_split_children(
         child_contours,
@@ -1492,6 +1775,7 @@ def split_asymmetric_gfp_contour_if_needed(
     params: dict,
     *,
     tightening_image: np.ndarray | None = None,
+    candidate: _AsymmetricSplitCandidate | None = None,
     has_paired_neck: bool = False,
     split_mode: str = DEFAULT_GREEN_DOT_SPLIT_MODE,
     debug: bool = False,
@@ -1503,7 +1787,8 @@ def split_asymmetric_gfp_contour_if_needed(
             logger.debug("Green asymmetric split rejected: contour is compact and round")
         return []
 
-    candidate = find_asymmetric_peak_saddle_candidate(metrics.mask, gfp_image, params)
+    if candidate is None:
+        candidate = find_asymmetric_peak_saddle_candidate(metrics.mask, gfp_image, params)
     if candidate is None:
         if debug:
             logger.debug("Green asymmetric split rejected: no two-peak saddle")
@@ -1543,9 +1828,10 @@ def split_necked_gfp_contour_if_needed(
 ) -> list[np.ndarray]:
     """Return one original contour or two child contours for a necked GFP blob.
 
-    The splitter is intentionally gated by the existing contour outline. It only
-    attempts a split when the blob has paired concave defects forming a narrow
-    waist, plus either two lobe peaks or strong peanut/dumbbell shape metrics.
+    The splitter is intentionally gated by the existing contour outline. Public
+    balanced preserves the former aggressive baseline, while public aggressive
+    is a higher-recall mode that unlocks more split attempts and lets
+    validation decide acceptance.
     """
 
     if contour is None or len(contour) < 3:
@@ -1601,6 +1887,7 @@ def split_necked_gfp_contour_if_needed(
         params,
         max_valley_ratio_key="max_distance_valley_ratio",
     )
+    asymmetric_candidate = find_asymmetric_peak_saddle_candidate(metrics.mask, gfp_image, params)
 
     def try_asymmetric_fallback() -> list[np.ndarray]:
         return split_asymmetric_gfp_contour_if_needed(
@@ -1608,18 +1895,12 @@ def split_necked_gfp_contour_if_needed(
             gfp_image,
             params,
             tightening_image=tightening_gray,
+            candidate=asymmetric_candidate,
             has_paired_neck=neck is not None,
             split_mode=split_mode,
             debug=debug,
         )
 
-    if neck is None:
-        child_contours = try_asymmetric_fallback()
-        if len(child_contours) == 2:
-            return child_contours
-        if debug:
-            logger.debug("Green neck split rejected: no paired concavity")
-        return [contour]
     if _is_round_single_dot(metrics, params):
         if debug:
             logger.debug("Green neck split rejected: contour is compact and round")
@@ -1627,97 +1908,224 @@ def split_necked_gfp_contour_if_needed(
 
     shape_suspicious = _shape_is_suspicious(metrics, params)
     split_peak_pair = _choose_split_peak_pair(intensity_pair, distance_pair, params)
-    aggressive_peak_backed_geometry_evidence = (
+    baseline_peak_backed_geometry_evidence = (
         split_peak_pair is not None
         and shape_suspicious
+        and neck is not None
         and neck.neck_ratio <= 0.80
     )
-    aggressive_peakless_geometry_evidence = (
+    baseline_peakless_geometry_evidence = (
         shape_suspicious
+        and neck is not None
         and metrics.deep_defect_count >= 1
         and metrics.aspect_ratio > float(params["max_single_dot_aspect_ratio"])
         and metrics.max_defect_depth_px >= 1.0
         and neck.neck_ratio <= 0.80
     )
-    if (
-        split_mode == "aggressive"
-        and split_peak_pair is None
-        and metrics.aspect_ratio >= 2.0
-        and metrics.solidity >= 0.94
-        and not aggressive_peakless_geometry_evidence
-    ):
-        if debug:
-            logger.debug(
-                "Green neck split rejected: smooth convex contour lacks peak-supported or usable neck-supported split evidence"
+
+    def try_balanced_baseline_routes(active_mode: str) -> list[np.ndarray]:
+        if neck is None:
+            child_contours = try_asymmetric_fallback()
+            if len(child_contours) == 2:
+                return child_contours
+            if debug:
+                logger.debug("Green neck split rejected: no paired concavity")
+            return [contour]
+        if (
+            split_peak_pair is None
+            and metrics.aspect_ratio >= 2.0
+            and metrics.solidity >= 0.94
+            and not baseline_peakless_geometry_evidence
+        ):
+            if debug:
+                logger.debug(
+                    "Green neck split rejected: smooth convex contour lacks peak-supported or usable neck-supported split evidence"
+                )
+            return [contour]
+        has_peak_evidence = split_peak_pair is not None
+        has_geometry_evidence = baseline_peakless_geometry_evidence
+        if not (has_peak_evidence or has_geometry_evidence):
+            child_contours = try_asymmetric_fallback()
+            if len(child_contours) == 2:
+                return child_contours
+            if debug:
+                logger.debug("Green neck split rejected: no two-lobe evidence")
+            return [contour]
+
+        split_labels = split_contour_with_watershed(
+            metrics.mask,
+            gfp_image,
+            split_peak_pair,
+            params,
+            neck_candidate=neck,
+        )
+        child_contours = validate_split_contours(
+            metrics.mask,
+            split_labels,
+            gfp_image,
+            params,
+            peak_pair=split_peak_pair,
+            neck_candidate=neck,
+        )
+        if len(child_contours) == 2:
+            return _finalize_accepted_split_children(
+                child_contours,
+                tightening_gray,
+                params,
+                active_mode,
+                peak_pair=split_peak_pair,
             )
-        return [contour]
-    has_peak_evidence = split_peak_pair is not None
-    has_geometry_evidence = (
-        aggressive_peakless_geometry_evidence
-        if split_mode == "aggressive"
-        else shape_suspicious and metrics.deep_defect_count >= 2
-    )
-    if not (has_peak_evidence or has_geometry_evidence):
+
+        chord_labels = _split_contour_with_neck_chord(metrics.mask, neck, params)
+        child_contours = validate_split_contours(
+            metrics.mask,
+            chord_labels,
+            gfp_image,
+            params,
+            peak_pair=None,
+            neck_candidate=neck,
+        )
+        if len(child_contours) == 2:
+            return _finalize_accepted_split_children(
+                child_contours,
+                tightening_gray,
+                params,
+                active_mode,
+                peak_pair=split_peak_pair,
+            )
+
+        if baseline_peak_backed_geometry_evidence or baseline_peakless_geometry_evidence:
+            geometry_labels = split_contour_with_geometry_first_watershed(
+                metrics.mask,
+                gfp_image,
+                neck,
+                params,
+            )
+            child_contours = validate_geometry_first_split(
+                metrics.mask,
+                geometry_labels,
+                params,
+                neck,
+            )
+            if len(child_contours) == 2:
+                return _finalize_accepted_split_children(
+                    child_contours,
+                    tightening_gray,
+                    params,
+                    active_mode,
+                    peak_pair=split_peak_pair,
+                )
+
         child_contours = try_asymmetric_fallback()
         if len(child_contours) == 2:
             return child_contours
+
         if debug:
-            logger.debug("Green neck split rejected: no two-lobe evidence")
+            logger.debug("Green neck split rejected: candidate split failed validation")
         return [contour]
 
-    # Watershed is preferred because it lets the split follow the intensity and
-    # distance ridge while staying constrained to the original merged contour.
-    split_labels = split_contour_with_watershed(
-        metrics.mask,
-        gfp_image,
-        split_peak_pair,
-        params,
-        neck_candidate=neck,
-    )
-    child_contours = validate_split_contours(
-        metrics.mask,
-        split_labels,
-        gfp_image,
-        params,
-        peak_pair=split_peak_pair,
-        neck_candidate=neck,
-    )
-    if len(child_contours) == 2:
-        return _finalize_accepted_split_children(
-            child_contours,
-            tightening_gray,
-            params,
-            split_mode,
-            peak_pair=split_peak_pair,
-        )
+    if split_mode == "balanced":
+        return try_balanced_baseline_routes(split_mode)
 
-    # If the watershed markers do not pass validation, a strong paired-defect
-    # neck can still be separated by the direct chord between the concave points.
-    chord_labels = _split_contour_with_neck_chord(metrics.mask, neck, params)
-    child_contours = validate_split_contours(
-        metrics.mask,
-        chord_labels,
-        gfp_image,
-        params,
-        peak_pair=None,
-        neck_candidate=neck,
+    baseline_result = try_balanced_baseline_routes(split_mode)
+    if len(baseline_result) == 2:
+        return baseline_result
+
+    strong_neck_indicator = (
+        neck is not None
+        and metrics.deep_defect_count >= 1
+        and neck.neck_ratio <= 0.60
     )
-    if len(child_contours) == 2:
-        return _finalize_accepted_split_children(
-            child_contours,
-            tightening_gray,
-            params,
-            split_mode,
-            peak_pair=split_peak_pair,
+    peak_backed_recall_indicator = (
+        split_peak_pair is not None
+        and neck is not None
+        and neck.neck_ratio <= 0.80
+    )
+    weak_neck_extension = neck is not None and neck.neck_ratio <= 0.60
+    weak_indicator_count = sum(
+        (
+            metrics.aspect_ratio > float(params["max_single_dot_aspect_ratio"]),
+            metrics.solidity <= float(params["max_suspicious_solidity"]),
+            metrics.circularity <= float(params["max_suspicious_circularity"]),
+            metrics.deep_defect_count >= 1,
+            metrics.max_defect_depth_px >= max(float(params["min_defect_depth_px"]), 0.5),
+            shape_suspicious and split_peak_pair is None,
         )
+    )
+    strong_indicator_count = sum(
+        (
+            peak_backed_recall_indicator,
+            asymmetric_candidate is not None,
+            strong_neck_indicator,
+        )
+    )
+    recall_first_triggered = strong_indicator_count >= 1 or (
+        weak_indicator_count >= 2 and (weak_neck_extension or asymmetric_candidate is not None)
+    )
 
     if (
-        split_mode == "aggressive"
-        and (
-            aggressive_peak_backed_geometry_evidence
-            or aggressive_peakless_geometry_evidence
-        )
+        split_peak_pair is None
+        and asymmetric_candidate is None
+        and metrics.aspect_ratio >= 2.0
+        and metrics.solidity >= 0.94
+        and not strong_neck_indicator
     ):
+        if debug:
+            logger.debug(
+                "Green neck split rejected: smooth convex contour lacks peak-backed or neck-backed merge evidence"
+            )
+        return [contour]
+
+    if not recall_first_triggered:
+        if debug:
+            logger.debug("Green neck split rejected: no aggressive evidence bundle")
+        return [contour]
+
+    if neck is not None:
+        split_labels = split_contour_with_watershed(
+            metrics.mask,
+            gfp_image,
+            split_peak_pair,
+            params,
+            neck_candidate=neck,
+        )
+        child_contours = validate_split_contours(
+            metrics.mask,
+            split_labels,
+            gfp_image,
+            params,
+            peak_pair=split_peak_pair,
+            neck_candidate=neck,
+            require_child_peak_ratio=split_peak_pair is not None,
+        )
+        if len(child_contours) == 2:
+            return _finalize_accepted_split_children(
+                child_contours,
+                tightening_gray,
+                params,
+                split_mode,
+                peak_pair=split_peak_pair,
+            )
+
+    if neck is not None:
+        chord_labels = _split_contour_with_neck_chord(metrics.mask, neck, params)
+        child_contours = validate_split_contours(
+            metrics.mask,
+            chord_labels,
+            gfp_image,
+            params,
+            peak_pair=None,
+            neck_candidate=neck,
+        )
+        if len(child_contours) == 2:
+            return _finalize_accepted_split_children(
+                child_contours,
+                tightening_gray,
+                params,
+                split_mode,
+                peak_pair=split_peak_pair,
+            )
+
         geometry_labels = split_contour_with_geometry_first_watershed(
             metrics.mask,
             gfp_image,
@@ -1743,8 +2151,21 @@ def split_necked_gfp_contour_if_needed(
     if len(child_contours) == 2:
         return child_contours
 
+    child_contours = _try_deterministic_aggressive_split(
+        metrics,
+        gfp_image,
+        params,
+        split_peak_pair=split_peak_pair,
+        neck_candidate=neck,
+        asymmetric_candidate=asymmetric_candidate,
+        tightening_image=tightening_gray,
+        split_mode=split_mode,
+    )
+    if len(child_contours) == 2:
+        return child_contours
+
     if debug:
-        logger.debug("Green neck split rejected: candidate split failed validation")
+        logger.debug("Green neck split rejected: recall-first routes failed validation")
     return [contour]
 
 
@@ -1788,7 +2209,7 @@ def _postprocess_and_filter_aggressive_green_contours(
     gfp_image: np.ndarray,
     config: dict | str | None = None,
 ) -> list[np.ndarray]:
-    """Preserve aggressive splits atomically through the legacy contour filter."""
+    """Preserve accepted split pairs atomically through the legacy contour filter."""
 
     processed: list[np.ndarray] = []
     for contour in contours or []:
@@ -2070,7 +2491,7 @@ def find_contours(
                 gray_green_no_bg if gray_green_no_bg is not None else gray_green
             ),
         }
-        if green_dot_split_enabled and green_contour_filter_enabled and green_dot_split_mode == "aggressive":
+        if green_dot_split_enabled and green_contour_filter_enabled:
             contours_green = _postprocess_and_filter_aggressive_green_contours(
                 contours_green,
                 gray_green,

--- a/cytocv/core/contour_processing/contour_operations.py
+++ b/cytocv/core/contour_processing/contour_operations.py
@@ -1519,11 +1519,14 @@ def split_necked_gfp_contour_if_needed(
         and split_peak_pair is None
         and metrics.aspect_ratio >= 2.0
         and metrics.solidity >= 0.94
-        and neck.neck_ratio >= 0.68
+        and (
+            metrics.max_defect_depth_px < 1.0
+            or neck.neck_ratio > 0.80
+        )
     ):
         if debug:
             logger.debug(
-                "Green neck split rejected: smooth convex contour lacks peak-supported split evidence"
+                "Green neck split rejected: smooth convex contour lacks peak-supported or usable neck-supported split evidence"
             )
         return [contour]
     has_peak_evidence = split_peak_pair is not None
@@ -1572,9 +1575,15 @@ def split_necked_gfp_contour_if_needed(
 
     if (
         split_mode == "aggressive"
-        and shape_suspicious
-        and metrics.aspect_ratio >= 1.35
-        and neck.neck_ratio <= 0.60
+        and metrics.max_defect_depth_px >= 1.0
+        and neck.neck_ratio <= 0.80
+        and (
+            split_peak_pair is not None
+            or (
+                shape_suspicious
+                and metrics.aspect_ratio >= 1.35
+            )
+        )
     ):
         geometry_labels = split_contour_with_geometry_first_watershed(
             metrics.mask,

--- a/cytocv/core/services/overlay_rendering.py
+++ b/cytocv/core/services/overlay_rendering.py
@@ -232,6 +232,15 @@ def overlay_render_config_exists(run_uuid: str) -> bool:
     return overlay_render_config_path(run_uuid).exists()
 
 
+def overlay_image_available(run_uuid: str, cell_id: int, channel: str) -> bool:
+    normalized_channel = normalize_overlay_channel(channel)
+    if overlay_render_config_exists(run_uuid):
+        return True
+    if overlay_cache_image_path(run_uuid, cell_id, normalized_channel).exists():
+        return True
+    return find_legacy_debug_image_path(run_uuid, cell_id, normalized_channel) is not None
+
+
 def normalize_overlay_channel(channel: str) -> str:
     normalized_role = normalize_channel_role(channel)
     if normalized_role in {CHANNEL_ROLE_RED, CHANNEL_ROLE_GREEN, CHANNEL_ROLE_BLUE}:
@@ -607,6 +616,9 @@ def ensure_overlay_cache_image(
     render_config: dict[str, object] | None = None,
 ) -> Path:
     normalized_channel = normalize_overlay_channel(channel)
+    cache_path = overlay_cache_image_path(run_uuid, cell_id, normalized_channel)
+    if cache_path.exists():
+        return cache_path
     cache_paths = ensure_overlay_cache_images_for_cell(
         run_uuid,
         cell_id,

--- a/cytocv/core/tests/test_accounts_preferences.py
+++ b/cytocv/core/tests/test_accounts_preferences.py
@@ -49,7 +49,7 @@ class PreferenceNormalizationTests(TestCase):
         self.assertEqual(defaults["puncta_line_mode"], "red_puncta")
         self.assertEqual(defaults["nuclear_cell_pair_mode"], "green_nucleus")
         self.assertTrue(defaults["green_dot_split_enabled"])
-        self.assertEqual(defaults["green_dot_split_mode"], "aggressive")
+        self.assertEqual(defaults["green_dot_split_mode"], "balanced")
         self.assertTrue(defaults["use_metadata_scale"])
         self.assertEqual(defaults["spatial_stats_unit"], "px")
         self.assertTrue(normalized["show_saved_file_channels"])
@@ -2002,7 +2002,7 @@ class ChannelVisibilityPreferenceTests(TestCase):
         self.assertEqual(defaults["puncta_line_mode"], "red_puncta")
         self.assertEqual(defaults["nuclear_cell_pair_mode"], "green_nucleus")
         self.assertTrue(defaults["green_dot_split_enabled"])
-        self.assertEqual(defaults["green_dot_split_mode"], "aggressive")
+        self.assertEqual(defaults["green_dot_split_mode"], "balanced")
 
     def test_plugin_settings_form_persists_measurement_defaults(self):
         response = self.client.post(

--- a/cytocv/core/tests/test_accounts_preferences.py
+++ b/cytocv/core/tests/test_accounts_preferences.py
@@ -56,6 +56,7 @@ class PreferenceNormalizationTests(TestCase):
         self.assertTrue(normalized["show_saved_file_scales"])
         self.assertTrue(normalized["sidebar_starts_open"])
         self.assertEqual(normalized["sidebar_spatial_stats_unit"], "px")
+        self.assertEqual(normalized["main_image_channel"], "")
 
     def test_normalize_preferences_filters_invalid_values(self):
         normalized = normalize_preferences_payload(
@@ -80,6 +81,7 @@ class PreferenceNormalizationTests(TestCase):
                 },
                 "auto_save_experiments": "off",
                 "show_saved_file_scales": "off",
+                "main_image_channel": "invalid",
             }
         )
 
@@ -101,6 +103,7 @@ class PreferenceNormalizationTests(TestCase):
         self.assertTrue(normalized["show_saved_file_channels"])
         self.assertFalse(normalized["show_saved_file_scales"])
         self.assertEqual(normalized["sidebar_spatial_stats_unit"], "px")
+        self.assertEqual(normalized["main_image_channel"], "")
 
     def test_normalize_preferences_migrates_legacy_green_split_default(self):
         normalized = normalize_preferences_payload(
@@ -124,6 +127,14 @@ class PreferenceNormalizationTests(TestCase):
 
         self.assertEqual(normalized["experiment_defaults"]["spatial_stats_unit"], "um")
         self.assertEqual(normalized["sidebar_spatial_stats_unit"], "um")
+
+    def test_main_image_channel_accepts_supported_slug(self):
+        normalized = normalize_preferences_payload({"main_image_channel": "green"})
+        self.assertEqual(normalized["main_image_channel"], "green")
+
+    def test_main_image_channel_drops_invalid_value(self):
+        normalized = normalize_preferences_payload({"main_image_channel": "purple"})
+        self.assertEqual(normalized["main_image_channel"], "")
 
 
 class AccountAreaAccessTests(TestCase):
@@ -699,6 +710,42 @@ class DisplayManualSaveTests(TestCase):
         self.assertContains(response, 'Green In Green Raw Sums')
         self.assertContains(response, 'Raw Green-channel intensity summed inside each ranked Green contour slot')
         self.assertNotContains(response, 'Intensity + Green Output')
+
+    def test_dashboard_template_exposes_preferred_main_image_channel(self):
+        self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="dashboard_preferred_main_channel",
+        )
+        preferences = get_user_preferences(self.user)
+        preferences["main_image_channel"] = "green"
+        update_user_preferences(self.user, preferences)
+
+        response = self.client.get(reverse("dashboard"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'const initialPreferredMainImageChannel = "green";',
+            html=False,
+        )
+
+    def test_display_template_exposes_preferred_main_image_channel(self):
+        saved_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="display_preferred_main_channel",
+        )
+        preferences = get_user_preferences(self.user)
+        preferences["main_image_channel"] = "green"
+        update_user_preferences(self.user, preferences)
+
+        response = self.client.get(reverse("display", args=[saved_uuid]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'const initialPreferredMainImageChannel = "green";',
+            html=False,
+        )
 
     def test_preprocess_template_renders_glass_layout_and_existing_hooks(self):
         preprocess_uuid = self._create_preprocess_file(filename="preprocess_glass_layout")
@@ -1632,6 +1679,7 @@ class ChannelVisibilityPreferenceTests(TestCase):
         preferences["show_saved_file_scales"] = False
         preferences["sidebar_starts_open"] = False
         preferences["sidebar_spatial_stats_unit"] = "um"
+        preferences["main_image_channel"] = "green"
         preferences["experiment_defaults"]["spatial_stats_unit"] = "um"
         update_user_preferences(self.user, preferences)
 
@@ -1649,6 +1697,7 @@ class ChannelVisibilityPreferenceTests(TestCase):
         self.assertFalse(updated["show_saved_file_scales"])
         self.assertFalse(updated["sidebar_starts_open"])
         self.assertEqual(updated["sidebar_spatial_stats_unit"], "um")
+        self.assertEqual(updated["main_image_channel"], "green")
         self.assertEqual(updated["experiment_defaults"]["spatial_stats_unit"], "um")
 
     def test_experiment_workflow_defaults_endpoint_rejects_invalid_payload(self):
@@ -1744,6 +1793,14 @@ class ChannelVisibilityPreferenceTests(TestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_dashboard_main_image_channel_requires_valid_channel(self):
+        response = self.client.post(
+            reverse("dashboard_channel_visibility"),
+            data=json.dumps({"main_image_channel": "purple"}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_dashboard_channel_visibility_persists_user_preference(self):
         response = self.client.post(
             reverse("dashboard_channel_visibility"),
@@ -1781,6 +1838,17 @@ class ChannelVisibilityPreferenceTests(TestCase):
         updated = get_user_preferences(self.user)
         self.assertEqual(updated["sidebar_spatial_stats_unit"], "um")
         self.assertEqual(updated["experiment_defaults"]["spatial_stats_unit"], "px")
+
+    def test_dashboard_main_image_channel_persists_user_preference(self):
+        response = self.client.post(
+            reverse("dashboard_channel_visibility"),
+            data=json.dumps({"main_image_channel": "green"}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["main_image_channel"], "green")
+        self.user.refresh_from_db()
+        self.assertEqual(get_user_preferences(self.user)["main_image_channel"], "green")
 
     def test_behavior_form_persists_channel_visibility_toggle(self):
         response = self.client.post(

--- a/cytocv/core/tests/test_core_app.py
+++ b/cytocv/core/tests/test_core_app.py
@@ -156,6 +156,19 @@ class RouteSurfaceRefactorTests(TestCase):
             ).save(output_dir / f"{image_stem}_frame_{frame_index}.png")
 
     @staticmethod
+    def _write_overlay_cache_image(
+        uuid_value: str,
+        cell_id: int,
+        channel: str,
+        *,
+        color: tuple[int, int, int],
+    ) -> Path:
+        path = overlay_cache_image_path(uuid_value, cell_id, channel)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        Image.fromarray(np.full((6, 6, 3), color, dtype=np.uint8)).save(path)
+        return path
+
+    @staticmethod
     def _write_overlay_config(uuid_value: str, image_stem: str) -> dict[str, object]:
         render_config = build_overlay_render_config(
             image_stem=image_stem,
@@ -572,6 +585,133 @@ class RouteSurfaceRefactorTests(TestCase):
             reverse("cell_overlay_image", args=[uuid_value, 1, "green"]),
             html=False,
         )
+
+    def test_display_uses_cached_overlay_endpoint_without_render_config(self):
+        uuid_value = str(uuid4())
+        with temporary_media_root() as media_root:
+            self._write_channel_config(media_root, uuid_value)
+            self._create_uploaded_image(uuid_value, name="display-cached-overlay")
+            segmented = self._create_segmented_image(
+                uuid_value,
+                name="display-cached-overlay",
+            )
+            segmented.NumCells = 1
+            segmented.save(update_fields=["NumCells"])
+            self._write_segmented_cell_assets(
+                media_root,
+                uuid_value,
+                "display-cached-overlay",
+            )
+            self._create_cell_stats(segmented, "display-cached-overlay")
+            self._write_overlay_cache_image(
+                uuid_value,
+                1,
+                "green",
+                color=(30, 220, 30),
+            )
+
+            response = self.client.get(reverse("display", args=[uuid_value]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            reverse("cell_overlay_image", args=[uuid_value, 1, "green"]),
+            html=False,
+        )
+        self.assertContains(
+            response,
+            f"/media/{uuid_value}/segmented/display-cached-overlay-{DEFAULT_CHANNEL_CONFIG['channel_red']}-1.png",
+            html=False,
+        )
+        self.assertContains(
+            response,
+            f"/media/{uuid_value}/segmented/display-cached-overlay-{DEFAULT_CHANNEL_CONFIG['channel_blue']}-1.png",
+            html=False,
+        )
+        self.assertNotContains(
+            response,
+            reverse("cell_overlay_image", args=[uuid_value, 1, "red"]),
+            html=False,
+        )
+        self.assertNotContains(
+            response,
+            reverse("cell_overlay_image", args=[uuid_value, 1, "blue"]),
+            html=False,
+        )
+
+    def test_dashboard_uses_cached_overlay_endpoint_without_render_config(self):
+        uuid_value = str(uuid4())
+        with temporary_media_root() as media_root:
+            self._write_channel_config(media_root, uuid_value)
+            self._create_uploaded_image(uuid_value, name="dashboard-cached-overlay")
+            segmented = self._create_segmented_image(
+                uuid_value,
+                name="dashboard-cached-overlay",
+            )
+            segmented.user = self.user
+            segmented.NumCells = 1
+            segmented.save(update_fields=["user", "NumCells"])
+            self._write_segmented_cell_assets(
+                media_root,
+                uuid_value,
+                "dashboard-cached-overlay",
+            )
+            self._create_cell_stats(segmented, "dashboard-cached-overlay")
+            self._write_overlay_cache_image(
+                uuid_value,
+                1,
+                "green",
+                color=(30, 220, 30),
+            )
+
+            response = self.client.get(reverse("dashboard"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            reverse("cell_overlay_image", args=[uuid_value, 1, "green"]),
+            html=False,
+        )
+        self.assertNotContains(
+            response,
+            reverse("cell_overlay_image", args=[uuid_value, 1, "red"]),
+            html=False,
+        )
+        self.assertNotContains(
+            response,
+            reverse("cell_overlay_image", args=[uuid_value, 1, "blue"]),
+            html=False,
+        )
+
+    def test_overlay_endpoint_serves_cached_channel_without_render_config(self):
+        uuid_value = str(uuid4())
+        expected_path: Path | None = None
+        with temporary_media_root() as media_root:
+            self._write_channel_config(media_root, uuid_value)
+            self._create_uploaded_image(uuid_value, name="overlay-cache-only")
+            segmented = self._create_segmented_image(uuid_value, name="overlay-cache-only")
+            segmented.NumCells = 1
+            segmented.save(update_fields=["NumCells"])
+            self._write_segmented_cell_assets(media_root, uuid_value, "overlay-cache-only")
+            self._create_cell_stats(segmented, "overlay-cache-only")
+            expected_path = self._write_overlay_cache_image(
+                uuid_value,
+                1,
+                "green",
+                color=(10, 180, 10),
+            )
+
+            response = self.client.get(
+                reverse("cell_overlay_image", args=[uuid_value, 1, "green"])
+            )
+            self.assertEqual(response.status_code, 200)
+            payload = b"".join(response.streaming_content)
+
+            with Image.open(expected_path) as expected_image:
+                expected = np.array(expected_image)
+
+        rendered = np.array(Image.open(BytesIO(payload)))
+        self.assertTrue(np.array_equal(rendered, expected))
 
     def test_overlay_endpoint_renders_pixel_exact_png_from_cached_crops(self):
         uuid_value = str(uuid4())

--- a/cytocv/core/tests/test_green_dot_split.py
+++ b/cytocv/core/tests/test_green_dot_split.py
@@ -274,6 +274,18 @@ def _cell_8_like_green_image() -> np.ndarray:
     )
 
 
+def _cell_8_like_single_peak_image(shape=(16, 19)) -> np.ndarray:
+    y_grid, x_grid = np.mgrid[0 : shape[0], 0 : shape[1]]
+    image = 210.0 * np.exp(
+        -(
+            ((x_grid - 7) ** 2 + (y_grid - 8) ** 2)
+            / (2.0 * 2.1 * 2.1)
+        )
+    )
+    image += 14.0
+    return np.clip(image, 0, 255).astype(np.uint8)
+
+
 def _cell_8_like_merged_contour() -> np.ndarray:
     return np.array(
         [
@@ -456,7 +468,7 @@ class GreenDotSplitTests(SimpleTestCase):
             )
             self.assertEqual(_contour_list_count(split), 2)
 
-    def test_aggressive_tightening_shrinks_split_children_while_balanced_keeps_wider_support(self):
+    def test_balanced_and_aggressive_tighten_broad_support_split_children(self):
         support_image, tightening_image = _broad_halo_tightening_images()
 
         balanced = _split_green_contours_from_image(
@@ -472,9 +484,12 @@ class GreenDotSplitTests(SimpleTestCase):
 
         self.assertEqual(_contour_list_count(balanced, min_area=4.0), 2)
         self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
-        self.assertLess(_total_contour_area(aggressive), _total_contour_area(balanced))
+        self.assertLessEqual(
+            abs(_total_contour_area(aggressive) - _total_contour_area(balanced)),
+            1.0,
+        )
 
-    def test_geometry_first_aggressive_splits_necked_single_peak_shape_that_balanced_keeps_merged(self):
+    def test_balanced_and_aggressive_split_geometry_first_single_peak_neck_shape(self):
         mask = _geometry_first_neck_mask()
         image = _geometry_first_single_peak_image(mask)
         contours = _contours_from_mask(mask)
@@ -490,10 +505,10 @@ class GreenDotSplitTests(SimpleTestCase):
             {"mode": "aggressive"},
         )
 
-        self.assertEqual(_contour_list_count(balanced), 1)
+        self.assertEqual(_contour_list_count(balanced), 2)
         self.assertEqual(_contour_list_count(aggressive), 2)
 
-    def test_wide_neck_single_peak_shape_splits_in_aggressive_but_balanced_keeps_merged(self):
+    def test_balanced_and_aggressive_split_wide_neck_single_peak_shape(self):
         mask = _wide_neck_guard_mask()
         image = _wide_neck_guard_single_peak_image(mask)
         contours = _contours_from_mask(mask)
@@ -509,10 +524,10 @@ class GreenDotSplitTests(SimpleTestCase):
             {"mode": "aggressive"},
         )
 
-        self.assertEqual(_contour_list_count(balanced), 1)
+        self.assertEqual(_contour_list_count(balanced), 2)
         self.assertEqual(_contour_list_count(aggressive), 2)
 
-    def test_moderate_aspect_two_peak_necked_contour_splits_in_aggressive_but_balanced_keeps_merged(self):
+    def test_balanced_and_aggressive_split_moderate_aspect_two_peak_necked_contour(self):
         mask = _moderate_aspect_two_peak_neck_mask()
         image = _moderate_aspect_two_peak_neck_image()
         contours = _contours_from_mask(mask)
@@ -528,10 +543,10 @@ class GreenDotSplitTests(SimpleTestCase):
             {"mode": "aggressive"},
         )
 
-        self.assertEqual(_contour_list_count(balanced), 1)
+        self.assertEqual(_contour_list_count(balanced), 2)
         self.assertEqual(_contour_list_count(aggressive), 2)
 
-    def test_cell_8_like_peak_backed_necked_contour_splits_in_aggressive_but_balanced_keeps_merged(self):
+    def test_balanced_and_aggressive_split_cell_8_like_peak_backed_necked_contour(self):
         image = _cell_8_like_green_image()
         contour = _cell_8_like_merged_contour()
         balanced = postprocess_gfp_contours_for_neck_splits(
@@ -545,7 +560,24 @@ class GreenDotSplitTests(SimpleTestCase):
             {"mode": "aggressive"},
         )
 
-        self.assertEqual(_contour_list_count(balanced, min_area=4.0), 1)
+        self.assertEqual(_contour_list_count(balanced, min_area=4.0), 2)
+        self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
+
+    def test_balanced_and_aggressive_split_cell_8_like_single_peak_neck_shape(self):
+        image = _cell_8_like_single_peak_image()
+        contour = _cell_8_like_merged_contour()
+        balanced = postprocess_gfp_contours_for_neck_splits(
+            [contour],
+            image,
+            {"mode": "balanced"},
+        )
+        aggressive = postprocess_gfp_contours_for_neck_splits(
+            [contour],
+            image,
+            {"mode": "aggressive"},
+        )
+
+        self.assertEqual(_contour_list_count(balanced, min_area=4.0), 2)
         self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
 
     def test_balanced_and_aggressive_fallback_split_asymmetric_two_gaussian_pair(self):
@@ -896,13 +928,44 @@ class GreenDotSplitTests(SimpleTestCase):
         )
         self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
 
-    def test_aggressive_find_contours_splits_tiny_tip_connected_merge_that_balanced_keeps_merged(self):
+    def test_aggressive_deterministic_fallback_splits_cell_8_like_single_peak_when_other_routes_fail(self):
+        image = _cell_8_like_single_peak_image()
+        contour = _cell_8_like_merged_contour()
+
+        with patch(
+            "core.contour_processing.contour_operations.split_contour_with_watershed",
+            return_value=None,
+        ), patch(
+            "core.contour_processing.contour_operations._split_contour_with_neck_chord",
+            return_value=None,
+        ), patch(
+            "core.contour_processing.contour_operations.split_contour_with_geometry_first_watershed",
+            return_value=None,
+        ), patch(
+            "core.contour_processing.contour_operations.split_asymmetric_gfp_contour_if_needed",
+            return_value=[],
+        ):
+            balanced = postprocess_gfp_contours_for_neck_splits(
+                [contour],
+                image,
+                {"mode": "balanced"},
+            )
+            aggressive = postprocess_gfp_contours_for_neck_splits(
+                [contour],
+                image,
+                {"mode": "aggressive"},
+            )
+
+        self.assertEqual(_contour_list_count(balanced, min_area=4.0), 1)
+        self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
+
+    def test_balanced_and_aggressive_find_contours_split_tiny_tip_connected_merge(self):
         image = _tip_connected_pair_image()
 
         balanced = _split_green_contours_from_image(image, "balanced")
         aggressive = _split_green_contours_from_image(image, "aggressive")
 
-        self.assertEqual(_contour_list_count(balanced, min_area=4.0), 1)
+        self.assertEqual(_contour_list_count(balanced, min_area=4.0), 2)
         self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
 
     def test_find_contours_passes_identical_pre_postprocess_green_contours_to_balanced_and_aggressive(self):
@@ -933,26 +996,26 @@ class GreenDotSplitTests(SimpleTestCase):
             self.assertTrue(np.array_equal(expected_contour, balanced_contour))
             self.assertTrue(np.array_equal(expected_contour, aggressive_contour))
 
-    def test_aggressive_filtered_find_contours_never_collapses_accepted_split_to_one_child(self):
+    def test_split_filtered_find_contours_never_collapses_accepted_split_to_one_child(self):
         image = _tip_connected_pair_image()
-
-        aggressive = _split_green_contours_from_image(image, "aggressive")
-        aggressive_filtered = _split_green_contours_from_image(
-            image,
-            "aggressive",
-            green_contour_filter_enabled=True,
-        )
         original = _green_pre_postprocess_contours_from_image(image)
-
-        self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
         self.assertEqual(len(original), 1)
-        filtered_count = _contour_list_count(aggressive_filtered, min_area=4.0)
-        self.assertIn(filtered_count, {1, 2})
-        if filtered_count == 1:
-            self.assertEqual(
-                cv2.contourArea(aggressive_filtered[0]),
-                cv2.contourArea(original[0]),
+        for split_mode in ("balanced", "aggressive"):
+            split_contours = _split_green_contours_from_image(image, split_mode)
+            filtered = _split_green_contours_from_image(
+                image,
+                split_mode,
+                green_contour_filter_enabled=True,
             )
+
+            self.assertEqual(_contour_list_count(split_contours, min_area=4.0), 2)
+            filtered_count = _contour_list_count(filtered, min_area=4.0)
+            self.assertIn(filtered_count, {1, 2})
+            if filtered_count == 1:
+                self.assertEqual(
+                    cv2.contourArea(filtered[0]),
+                    cv2.contourArea(original[0]),
+                )
 
     def test_aggressive_tightening_keeps_compact_binary_split_children_nearly_unchanged(self):
         mask = np.zeros((96, 128), dtype=np.uint8)
@@ -981,22 +1044,22 @@ class GreenDotSplitTests(SimpleTestCase):
             1.0,
         )
 
-    def test_aggressive_filtered_find_contours_preserves_clean_two_child_split(self):
+    def test_split_filtered_find_contours_preserves_clean_two_child_split(self):
         image = _gaussian_pair_image(bridge_intensity=90.0)
+        for split_mode in ("balanced", "aggressive"):
+            split_contours = _split_green_contours_from_image(image, split_mode)
+            filtered = _split_green_contours_from_image(
+                image,
+                split_mode,
+                green_contour_filter_enabled=True,
+            )
 
-        aggressive = _split_green_contours_from_image(image, "aggressive")
-        aggressive_filtered = _split_green_contours_from_image(
-            image,
-            "aggressive",
-            green_contour_filter_enabled=True,
-        )
-
-        self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
-        self.assertEqual(_contour_list_count(aggressive_filtered, min_area=4.0), 2)
-        self.assertEqual(
-            sorted(cv2.contourArea(contour) for contour in aggressive),
-            sorted(cv2.contourArea(contour) for contour in aggressive_filtered),
-        )
+            self.assertEqual(_contour_list_count(split_contours, min_area=4.0), 2)
+            self.assertEqual(_contour_list_count(filtered, min_area=4.0), 2)
+            self.assertEqual(
+                sorted(cv2.contourArea(contour) for contour in split_contours),
+                sorted(cv2.contourArea(contour) for contour in filtered),
+            )
 
     def test_real_failure_like_geometry_keeps_two_bright_children_and_lower_blob(self):
         image = _real_failure_like_green_image()
@@ -1010,7 +1073,7 @@ class GreenDotSplitTests(SimpleTestCase):
         )
 
         self.assertEqual(len(preprocessed), 2)
-        self.assertEqual(len(aggressive), 3)
+        self.assertGreaterEqual(len(aggressive), 3)
         self.assertEqual(len(aggressive_filtered), 3)
 
         centroids = [_contour_centroid(contour) for contour in aggressive_filtered]

--- a/cytocv/core/tests/test_green_dot_split.py
+++ b/cytocv/core/tests/test_green_dot_split.py
@@ -13,6 +13,7 @@ from core.contour_processing.contour_operations import (
     _find_distance_peaks_in_contour,
     _filter_green_contours_with_image,
     _markers_from_neck,
+    _shape_is_suspicious,
     _split_merged_green_contours,
     _split_params,
     _split_contour_with_neck_chord,
@@ -247,6 +248,49 @@ def _broad_halo_tightening_images() -> tuple[np.ndarray, np.ndarray]:
         amplitude_b=236.0,
     )
     return support, tightening
+
+
+def _cell_8_like_green_image() -> np.ndarray:
+    return np.array(
+        [
+            [9, 9, 10, 10, 11, 11, 10, 9, 8, 7, 7, 7, 7, 6, 6, 6, 6, 6, 6],
+            [9, 10, 10, 11, 12, 12, 10, 9, 8, 8, 7, 7, 6, 6, 7, 7, 7, 7, 7],
+            [8, 9, 10, 11, 12, 12, 11, 10, 8, 8, 7, 7, 7, 7, 7, 7, 7, 7, 7],
+            [7, 8, 9, 10, 11, 12, 12, 11, 10, 9, 9, 8, 8, 8, 8, 8, 8, 7, 7],
+            [7, 7, 8, 9, 10, 12, 13, 13, 12, 12, 12, 14, 13, 12, 10, 10, 8, 8, 7],
+            [7, 8, 8, 9, 10, 12, 13, 15, 16, 16, 20, 24, 24, 18, 13, 11, 9, 8, 7],
+            [8, 9, 9, 9, 11, 15, 20, 22, 22, 23, 26, 32, 33, 25, 16, 11, 9, 8, 7],
+            [8, 9, 9, 10, 13, 22, 34, 38, 34, 28, 27, 30, 32, 26, 17, 11, 9, 7, 7],
+            [7, 8, 9, 11, 15, 27, 44, 52, 44, 31, 23, 21, 22, 20, 14, 9, 8, 7, 7],
+            [7, 8, 9, 10, 14, 23, 36, 46, 42, 30, 19, 16, 15, 13, 10, 8, 7, 7, 6],
+            [8, 9, 9, 10, 12, 15, 20, 27, 28, 22, 16, 13, 11, 9, 8, 7, 7, 7, 6],
+            [9, 10, 10, 10, 10, 10, 11, 13, 15, 14, 12, 11, 10, 8, 7, 7, 7, 7, 6],
+            [9, 11, 11, 10, 10, 9, 9, 10, 10, 10, 10, 10, 9, 8, 7, 7, 7, 7, 6],
+            [8, 10, 10, 10, 10, 10, 10, 10, 10, 10, 9, 9, 8, 8, 8, 7, 7, 6, 6],
+            [7, 8, 8, 9, 9, 10, 10, 10, 10, 10, 9, 8, 8, 8, 8, 7, 6, 6, 6],
+            [6, 6, 7, 8, 9, 9, 10, 10, 9, 9, 8, 8, 8, 8, 8, 7, 6, 6, 5],
+        ],
+        dtype=np.uint8,
+    )
+
+
+def _cell_8_like_merged_contour() -> np.ndarray:
+    return np.array(
+        [
+            [[10, 5]],
+            [[9, 6]],
+            [[6, 6]],
+            [[5, 7]],
+            [[5, 9]],
+            [[6, 10]],
+            [[9, 10]],
+            [[11, 8]],
+            [[13, 8]],
+            [[13, 6]],
+            [[12, 5]],
+        ],
+        dtype=np.int32,
+    )
 
 
 def _moderate_aspect_two_peak_tightening_image() -> np.ndarray:
@@ -486,6 +530,23 @@ class GreenDotSplitTests(SimpleTestCase):
 
         self.assertEqual(_contour_list_count(balanced), 1)
         self.assertEqual(_contour_list_count(aggressive), 2)
+
+    def test_cell_8_like_peak_backed_necked_contour_splits_in_aggressive_but_balanced_keeps_merged(self):
+        image = _cell_8_like_green_image()
+        contour = _cell_8_like_merged_contour()
+        balanced = postprocess_gfp_contours_for_neck_splits(
+            [contour],
+            image,
+            {"mode": "balanced"},
+        )
+        aggressive = postprocess_gfp_contours_for_neck_splits(
+            [contour],
+            image,
+            {"mode": "aggressive"},
+        )
+
+        self.assertEqual(_contour_list_count(balanced, min_area=4.0), 1)
+        self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
 
     def test_balanced_and_aggressive_fallback_split_asymmetric_two_gaussian_pair(self):
         image = _gaussian_pair_image(
@@ -732,6 +793,108 @@ class GreenDotSplitTests(SimpleTestCase):
             _total_contour_area(tightened_aggressive),
             _total_contour_area(geometry_children),
         )
+
+    def test_cell_8_like_fixture_reaches_geometry_split_below_old_defect_depth_gate(self):
+        image = _cell_8_like_green_image()
+        contour = _cell_8_like_merged_contour()
+        params = _split_params("aggressive")
+        metrics = compute_contour_shape_metrics(
+            contour,
+            image.shape,
+            min_defect_depth_px=params["min_defect_depth_px"],
+        )
+
+        self.assertIsNotNone(metrics)
+        self.assertTrue(_shape_is_suspicious(metrics, params))
+        self.assertGreaterEqual(metrics.deep_defect_count, 1)
+        self.assertLess(metrics.max_defect_depth_px, 1.0)
+
+        neck_candidates = find_convexity_defect_neck_candidates(
+            metrics.contour,
+            metrics.mask,
+            params,
+        )
+        self.assertTrue(neck_candidates)
+        best_neck = neck_candidates[0]
+        self.assertLessEqual(best_neck.neck_ratio, 0.80)
+
+        intensity_peaks = find_intensity_peaks_in_contour(metrics.mask, image, params)
+        distance_peaks, distance_image = _find_distance_peaks_in_contour(
+            metrics.mask,
+            params,
+        )
+        intensity_pair = _best_peak_pair(
+            intensity_peaks,
+            cv2.GaussianBlur(image.astype(np.float32), (3, 3), 0),
+            params,
+            max_valley_ratio_key="max_intensity_valley_ratio",
+        )
+        distance_pair = _best_peak_pair(
+            distance_peaks,
+            distance_image,
+            params,
+            max_valley_ratio_key="max_distance_valley_ratio",
+        )
+        split_peak_pair = _choose_split_peak_pair(intensity_pair, distance_pair, params)
+
+        self.assertIsNotNone(split_peak_pair)
+
+        split_labels = split_contour_with_watershed(
+            metrics.mask,
+            image,
+            split_peak_pair,
+            params,
+            neck_candidate=best_neck,
+        )
+        self.assertEqual(
+            len(
+                validate_split_contours(
+                    metrics.mask,
+                    split_labels,
+                    image,
+                    params,
+                    peak_pair=split_peak_pair,
+                    neck_candidate=best_neck,
+                )
+            ),
+            0,
+        )
+
+        chord_labels = _split_contour_with_neck_chord(metrics.mask, best_neck, params)
+        self.assertEqual(
+            len(
+                validate_split_contours(
+                    metrics.mask,
+                    chord_labels,
+                    image,
+                    params,
+                    peak_pair=None,
+                    neck_candidate=best_neck,
+                )
+            ),
+            0,
+        )
+
+        geometry_labels = split_contour_with_geometry_first_watershed(
+            metrics.mask,
+            image,
+            best_neck,
+            params,
+        )
+        geometry_children = validate_geometry_first_split(
+            metrics.mask,
+            geometry_labels,
+            params,
+            best_neck,
+        )
+        self.assertEqual(len(geometry_children), 2)
+
+        aggressive = postprocess_gfp_contours_for_neck_splits(
+            [contour],
+            image,
+            {"mode": "aggressive"},
+        )
+        self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
 
     def test_aggressive_find_contours_splits_tiny_tip_connected_merge_that_balanced_keeps_merged(self):
         image = _tip_connected_pair_image()

--- a/cytocv/core/tests/test_green_dot_split.py
+++ b/cytocv/core/tests/test_green_dot_split.py
@@ -8,9 +8,12 @@ from django.test import SimpleTestCase
 from unittest.mock import patch
 
 from core.contour_processing.contour_operations import (
+    _best_peak_pair,
+    _choose_split_peak_pair,
+    _find_distance_peaks_in_contour,
     _filter_green_contours_with_image,
-    _split_merged_green_contours,
     _markers_from_neck,
+    _split_merged_green_contours,
     _split_params,
     _split_contour_with_neck_chord,
     compute_contour_shape_metrics,
@@ -18,6 +21,10 @@ from core.contour_processing.contour_operations import (
     find_convexity_defect_neck_candidates,
     find_intensity_peaks_in_contour,
     postprocess_gfp_contours_for_neck_splits,
+    split_contour_with_geometry_first_watershed,
+    split_contour_with_watershed,
+    validate_geometry_first_split,
+    validate_split_contours,
 )
 from core.image_processing import GrayImage
 
@@ -110,6 +117,75 @@ def _geometry_first_single_peak_image(mask: np.ndarray) -> np.ndarray:
     )
     image += 18.0 * (mask > 0)
     return np.clip(image, 0, 255).astype(np.uint8)
+
+
+def _wide_neck_guard_mask(shape=(96, 128)) -> np.ndarray:
+    mask = np.zeros(shape, dtype=np.uint8)
+    cv2.ellipse(mask, (60, 48), (24, 8), 0, 0, 360, 255, -1)
+    cv2.circle(mask, (54, 36), 4, 0, -1)
+    return mask
+
+
+def _wide_neck_guard_single_peak_image(mask: np.ndarray) -> np.ndarray:
+    y_grid, x_grid = np.mgrid[0 : mask.shape[0], 0 : mask.shape[1]]
+    image = 235.0 * np.exp(
+        -(
+            ((x_grid - 48) ** 2 + (y_grid - 48) ** 2)
+            / (2.0 * 3.4 * 3.4)
+        )
+    )
+    image += 22.0 * (mask > 0)
+    return np.clip(image, 0, 255).astype(np.uint8)
+
+
+def _moderate_aspect_two_peak_neck_mask() -> np.ndarray:
+    return np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+
+
+def _moderate_aspect_two_peak_neck_image() -> np.ndarray:
+    return np.array(
+        [
+            [9, 10, 10, 10, 10, 10, 10, 10, 11, 12, 13, 12, 12, 11, 11, 11, 11, 11, 10, 10],
+            [10, 10, 10, 10, 10, 9, 9, 10, 11, 12, 13, 13, 12, 11, 11, 11, 11, 11, 10, 10],
+            [10, 10, 9, 10, 10, 10, 10, 11, 12, 13, 13, 13, 13, 13, 12, 12, 12, 12, 11, 11],
+            [10, 10, 10, 10, 11, 12, 13, 14, 14, 14, 14, 14, 15, 14, 14, 13, 13, 12, 12, 12],
+            [10, 10, 10, 11, 15, 22, 26, 23, 19, 17, 16, 15, 15, 15, 14, 14, 13, 12, 11, 11],
+            [10, 11, 12, 14, 22, 36, 46, 42, 30, 21, 18, 16, 16, 15, 15, 14, 13, 11, 11, 11],
+            [12, 13, 14, 16, 24, 40, 55, 56, 42, 27, 20, 20, 20, 19, 17, 15, 14, 12, 11, 11],
+            [13, 14, 15, 17, 22, 32, 46, 53, 45, 31, 25, 30, 38, 39, 29, 20, 16, 13, 11, 11],
+            [13, 14, 14, 16, 18, 23, 30, 38, 37, 32, 31, 44, 66, 71, 50, 27, 17, 12, 11, 11],
+            [12, 13, 13, 14, 15, 18, 22, 27, 30, 31, 35, 50, 78, 88, 65, 33, 17, 12, 11, 10],
+            [10, 11, 12, 12, 13, 16, 20, 23, 27, 29, 32, 42, 61, 72, 58, 33, 17, 12, 12, 11],
+            [10, 11, 12, 12, 14, 16, 18, 20, 22, 25, 26, 29, 36, 41, 37, 25, 16, 13, 12, 12],
+            [11, 12, 12, 13, 15, 17, 18, 18, 19, 20, 20, 21, 22, 22, 20, 17, 13, 12, 12, 11],
+            [12, 13, 14, 15, 16, 17, 18, 17, 17, 17, 17, 16, 16, 15, 14, 13, 12, 12, 11, 10],
+            [12, 13, 15, 16, 16, 16, 16, 17, 16, 16, 15, 14, 13, 13, 13, 12, 11, 11, 10, 9],
+            [11, 13, 14, 15, 15, 15, 15, 16, 15, 14, 14, 13, 13, 13, 13, 11, 10, 10, 10, 9],
+            [11, 12, 12, 13, 13, 14, 15, 14, 14, 13, 13, 13, 13, 13, 12, 10, 9, 9, 9, 9],
+        ],
+        dtype=np.uint8,
+    )
 
 
 def _tip_connected_pair_image(shape=(72, 96)) -> np.ndarray:
@@ -320,6 +396,44 @@ class GreenDotSplitTests(SimpleTestCase):
         self.assertEqual(_contour_list_count(balanced), 1)
         self.assertEqual(_contour_list_count(aggressive), 2)
 
+    def test_wide_neck_single_peak_shape_splits_in_aggressive_but_balanced_keeps_merged(self):
+        mask = _wide_neck_guard_mask()
+        image = _wide_neck_guard_single_peak_image(mask)
+        contours = _contours_from_mask(mask)
+
+        balanced = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            image,
+            {"mode": "balanced"},
+        )
+        aggressive = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            image,
+            {"mode": "aggressive"},
+        )
+
+        self.assertEqual(_contour_list_count(balanced), 1)
+        self.assertEqual(_contour_list_count(aggressive), 2)
+
+    def test_moderate_aspect_two_peak_necked_contour_splits_in_aggressive_but_balanced_keeps_merged(self):
+        mask = _moderate_aspect_two_peak_neck_mask()
+        image = _moderate_aspect_two_peak_neck_image()
+        contours = _contours_from_mask(mask)
+
+        balanced = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            image,
+            {"mode": "balanced"},
+        )
+        aggressive = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            image,
+            {"mode": "aggressive"},
+        )
+
+        self.assertEqual(_contour_list_count(balanced), 1)
+        self.assertEqual(_contour_list_count(aggressive), 2)
+
     def test_balanced_and_aggressive_fallback_split_asymmetric_two_gaussian_pair(self):
         image = _gaussian_pair_image(
             center_a=(48, 48),
@@ -407,6 +521,150 @@ class GreenDotSplitTests(SimpleTestCase):
         )
 
         self.assertEqual(_contour_list_count(split), 2)
+
+    def test_wide_neck_single_peak_fixture_would_have_hit_old_aggressive_guards_but_now_splits(self):
+        mask = _wide_neck_guard_mask()
+        image = _wide_neck_guard_single_peak_image(mask)
+        contours = _contours_from_mask(mask)
+        contour = max(contours, key=cv2.contourArea)
+        params = _split_params("aggressive")
+        metrics = compute_contour_shape_metrics(
+            contour,
+            mask.shape,
+            min_defect_depth_px=params["min_defect_depth_px"],
+        )
+
+        self.assertIsNotNone(metrics)
+        neck_candidates = find_convexity_defect_neck_candidates(
+            metrics.contour,
+            metrics.mask,
+            params,
+        )
+        self.assertTrue(neck_candidates)
+        best_neck = neck_candidates[0]
+
+        intensity_peaks = find_intensity_peaks_in_contour(metrics.mask, image, params)
+        distance_peaks, distance_image = _find_distance_peaks_in_contour(
+            metrics.mask,
+            params,
+        )
+        intensity_pair = _best_peak_pair(
+            intensity_peaks,
+            image.astype(np.float32),
+            params,
+            max_valley_ratio_key="max_intensity_valley_ratio",
+        )
+        distance_pair = _best_peak_pair(
+            distance_peaks,
+            distance_image,
+            params,
+            max_valley_ratio_key="max_distance_valley_ratio",
+        )
+
+        self.assertGreaterEqual(metrics.aspect_ratio, 2.0)
+        self.assertGreaterEqual(metrics.solidity, 0.94)
+        self.assertGreaterEqual(metrics.max_defect_depth_px, 1.0)
+        self.assertGreater(best_neck.neck_ratio, 0.60)
+        self.assertLessEqual(best_neck.neck_ratio, 0.80)
+        self.assertIsNone(
+            _choose_split_peak_pair(intensity_pair, distance_pair, params)
+        )
+
+        aggressive = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            image,
+            {"mode": "aggressive"},
+        )
+        self.assertEqual(_contour_list_count(aggressive), 2)
+
+    def test_moderate_aspect_two_peak_neck_fixture_reaches_geometry_split_after_peak_split_fails(self):
+        mask = _moderate_aspect_two_peak_neck_mask()
+        image = _moderate_aspect_two_peak_neck_image()
+        contour = max(_contours_from_mask(mask), key=cv2.contourArea)
+        params = _split_params("aggressive")
+        metrics = compute_contour_shape_metrics(
+            contour,
+            mask.shape,
+            min_defect_depth_px=params["min_defect_depth_px"],
+        )
+
+        self.assertIsNotNone(metrics)
+        self.assertGreater(metrics.aspect_ratio, float(params["max_single_dot_aspect_ratio"]))
+        self.assertLess(metrics.aspect_ratio, 1.35)
+        self.assertGreaterEqual(metrics.deep_defect_count, 2)
+        self.assertGreaterEqual(metrics.max_defect_depth_px, 1.0)
+
+        neck_candidates = find_convexity_defect_neck_candidates(
+            metrics.contour,
+            metrics.mask,
+            params,
+        )
+        self.assertTrue(neck_candidates)
+        best_neck = neck_candidates[0]
+        self.assertLessEqual(best_neck.neck_ratio, 0.80)
+
+        intensity_peaks = find_intensity_peaks_in_contour(metrics.mask, image, params)
+        distance_peaks, distance_image = _find_distance_peaks_in_contour(
+            metrics.mask,
+            params,
+        )
+        intensity_pair = _best_peak_pair(
+            intensity_peaks,
+            cv2.GaussianBlur(image.astype(np.float32), (3, 3), 0),
+            params,
+            max_valley_ratio_key="max_intensity_valley_ratio",
+        )
+        distance_pair = _best_peak_pair(
+            distance_peaks,
+            distance_image,
+            params,
+            max_valley_ratio_key="max_distance_valley_ratio",
+        )
+        split_peak_pair = _choose_split_peak_pair(intensity_pair, distance_pair, params)
+
+        self.assertIsNotNone(split_peak_pair)
+
+        split_labels = split_contour_with_watershed(
+            metrics.mask,
+            image,
+            split_peak_pair,
+            params,
+            neck_candidate=best_neck,
+        )
+        self.assertEqual(
+            len(
+                validate_split_contours(
+                    metrics.mask,
+                    split_labels,
+                    image,
+                    params,
+                    peak_pair=split_peak_pair,
+                    neck_candidate=best_neck,
+                )
+            ),
+            0,
+        )
+
+        geometry_labels = split_contour_with_geometry_first_watershed(
+            metrics.mask,
+            image,
+            best_neck,
+            params,
+        )
+        geometry_children = validate_geometry_first_split(
+            metrics.mask,
+            geometry_labels,
+            params,
+            best_neck,
+        )
+        self.assertEqual(len(geometry_children), 2)
+
+        aggressive = postprocess_gfp_contours_for_neck_splits(
+            [contour],
+            image,
+            {"mode": "aggressive"},
+        )
+        self.assertEqual(_contour_list_count(aggressive), 2)
 
     def test_aggressive_find_contours_splits_tiny_tip_connected_merge_that_balanced_keeps_merged(self):
         image = _tip_connected_pair_image()

--- a/cytocv/core/tests/test_green_dot_split.py
+++ b/cytocv/core/tests/test_green_dot_split.py
@@ -52,6 +52,10 @@ def _contour_list_count(contours: list[np.ndarray], *, min_area: float = 8.0) ->
     return sum(1 for contour in contours if cv2.contourArea(contour) >= min_area)
 
 
+def _total_contour_area(contours: list[np.ndarray]) -> float:
+    return float(sum(cv2.contourArea(contour) for contour in contours))
+
+
 def _gaussian_pair_image(
     *,
     center_a=(48, 48),
@@ -225,6 +229,32 @@ def _real_failure_like_green_image(shape=(80, 96)) -> np.ndarray:
     return np.clip(image, 0, 255).astype(np.uint8)
 
 
+def _broad_halo_tightening_images() -> tuple[np.ndarray, np.ndarray]:
+    support = _gaussian_pair_image(
+        center_a=(46, 48),
+        center_b=(66, 48),
+        sigma=5.0,
+        bridge_intensity=88.0,
+        amplitude_a=238.0,
+        amplitude_b=224.0,
+    )
+    tightening = _gaussian_pair_image(
+        center_a=(46, 48),
+        center_b=(66, 48),
+        sigma=2.7,
+        bridge_intensity=8.0,
+        amplitude_a=248.0,
+        amplitude_b=236.0,
+    )
+    return support, tightening
+
+
+def _moderate_aspect_two_peak_tightening_image() -> np.ndarray:
+    image = _moderate_aspect_two_peak_neck_image().astype(np.float32)
+    tightened = np.clip((image - 18.0) * 2.6, 0, 255)
+    return tightened.astype(np.uint8)
+
+
 def _contour_centroid(contour: np.ndarray) -> tuple[float, float]:
     moments = cv2.moments(contour)
     if moments["m00"] == 0:
@@ -233,7 +263,11 @@ def _contour_centroid(contour: np.ndarray) -> tuple[float, float]:
     return moments["m10"] / moments["m00"], moments["m01"] / moments["m00"]
 
 
-def _green_only_images(image: np.ndarray) -> GrayImage:
+def _green_only_images(
+    image: np.ndarray,
+    *,
+    green_no_bg: np.ndarray | None = None,
+) -> GrayImage:
     return GrayImage(
         {
             "gray_red_3": None,
@@ -241,7 +275,7 @@ def _green_only_images(image: np.ndarray) -> GrayImage:
             "gray_blue_3": None,
             "gray_blue": None,
             "green": image,
-            "green_no_bg": None,
+            "green_no_bg": green_no_bg,
             "red_no_bg": None,
         }
     )
@@ -275,9 +309,10 @@ def _split_green_contours_from_image(
     split_mode: str,
     *,
     green_contour_filter_enabled: bool = False,
+    green_no_bg: np.ndarray | None = None,
 ) -> list[np.ndarray]:
     contours_data = find_contours(
-        _green_only_images(image),
+        _green_only_images(image, green_no_bg=green_no_bg),
         green_contour_filter_enabled=green_contour_filter_enabled,
         alternate_red_detection=False,
         green_dot_split_enabled=True,
@@ -376,6 +411,24 @@ class GreenDotSplitTests(SimpleTestCase):
                 {"mode": split_mode},
             )
             self.assertEqual(_contour_list_count(split), 2)
+
+    def test_aggressive_tightening_shrinks_split_children_while_balanced_keeps_wider_support(self):
+        support_image, tightening_image = _broad_halo_tightening_images()
+
+        balanced = _split_green_contours_from_image(
+            support_image,
+            "balanced",
+            green_no_bg=tightening_image,
+        )
+        aggressive = _split_green_contours_from_image(
+            support_image,
+            "aggressive",
+            green_no_bg=tightening_image,
+        )
+
+        self.assertEqual(_contour_list_count(balanced, min_area=4.0), 2)
+        self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
+        self.assertLess(_total_contour_area(aggressive), _total_contour_area(balanced))
 
     def test_geometry_first_aggressive_splits_necked_single_peak_shape_that_balanced_keeps_merged(self):
         mask = _geometry_first_neck_mask()
@@ -666,6 +719,20 @@ class GreenDotSplitTests(SimpleTestCase):
         )
         self.assertEqual(_contour_list_count(aggressive), 2)
 
+        tightened_aggressive = postprocess_gfp_contours_for_neck_splits(
+            [contour],
+            image,
+            {
+                "mode": "aggressive",
+                "tightening_image": _moderate_aspect_two_peak_tightening_image(),
+            },
+        )
+        self.assertEqual(_contour_list_count(tightened_aggressive), 2)
+        self.assertLess(
+            _total_contour_area(tightened_aggressive),
+            _total_contour_area(geometry_children),
+        )
+
     def test_aggressive_find_contours_splits_tiny_tip_connected_merge_that_balanced_keeps_merged(self):
         image = _tip_connected_pair_image()
 
@@ -703,7 +770,7 @@ class GreenDotSplitTests(SimpleTestCase):
             self.assertTrue(np.array_equal(expected_contour, balanced_contour))
             self.assertTrue(np.array_equal(expected_contour, aggressive_contour))
 
-    def test_aggressive_filtered_find_contours_restores_original_when_filter_would_drop_one_child(self):
+    def test_aggressive_filtered_find_contours_never_collapses_accepted_split_to_one_child(self):
         image = _tip_connected_pair_image()
 
         aggressive = _split_green_contours_from_image(image, "aggressive")
@@ -716,8 +783,40 @@ class GreenDotSplitTests(SimpleTestCase):
 
         self.assertEqual(_contour_list_count(aggressive, min_area=4.0), 2)
         self.assertEqual(len(original), 1)
-        self.assertEqual(_contour_list_count(aggressive_filtered, min_area=4.0), 1)
-        self.assertEqual(cv2.contourArea(aggressive_filtered[0]), cv2.contourArea(original[0]))
+        filtered_count = _contour_list_count(aggressive_filtered, min_area=4.0)
+        self.assertIn(filtered_count, {1, 2})
+        if filtered_count == 1:
+            self.assertEqual(
+                cv2.contourArea(aggressive_filtered[0]),
+                cv2.contourArea(original[0]),
+            )
+
+    def test_aggressive_tightening_keeps_compact_binary_split_children_nearly_unchanged(self):
+        mask = np.zeros((96, 128), dtype=np.uint8)
+        cv2.circle(mask, (54, 48), 13, 255, -1)
+        cv2.circle(mask, (74, 48), 13, 255, -1)
+        contours = _contours_from_mask(mask)
+
+        aggressive_untightened = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            mask,
+            {"mode": "aggressive"},
+        )
+        aggressive_tightened = postprocess_gfp_contours_for_neck_splits(
+            contours,
+            mask,
+            {"mode": "aggressive", "tightening_image": mask},
+        )
+
+        self.assertEqual(_contour_list_count(aggressive_untightened), 2)
+        self.assertEqual(_contour_list_count(aggressive_tightened), 2)
+        self.assertLessEqual(
+            abs(
+                _total_contour_area(aggressive_tightened)
+                - _total_contour_area(aggressive_untightened)
+            ),
+            1.0,
+        )
 
     def test_aggressive_filtered_find_contours_preserves_clean_two_child_split(self):
         image = _gaussian_pair_image(bridge_intensity=90.0)
@@ -755,6 +854,33 @@ class GreenDotSplitTests(SimpleTestCase):
         self.assertTrue(any(x < 52 and y < 42 for x, y in centroids))
         self.assertTrue(any(x > 52 and y < 42 for x, y in centroids))
         self.assertTrue(any(x > 54 and y > 44 for x, y in centroids))
+
+    def test_aggressive_does_not_change_unsplit_round_or_irregular_single_contour_area(self):
+        round_mask = np.zeros((80, 100), dtype=np.uint8)
+        cv2.circle(round_mask, (50, 40), 10, 255, -1)
+        irregular_mask = np.zeros((80, 100), dtype=np.uint8)
+        cv2.circle(irregular_mask, (50, 40), 11, 255, -1)
+        cv2.circle(irregular_mask, (58, 37), 3, 0, -1)
+        cv2.circle(irregular_mask, (44, 45), 2, 0, -1)
+
+        for mask in (round_mask, irregular_mask):
+            contours = _contours_from_mask(mask)
+            balanced = postprocess_gfp_contours_for_neck_splits(
+                contours,
+                mask,
+                {"mode": "balanced"},
+            )
+            aggressive = postprocess_gfp_contours_for_neck_splits(
+                contours,
+                mask,
+                {"mode": "aggressive", "tightening_image": mask},
+            )
+            self.assertEqual(_contour_list_count(balanced), 1)
+            self.assertEqual(_contour_list_count(aggressive), 1)
+            self.assertEqual(
+                cv2.contourArea(aggressive[0]),
+                cv2.contourArea(balanced[0]),
+            )
 
     def test_green_filter_rescues_strong_peak_that_fails_legacy_shape_rule(self):
         mask = np.zeros((64, 64), dtype=np.uint8)

--- a/cytocv/core/tests/test_modern_contour_statistics.py
+++ b/cytocv/core/tests/test_modern_contour_statistics.py
@@ -6,10 +6,16 @@ from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import cv2
 import numpy as np
 from django.test import SimpleTestCase
 
+from core.contour_processing.contour_operations import find_contours
 from core.image_processing import GrayImage
+from core.services.canonical_contours import (
+    build_canonical_contour_payload,
+    flatten_slot_contours,
+)
 from core.stats_plugins import build_stats_execution_plan
 from core.views.segment_image import get_stats
 
@@ -76,6 +82,7 @@ class ModernContourStatisticsTests(SimpleTestCase):
         contours_data: dict,
         y_range,
         x_range,
+        green_no_bg_gray: np.ndarray | None = None,
         puncta_line_mode: str = "red_puncta",
         cen_dot_distance: float = 37.0,
     ):
@@ -93,7 +100,7 @@ class ModernContourStatisticsTests(SimpleTestCase):
             img={
                 "red_no_bg": red_gray,
                 "gray_red": red_gray,
-                "green_no_bg": green_gray,
+                "green_no_bg": green_gray if green_no_bg_gray is None else green_no_bg_gray,
                 "green": green_gray,
                 "gray_blue": np.zeros_like(red_gray),
                 "gray_blue_3": np.zeros_like(red_gray),
@@ -129,6 +136,43 @@ class ModernContourStatisticsTests(SimpleTestCase):
                 )
 
         return cp, np.array(debug_red), np.array(debug_green), np.array(debug_blue)
+
+    @staticmethod
+    def _tightening_support_and_core_images(
+        shape: tuple[int, int] = (96, 128),
+    ) -> tuple[np.ndarray, np.ndarray]:
+        y_grid, x_grid = np.mgrid[0 : shape[0], 0 : shape[1]]
+
+        def pair(*, sigma: float, bridge_intensity: float, amplitude_a: float, amplitude_b: float):
+            dot_a = amplitude_a * np.exp(
+                -(
+                    ((x_grid - 46) ** 2 + (y_grid - 48) ** 2)
+                    / (2.0 * sigma * sigma)
+                )
+            )
+            dot_b = amplitude_b * np.exp(
+                -(
+                    ((x_grid - 66) ** 2 + (y_grid - 48) ** 2)
+                    / (2.0 * sigma * sigma)
+                )
+            )
+            image = np.maximum(dot_a, dot_b)
+            cv2.line(image, (46, 48), (66, 48), bridge_intensity, 3)
+            return np.clip(image, 0, 255).astype(np.uint8)
+
+        support = pair(
+            sigma=5.0,
+            bridge_intensity=88.0,
+            amplitude_a=238.0,
+            amplitude_b=224.0,
+        )
+        tightening = pair(
+            sigma=2.7,
+            bridge_intensity=8.0,
+            amplitude_a=248.0,
+            amplitude_b=236.0,
+        )
+        return support, tightening
 
     def test_red_nucleus_uses_same_clipped_slot_for_green_in_red_and_green_nuclear(self):
         shape = (16, 16)
@@ -255,3 +299,62 @@ class ModernContourStatisticsTests(SimpleTestCase):
         self.assertEqual(cp.properties["puncta_line_measurement_channel"], "channel_red")
         self.assertAlmostEqual(cp.puncta_distance, 6.0, places=4)
         self.assertEqual(cp.puncta_line_intensity, 14.0)
+
+    def test_aggressive_tightened_green_slots_drive_stats_and_debug_contours(self):
+        shape = (96, 128)
+        red_gray = np.zeros(shape, dtype=np.uint8)
+        support_green, tightening_green = self._tightening_support_and_core_images(shape)
+        preprocessed = GrayImage(
+            img={
+                "red_no_bg": red_gray,
+                "gray_red": red_gray,
+                "gray_red_3": red_gray,
+                "green": support_green,
+                "green_no_bg": tightening_green,
+                "gray_blue": np.zeros_like(red_gray),
+                "gray_blue_3": np.zeros_like(red_gray),
+            }
+        )
+        contours_data = find_contours(
+            preprocessed,
+            green_contour_filter_enabled=False,
+            alternate_red_detection=False,
+            green_dot_split_enabled=True,
+            green_dot_split_mode="aggressive",
+        )
+
+        with TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir)
+            self._write_outline(
+                output_dir,
+                y_range=range(0, shape[0]),
+                x_range=range(0, shape[1]),
+            )
+            expected_payload = build_canonical_contour_payload(
+                contours_data,
+                image_name="test.dv",
+                cell_id=1,
+                output_dir=temp_dir,
+                shape=shape,
+            )
+            expected_slots = expected_payload["canonical_green_slots"]
+            expected_contours = flatten_slot_contours(expected_slots)
+
+            cp, _, debug_green, _ = self._run_get_stats(
+                mode="green_nucleus",
+                selected_analysis=["GreenRedIntensity"],
+                red_gray=red_gray,
+                green_gray=support_green,
+                green_no_bg_gray=tightening_green,
+                contours_data=contours_data,
+                y_range=range(0, shape[0]),
+                x_range=range(0, shape[1]),
+            )
+
+        self.assertEqual(len(expected_slots), 2)
+        self.assertAlmostEqual(cp.green_contour_1_size, float(expected_slots[0].area), places=4)
+        self.assertAlmostEqual(cp.green_contour_2_size, float(expected_slots[1].area), places=4)
+
+        expected_debug_green = self._rgb(support_green)
+        cv2.drawContours(expected_debug_green, expected_contours, -1, (0, 255, 0), 1)
+        self.assertTrue(np.array_equal(debug_green, expected_debug_green))

--- a/cytocv/core/views/display.py
+++ b/cytocv/core/views/display.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_POST
 
-from accounts.preferences import get_user_preferences
+from accounts.preferences import get_user_preferences, normalize_main_image_channel
 from core.channel_roles import (
     CHANNEL_ROLE_BLUE,
     CHANNEL_ROLE_DIC,
@@ -208,6 +208,10 @@ def display(request, uuids):
         preferences.get("sidebar_spatial_stats_unit"),
         default=default_spatial_stats_unit,
     )
+    main_image_channel = normalize_main_image_channel(
+        preferences.get("main_image_channel"),
+        default="",
+    )
 
     # Loop through each UUID and retrieve associated data
     for uuid in uuid_list:
@@ -385,6 +389,7 @@ def display(request, uuids):
         'sidebar_starts_open': sidebar_starts_open,
         'default_spatial_stats_unit': default_spatial_stats_unit,
         'sidebar_spatial_stats_unit': sidebar_spatial_stats_unit,
+        'main_image_channel': main_image_channel,
     })
 
 

--- a/cytocv/core/views/display.py
+++ b/cytocv/core/views/display.py
@@ -35,7 +35,7 @@ from core.services.artifact_storage import (
 )
 from core.services.cell_statistics_payload import serialize_cell_statistics_payload
 from core.services.main_image_urls import build_main_image_paths
-from core.services.overlay_rendering import build_overlay_image_url, overlay_render_config_exists
+from core.services.overlay_rendering import build_overlay_image_url, overlay_image_available
 from core.services.puncta_line_mode import VALID_PUNCTA_LINE_MODES
 from core.scale import (
     get_scale_context_payload,
@@ -270,8 +270,6 @@ def display(request, uuids):
                 channel_config=channel_config,
                 available_frames=available_frames,
             )
-            has_overlay_render_config = overlay_render_config_exists(uuid)
-
             # Build the images for each cell based on the dynamic channel configuration
             images = {}
             statistics = {}
@@ -311,12 +309,10 @@ def display(request, uuids):
                 for channel_name in channel_order:
                     channel_index = channel_config.get(channel_name)
                     no_outline = f"{MEDIA_URL}{uuid}/segmented/{image_name_stem}-{channel_index}-{i}-no_outline.png"
-                    debug_file_name = f"{image_name_stem}-{i}-{channel_name}_debug.png"
-                    debug_file_path = Path(MEDIA_ROOT) / str(uuid) / "segmented" / debug_file_name
                     if (
                         channel_name in [CHANNEL_ROLE_RED, CHANNEL_ROLE_GREEN, CHANNEL_ROLE_BLUE]
                         and cell_stat is not None
-                        and (has_overlay_render_config or debug_file_path.exists())
+                        and overlay_image_available(uuid, i, channel_name)
                     ):
                         image_url = build_overlay_image_url(uuid, i, channel_name)
                     else:

--- a/cytocv/templates/dashboard.html
+++ b/cytocv/templates/dashboard.html
@@ -2280,6 +2280,7 @@
         ];
         const defaultSpatialStatsUnit = "{{ default_spatial_stats_unit|default:'px'|escapejs }}";
         const initialSidebarSpatialStatsUnit = "{{ sidebar_spatial_stats_unit|default:default_spatial_stats_unit|escapejs }}";
+        const initialPreferredMainImageChannel = "{{ main_image_channel|default:''|escapejs }}";
         const spatialFieldKinds = {
             puncta_distance: 'distance',
             blue_contour_size: 'area',
@@ -2342,6 +2343,7 @@
             distance_of_green_from_red_3: 'Distance Of Green From Red 3',
         };
         let currentSpatialStatsUnit = initialSidebarSpatialStatsUnit;
+        let preferredMainImageChannel = normalizeMainImageChannel(initialPreferredMainImageChannel);
         let activeFileLoadToken = 0;
         let activeCellRenderToken = 0;
         let hasInitializedDashboardFile = false;
@@ -2755,6 +2757,40 @@
             });
         }
 
+        function normalizeMainImageChannel(channel) {
+            return channels.includes(channel) ? channel : '';
+        }
+
+        function getPreferredMainImageChannel() {
+            return normalizeMainImageChannel(preferredMainImageChannel);
+        }
+
+        function setPreferredMainImageChannel(channel) {
+            preferredMainImageChannel = normalizeMainImageChannel(channel);
+            return preferredMainImageChannel;
+        }
+
+        async function persistPreferredMainImageChannel(channel) {
+            const response = await fetch('/dashboard/preferences/channels/', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': csrfToken || '',
+                },
+                credentials: 'same-origin',
+                body: JSON.stringify({ main_image_channel: normalizeMainImageChannel(channel) }),
+            });
+            if (!response.ok) {
+                throw new Error('Unable to save main image channel preference.');
+            }
+            const payload = await response.json();
+            return setPreferredMainImageChannel(payload.main_image_channel || channel);
+        }
+
+        function showChannelPreferenceWarning() {
+            showChannelError('Main channel changed, but the preference could not be saved right now.');
+        }
+
         function syncContourStateLabel(showContours) {
             const contourStateValue = document.getElementById('contourStateValue');
             if (contourStateValue) {
@@ -3157,6 +3193,7 @@
             }
 
             const requestToken = ++activeFileLoadToken;
+            ++activeChannelRequest;
             currentFileIndex = normalizedIndex;
             maxCells = Number(fileData.NumberOfCells || 0);
             if (!Number.isFinite(maxCells) || maxCells < 0) {
@@ -3164,7 +3201,19 @@
             }
             currentCellNumber = 1;
 
-            const mainImagePath = fileData.MainImagePath || noCellPlaceholder;
+            const defaultMainImagePath = fileData.MainImagePath || noCellPlaceholder;
+            const inferredDefaultChannel = primeMainImageWarmState(fileUUID, fileData, defaultMainImagePath);
+            const preferredChannel = getPreferredMainImageChannel();
+            const preferredMainImagePath = preferredChannel
+                ? (getMainImagePaths(fileData)[preferredChannel] || '')
+                : '';
+            const mainImagePath = preferredMainImagePath || defaultMainImagePath;
+            const activeMainChannel = preferredMainImagePath
+                ? preferredChannel
+                : inferredDefaultChannel;
+            if (activeMainChannel && activeMainChannel !== inferredDefaultChannel) {
+                markMainImageChannelWarm(fileUUID, fileData, activeMainChannel, mainImagePath);
+            }
             const showContours = getContourToggleState();
             syncContourStateLabel(showContours);
             const initialCellState = getCellDisplayState(fileData.CellPairImages, fileData.Statistics, {
@@ -3205,6 +3254,7 @@
                 return false;
             }
 
+            fileData.MainImagePath = mainImagePath;
             if (fileData.NoCellsWarning) {
                 showChannelError(fileData.NoCellsWarning);
             }
@@ -3212,11 +3262,12 @@
             updateSidebarActive();
             syncFileNavigationState();
 
-            const inferred = primeMainImageWarmState(fileUUID, fileData, mainImagePath);
-            if (inferred) {
-                setActiveChannel(inferred);
+            if (activeMainChannel) {
+                setActiveChannel(activeMainChannel);
+            } else if (inferredDefaultChannel) {
+                setActiveChannel(inferredDefaultChannel);
             }
-            scheduleMainImageWarmup(fileUUID, fileData, inferred);
+            scheduleMainImageWarmup(fileUUID, fileData, activeMainChannel || inferredDefaultChannel);
             if (showContours) {
                 markCurrentCellWarm(fileUUID, true);
                 scheduleCircularOverlayWarmup('initial');
@@ -3392,26 +3443,48 @@
                 });
         }
 
-        async function switchMainChannel(channel) {
+        async function switchMainChannel(channel, { persistPreference = true } = {}) {
             const mainImage = document.getElementById('mainImage');
             if (!mainImage) return;
+            const normalizedChannel = normalizeMainImageChannel(channel);
+            if (!normalizedChannel) return;
             const fileUUID = fileUUIDs[currentFileIndex];
             const fileData = fileUUID ? filesData[fileUUID] : null;
             if (!fileUUID || !fileData) return;
             const requestId = ++activeChannelRequest;
+            const fileLoadTokenAtRequest = activeFileLoadToken;
             try {
-                const imageUrl = await warmMainImageChannel(fileUUID, fileData, channel);
+                const imageUrl = await warmMainImageChannel(fileUUID, fileData, normalizedChannel);
                 if (!imageUrl) {
                     throw new Error('Missing image URL');
                 }
-                if (requestId !== activeChannelRequest) {
+                if (
+                    requestId !== activeChannelRequest
+                    || fileLoadTokenAtRequest !== activeFileLoadToken
+                    || fileUUID !== fileUUIDs[currentFileIndex]
+                ) {
                     return;
                 }
                 await setImageWithBlend(mainImage, imageUrl, {
                     duration: FILE_BLEND_IMAGE_MS,
                     blend: hasInitializedDashboardFile,
                 });
-                setActiveChannel(channel);
+                if (
+                    requestId !== activeChannelRequest
+                    || fileLoadTokenAtRequest !== activeFileLoadToken
+                    || fileUUID !== fileUUIDs[currentFileIndex]
+                ) {
+                    return;
+                }
+                fileData.MainImagePath = imageUrl;
+                markMainImageChannelWarm(fileUUID, fileData, normalizedChannel, imageUrl);
+                setActiveChannel(normalizedChannel);
+                setPreferredMainImageChannel(normalizedChannel);
+                if (persistPreference) {
+                    void persistPreferredMainImageChannel(normalizedChannel).catch(() => {
+                        showChannelPreferenceWarning();
+                    });
+                }
             } catch (error) {
                 if (error && error.name === 'AbortError') return;
                 showChannelError('Unable to load that channel image. Please try again.');

--- a/cytocv/templates/display.html
+++ b/cytocv/templates/display.html
@@ -2235,6 +2235,7 @@
         ];
         const defaultSpatialStatsUnit = "{{ default_spatial_stats_unit|default:'px'|escapejs }}";
         const initialSidebarSpatialStatsUnit = "{{ sidebar_spatial_stats_unit|default:default_spatial_stats_unit|escapejs }}";
+        const initialPreferredMainImageChannel = "{{ main_image_channel|default:''|escapejs }}";
         const spatialFieldKinds = {
             puncta_distance: 'distance',
             blue_contour_size: 'area',
@@ -2297,6 +2298,7 @@
             distance_of_green_from_red_3: 'Distance Of Green From Red 3',
         };
         let currentSpatialStatsUnit = initialSidebarSpatialStatsUnit;
+        let preferredMainImageChannel = normalizeMainImageChannel(initialPreferredMainImageChannel);
         let activeFileLoadToken = 0;
         let activeCellRenderToken = 0;
         let hasInitializedDisplayFile = false;
@@ -2666,6 +2668,7 @@
             }
 
             const requestToken = ++activeFileLoadToken;
+            ++activeChannelRequest;
             currentFileIndex = normalizedIndex;
             maxCells = Number(fileData.NumberOfCells || 0);
             if (!Number.isFinite(maxCells) || maxCells < 0) {
@@ -2673,7 +2676,19 @@
             }
             currentCellNumber = 1;
 
-            const mainImagePath = fileData.MainImagePath || noCellPlaceholder;
+            const defaultMainImagePath = fileData.MainImagePath || noCellPlaceholder;
+            const inferredDefaultChannel = primeMainImageWarmState(fileUUID, fileData, defaultMainImagePath);
+            const preferredChannel = getPreferredMainImageChannel();
+            const preferredMainImagePath = preferredChannel
+                ? (getMainImagePaths(fileData)[preferredChannel] || '')
+                : '';
+            const mainImagePath = preferredMainImagePath || defaultMainImagePath;
+            const activeMainChannel = preferredMainImagePath
+                ? preferredChannel
+                : inferredDefaultChannel;
+            if (activeMainChannel && activeMainChannel !== inferredDefaultChannel) {
+                markMainImageChannelWarm(fileUUID, fileData, activeMainChannel, mainImagePath);
+            }
             const showContours = getContourToggleState();
             syncContourStateLabel(showContours);
             const initialCellState = getCellDisplayState(fileData.CellPairImages, fileData.Statistics, {
@@ -2721,6 +2736,7 @@
                 return false;
             }
 
+            fileData.MainImagePath = mainImagePath;
             if (fileData.NoCellsWarning) {
                 showChannelError(fileData.NoCellsWarning);
             }
@@ -2728,11 +2744,12 @@
             updateSidebarActive();
             syncFileNavigationState();
 
-            const inferred = primeMainImageWarmState(fileUUID, fileData, mainImagePath);
-            if (inferred) {
-                setActiveChannel(inferred);
+            if (activeMainChannel) {
+                setActiveChannel(activeMainChannel);
+            } else if (inferredDefaultChannel) {
+                setActiveChannel(inferredDefaultChannel);
             }
-            scheduleMainImageWarmup(fileUUID, fileData, inferred);
+            scheduleMainImageWarmup(fileUUID, fileData, activeMainChannel || inferredDefaultChannel);
             if (showContours) {
                 markCurrentCellWarm(fileUUID, true);
                 scheduleCircularOverlayWarmup('initial');
@@ -2798,6 +2815,10 @@
             msg.appendChild(close);
             container.appendChild(msg);
             setTimeout(() => msg.remove(), 8000);
+        }
+
+        function showChannelPreferenceWarning() {
+            showChannelError('Main channel changed, but the preference could not be saved right now.');
         }
 
         function preloadImage(url) {
@@ -2941,26 +2962,48 @@
                 });
         }
 
-        async function switchMainChannel(channel) {
+        async function switchMainChannel(channel, { persistPreference = true } = {}) {
             const mainImage = document.getElementById('mainImage');
             if (!mainImage) return;
+            const normalizedChannel = normalizeMainImageChannel(channel);
+            if (!normalizedChannel) return;
             const fileUUID = fileUUIDs[currentFileIndex];
             const fileData = fileUUID ? filesData[fileUUID] : null;
             if (!fileUUID || !fileData) return;
             const requestId = ++activeChannelRequest;
+            const fileLoadTokenAtRequest = activeFileLoadToken;
             try {
-                const imageUrl = await warmMainImageChannel(fileUUID, fileData, channel);
+                const imageUrl = await warmMainImageChannel(fileUUID, fileData, normalizedChannel);
                 if (!imageUrl) {
                     throw new Error('Missing image URL');
                 }
-                if (requestId !== activeChannelRequest) {
+                if (
+                    requestId !== activeChannelRequest
+                    || fileLoadTokenAtRequest !== activeFileLoadToken
+                    || fileUUID !== fileUUIDs[currentFileIndex]
+                ) {
                     return;
                 }
                 await setImageWithBlend(mainImage, imageUrl, {
                     duration: FILE_BLEND_IMAGE_MS,
                     blend: hasInitializedDisplayFile,
                 });
-                setActiveChannel(channel);
+                if (
+                    requestId !== activeChannelRequest
+                    || fileLoadTokenAtRequest !== activeFileLoadToken
+                    || fileUUID !== fileUUIDs[currentFileIndex]
+                ) {
+                    return;
+                }
+                fileData.MainImagePath = imageUrl;
+                markMainImageChannelWarm(fileUUID, fileData, normalizedChannel, imageUrl);
+                setActiveChannel(normalizedChannel);
+                setPreferredMainImageChannel(normalizedChannel);
+                if (persistPreference) {
+                    void persistPreferredMainImageChannel(normalizedChannel).catch(() => {
+                        showChannelPreferenceWarning();
+                    });
+                }
             } catch (error) {
                 if (error && error.name === 'AbortError') return;
                 showChannelError('Unable to load that channel image. Please try again.');
@@ -2995,6 +3038,36 @@
                 btn.classList.toggle('active', isActive);
                 btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
             });
+        }
+
+        function normalizeMainImageChannel(channel) {
+            return channels.includes(channel) ? channel : '';
+        }
+
+        function getPreferredMainImageChannel() {
+            return normalizeMainImageChannel(preferredMainImageChannel);
+        }
+
+        function setPreferredMainImageChannel(channel) {
+            preferredMainImageChannel = normalizeMainImageChannel(channel);
+            return preferredMainImageChannel;
+        }
+
+        async function persistPreferredMainImageChannel(channel) {
+            const response = await fetch('/dashboard/preferences/channels/', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': csrfToken || '',
+                },
+                credentials: 'same-origin',
+                body: JSON.stringify({ main_image_channel: normalizeMainImageChannel(channel) }),
+            });
+            if (!response.ok) {
+                throw new Error('Unable to save main image channel preference.');
+            }
+            const payload = await response.json();
+            return setPreferredMainImageChannel(payload.main_image_channel || channel);
         }
 
         function syncContourStateLabel(showContours) {


### PR DESCRIPTION
This pull request adds support for storing and validating a user's preferred main image channel in user preferences, improves overlay image availability checks, and updates related tests and validation logic. The main goal is to allow users to select and persist their preferred main image channel (e.g., "green", "red", "blue", "dic") for display, with robust validation and normalization throughout the backend.

**User Preferences and Validation Enhancements:**
* Added `main_image_channel` to user preferences, with normalization and validation to ensure only supported channel slugs are accepted (e.g., "dic", "blue", "red", "green"). [[1]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379R28-R30) [[2]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379R76) [[3]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379R119-R127) [[4]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR626-R629) [[5]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR854) [[6]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL1024-R1033) [[7]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR1061-R1070) [[8]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR1079-R1080)
* Updated the dashboard channel visibility endpoint to validate the `main_image_channel` and return a 400 error for invalid values. [[1]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR1061-R1070) [[2]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR1097-R1100)

**Overlay Rendering Improvements:**
* Added `overlay_image_available` to robustly check for overlay image existence, replacing the previous config check. [[1]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL51-R53) [[2]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL649) [[3]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL720-R725) [[4]](diffhunk://#diff-fef90c7f659bbbec01c491c55a19fe49407cecef117e02858bb1d4ec7daff174R235-R243)
* Optimized overlay cache image handling to avoid unnecessary rendering if the cached file already exists.

**Default and Test Adjustments:**
* Changed the default for `green_dot_split_mode` from "aggressive" to "balanced" in plugin defaults and updated tests accordingly. [[1]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379L54-R57) [[2]](diffhunk://#diff-5975815911a31d142ebee61979d45315aa015a6ea81fef83b26168776c2774f2L52-R59) [[3]](diffhunk://#diff-5975815911a31d142ebee61979d45315aa015a6ea81fef83b26168776c2774f2L1937-R2005)
* Added and updated tests to cover main image channel normalization, persistence, and validation, as well as template rendering with the preferred channel. [[1]](diffhunk://#diff-5975815911a31d142ebee61979d45315aa015a6ea81fef83b26168776c2774f2R84) [[2]](diffhunk://#diff-5975815911a31d142ebee61979d45315aa015a6ea81fef83b26168776c2774f2R106) [[3]](diffhunk://#diff-5975815911a31d142ebee61979d45315aa015a6ea81fef83b26168776c2774f2R131-R138) [[4]](diffhunk://#diff-5975815911a31d142ebee61979d45315aa015a6ea81fef83b26168776c2774f2R714-R749) [[5]](diffhunk://#diff-5975815911a31d142ebee61979d45315aa015a6ea81fef83b26168776c2774f2R1682) [[6]](diffhunk://#diff-5975815911a31d142ebee61979d45315aa015a6ea81fef83b26168776c2774f2R1700) [[7]](diffhunk://#diff-5975815911a31d142ebee61979d45315aa015a6ea81fef83b26168776c2774f2R1796-R1803) [[8]](diffhunk://#diff-5975815911a31d142ebee61979d45315aa015a6ea81fef83b26168776c2774f2R1842-R1852)

These changes ensure that user preferences for the main image channel are handled consistently and validated throughout the application, while also improving overlay image logic and updating tests for these new behaviors.