### PR TITLE
Trust forwarded HTTPS scheme in Nginx configuration

### DIFF
--- a/cytocv/cytocv/settings.py
+++ b/cytocv/cytocv/settings.py
@@ -449,6 +449,13 @@ PUBLIC_BASE_URL = (_get_env(
     prefer_env_file=True,
 ) or "").strip().rstrip("/")
 
+# Reverse proxy HTTPS awareness
+#
+# Production deployments commonly terminate TLS at Nginx and forward requests
+# to Gunicorn over HTTP. Trust the forwarded scheme so strict-mode HTTPS
+# redirects and secure-cookie handling behave correctly behind the proxy.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 # Default primary key field type
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 


### PR DESCRIPTION
This pull request adds improved support for deployments behind a reverse proxy by configuring Django to properly recognize HTTPS requests forwarded from a proxy server. This change is important for ensuring that security features like HTTPS redirects and secure cookies work correctly in production environments.

**Deployment and Security Configuration:**

* Added the `SECURE_PROXY_SSL_HEADER` setting in `cytocv/cytocv/settings.py` to trust the `X-Forwarded-Proto` header, allowing Django to recognize HTTPS requests when running behind a proxy such as Nginx.