### PR TITLE
Document cytocv2 maintenance deployment process

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ For operational deployment material, use these documents:
 - Sanitized VM deployment guide: [docs/vm-deployment-guide/README.md](docs/vm-deployment-guide/README.md)
 - Historical first VM deployment record: [docs/vm-deployment-record/README.md](docs/vm-deployment-record/README.md)
 - Historical replacement VM deployment record: [docs/vm-deployment-record-cytocv2/README.md](docs/vm-deployment-record-cytocv2/README.md)
+- Historical cytocv2 maintenance refresh record: [docs/vm-deployment-record-cytocv2-2026-04-maintenance/README.md](docs/vm-deployment-record-cytocv2-2026-04-maintenance/README.md)
 
 The VM-specific documents are retained as sanitized historical maintainer notes. Use the core operations docs above as the current source of truth for active deployments.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ This directory is the canonical documentation home for CytoCV. The root `README.
 - PDFs in `docs/research/` are derived formal deliverables.
 - Diagrams live in `docs/diagrams/`.
 - Obsolete or superseded material should move to `docs/archive/`.
-- Historical project records that should remain readable but are not part of the active doc system may remain in dedicated subfolders such as `docs/vm-deployment-record/` and `docs/vm-deployment-record-cytocv2/`.
+- Historical project records that should remain readable but are not part of the active doc system may remain in dedicated subfolders such as `docs/vm-deployment-record/`, `docs/vm-deployment-record-cytocv2/`, and dated follow-up record folders.
 
 ## User Documentation
 
@@ -71,3 +71,4 @@ Formal PDF deliverables:
 - License: [`license/README.md`](license/README.md)
 - Historical deployment record (first VM): [`vm-deployment-record/README.md`](vm-deployment-record/README.md)
 - Historical deployment record (replacement VM): [`vm-deployment-record-cytocv2/README.md`](vm-deployment-record-cytocv2/README.md)
+- Historical deployment record (cytocv2 April 2026 maintenance refresh): [`vm-deployment-record-cytocv2-2026-04-maintenance/README.md`](vm-deployment-record-cytocv2-2026-04-maintenance/README.md)

--- a/docs/ops/deployment-guide.md
+++ b/docs/ops/deployment-guide.md
@@ -67,6 +67,69 @@ At startup, the Django settings module:
 - validates production secret-key safety
 - configures provider auth, email, reCAPTCHA, CSP, and security headers
 
+## Existing VM Code Update
+
+For an already provisioned `systemd` / Nginx VM, update the existing checkout
+rather than recloning the application.
+
+If the checkout path is uncertain, locate the repository first:
+
+```bash
+find ~ -maxdepth 3 -type d -name ".git" 2>/dev/null
+```
+
+Then move to the parent directory of the `.git` path and verify the branch:
+
+```bash
+cd /path/to/CytoCV
+git status
+git branch --show-current
+git fetch origin
+git pull --ff-only origin main
+```
+
+`git pull --ff-only origin main` is appropriate when the deployed checkout can
+advance directly to `origin/main`, even if the local branch is named for the
+deployment or maintainer. If this command fails, stop and reconcile the branch
+state instead of forcing a reset. Untracked `cytocv/staticfiles/` content is
+normal on deployments that run `collectstatic` locally.
+
+After pulling code, run the Django deployment checks from the virtual
+environment:
+
+```bash
+source cyto_cv/bin/activate
+cd cytocv
+python manage.py migrate
+python manage.py check
+python manage.py collectstatic --noinput
+```
+
+Restart the supervised processes:
+
+```bash
+sudo systemctl restart cytocv
+sudo systemctl restart cytocv-upload-prep-worker
+sudo systemctl restart cytocv-analysis-worker
+sudo systemctl restart cytocv-artifact-maintenance.timer
+```
+
+Validate and reload Nginx when proxy configuration or static-file handling may
+have changed:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+If the deployment `.env` needs editing, open the actual repository path, not a
+placeholder path:
+
+```bash
+cd /actual/CytoCV/checkout
+nano .env
+```
+
 ## Operational Concerns
 
 Production deployment should account for:
@@ -161,6 +224,58 @@ Rollback guidance:
 - if the analysis worker is unavailable, upload preparation still completes but analysis batches remain queued until that worker returns
 - `CYTOCV_ANALYSIS_EXECUTION_MODE=sync` only falls analysis back to the request-owned path after upload preparation has already completed
 - keep `CYTOCV_SEGMENT_SAVE_DEBUG_ARTIFACTS=0` unless you explicitly need debug overlays
+
+## Intentional Database Data Reset
+
+Use this path only when the intended result is an empty production database
+while keeping the PostgreSQL database, schema, and service configuration. This
+deletes application data such as users, uploads, jobs, sessions, and auth
+records. It does not remove uploaded media or collected static files from disk.
+
+Create a backup before flushing. `pg_dump` must connect with the configured
+PostgreSQL role from `.env`; otherwise it may default to the Linux account and
+fail with a missing-role error.
+
+```bash
+cd /path/to/CytoCV
+set -a
+source .env
+set +a
+
+PGPASSWORD="$CYTOCV_DB_PASSWORD" pg_dump \
+  -h "${CYTOCV_DB_HOST:-127.0.0.1}" \
+  -p "${CYTOCV_DB_PORT:-5432}" \
+  -U "$CYTOCV_DB_USER" \
+  "$CYTOCV_DB_NAME" > cytocv-before-flush.sql
+```
+
+Stop the web process and workers before deleting data:
+
+```bash
+sudo systemctl stop cytocv
+sudo systemctl stop cytocv-upload-prep-worker
+sudo systemctl stop cytocv-analysis-worker
+sudo systemctl stop cytocv-artifact-maintenance.timer
+```
+
+Flush through Django so the schema remains intact:
+
+```bash
+source cyto_cv/bin/activate
+cd cytocv
+python manage.py flush
+python manage.py migrate
+python manage.py check
+```
+
+Restart the deployment:
+
+```bash
+sudo systemctl start cytocv
+sudo systemctl start cytocv-upload-prep-worker
+sudo systemctl start cytocv-analysis-worker
+sudo systemctl start cytocv-artifact-maintenance.timer
+```
 
 ## Root Cause Note
 

--- a/docs/vm-deployment-guide/README.md
+++ b/docs/vm-deployment-guide/README.md
@@ -152,6 +152,24 @@ After deployment, verify:
 7. display, dashboard, and CSV/XLSX export work for a signed-in account
 8. protected result assets load only through authenticated access
 
+## 11. Existing VM Maintenance
+
+For an already deployed VM, use the active operations guide rather than
+re-running the new-host provisioning sequence:
+
+- existing checkout update path: [`../ops/deployment-guide.md#existing-vm-code-update`](../ops/deployment-guide.md#existing-vm-code-update)
+- intentional data reset path: [`../ops/deployment-guide.md#intentional-database-data-reset`](../ops/deployment-guide.md#intentional-database-data-reset)
+
+When the checkout path is uncertain, locate the repository before editing
+deployment files:
+
+```bash
+find ~ -maxdepth 3 -type d -name "CytoCV"
+```
+
+Keep exact hostnames, account names, absolute paths, and SSH key material in
+private operational records rather than shared repository documentation.
+
 ## Historical Lessons Preserved Here
 
 - A VM can host the website but still fail analysis if the CPU environment is not compatible with the ML runtime.

--- a/docs/vm-deployment-record-cytocv2-2026-04-maintenance/README.md
+++ b/docs/vm-deployment-record-cytocv2-2026-04-maintenance/README.md
@@ -1,0 +1,203 @@
+# CytoCV VM Deployment Record (cytocv2 Maintenance Refresh, April 2026)
+
+This is a sanitized historical summary of the April 2026 maintenance refresh on
+the replacement CytoCV Linux VM. It preserves operational lessons without
+recording live hostnames, IP addresses, usernames, passwords, key material,
+database credentials, or exact private filesystem paths.
+
+This document is historical context, not the active deployment recipe. For
+current deployment guidance, use:
+
+- [`../vm-deployment-guide/README.md`](../vm-deployment-guide/README.md)
+- [`../ops/deployment-guide.md`](../ops/deployment-guide.md)
+- [`../ops/environment-reference.md`](../ops/environment-reference.md)
+- [`../../deploy/systemd/README.md`](../../deploy/systemd/README.md)
+
+## What This Maintenance Refresh Achieved
+
+This refresh brought the existing VM deployment back in line with the current
+repository state and intentionally reset stored application data:
+
+- confirmed interactive SSH access to the replacement VM
+- added a dedicated operator SSH key path for future access
+- located the active repository checkout and deployment `.env`
+- fast-forwarded the deployed checkout to `origin/main`
+- preserved the existing PostgreSQL database and schema while deleting stored
+  application rows through Django
+- confirmed `migrate` and `check` completed successfully
+- restarted the web service, upload-preparation worker, analysis worker, and
+  artifact-maintenance timer
+- confirmed the expected `systemd` services were active after restart
+
+## Access And Checkout Discovery
+
+The initial access issue was not network reachability. Verbose SSH output showed
+that the client could reach the server and that the server allowed public-key
+and password authentication, but no local private keys were available. Password
+access succeeded after confirming the correct replacement-VM hostname.
+
+The maintenance path then created a dedicated Ed25519 SSH key on the operator
+machine and installed the public key for the deploy account. Two details matter
+for future maintainers:
+
+- the `Host ...` SSH alias block belongs in the client-side SSH config, not in
+  the remote Linux shell
+- `authorized_keys` on the VM should contain the full one-line public key,
+  starting with `ssh-ed25519`, with no shell prompt text copied into the file
+
+If the local SSH agent cannot be started because of workstation permissions,
+the key can still be used explicitly with `ssh -i` until the agent is configured
+by an administrator.
+
+The active checkout was not in the shell's current directory. The reliable
+discovery command was:
+
+```bash
+find ~ -maxdepth 3 -type d -name "CytoCV"
+```
+
+The `.env` file was then edited from the real checkout path. Placeholder paths
+such as `/path/to/CytoCV/.env` should never be used literally.
+
+## Code Refresh Path
+
+The deployed repository was on a maintainer/deployment branch name rather than
+a local branch named `main`. The update was still clean because the checkout
+could fast-forward to `origin/main`.
+
+The safe command pattern was:
+
+```bash
+cd /path/to/CytoCV
+git status
+git branch --show-current
+git fetch origin
+git pull --ff-only origin main
+git log --oneline -5
+```
+
+An untracked `cytocv/staticfiles/` directory was present. That directory is
+expected when collected static files are generated on the VM and should not be
+deleted as part of a normal code refresh.
+
+After the pull, the deployment path remained:
+
+```bash
+source cyto_cv/bin/activate
+cd cytocv
+python manage.py migrate
+python manage.py check
+python manage.py collectstatic --noinput
+```
+
+For this refresh, migrations reported no pending work and Django checks passed.
+
+## Database Reset Path
+
+The goal was to delete application data while keeping the PostgreSQL database
+itself. The services were stopped first so Gunicorn and the workers could not
+read or write jobs during the reset:
+
+```bash
+sudo systemctl stop cytocv
+sudo systemctl stop cytocv-upload-prep-worker
+sudo systemctl stop cytocv-analysis-worker
+sudo systemctl stop cytocv-artifact-maintenance.timer
+```
+
+The data reset used Django's schema-preserving flush path:
+
+```bash
+cd /path/to/CytoCV
+source cyto_cv/bin/activate
+cd /path/to/CytoCV/cytocv
+python manage.py flush
+python manage.py migrate
+python manage.py check
+```
+
+This removed database rows but kept the database and schema. It did not remove
+uploaded media or collected static files from disk.
+
+A backup command was attempted after the flush and failed because `pg_dump`
+defaulted to the Linux account instead of the configured PostgreSQL role. That
+did not modify the database. For future resets, run the backup before flushing
+and pass the configured database user explicitly:
+
+```bash
+cd /path/to/CytoCV
+set -a
+source .env
+set +a
+
+PGPASSWORD="$CYTOCV_DB_PASSWORD" pg_dump \
+  -h "${CYTOCV_DB_HOST:-127.0.0.1}" \
+  -p "${CYTOCV_DB_PORT:-5432}" \
+  -U "$CYTOCV_DB_USER" \
+  "$CYTOCV_DB_NAME" > cytocv-before-flush.sql
+```
+
+## Service Restart And Verification
+
+After the flush, the deployment services were started again:
+
+```bash
+sudo systemctl start cytocv
+sudo systemctl start cytocv-upload-prep-worker
+sudo systemctl start cytocv-analysis-worker
+sudo systemctl start cytocv-artifact-maintenance.timer
+```
+
+The expected final service state was:
+
+- `cytocv.service` active with Gunicorn workers running
+- `cytocv-upload-prep-worker.service` active
+- `cytocv-analysis-worker.service` active
+- `cytocv-artifact-maintenance.timer` active and waiting for its next run
+
+The web-service journal showed clean Gunicorn startup after the refresh. Older
+pre-refresh logs still contained an account-email logo MIME subtype error; the
+code refresh included the related fix, and the latest checked startup logs did
+not show a current service failure. A full signup/email smoke test should remain
+part of final user-facing validation whenever account email behavior changes.
+
+Nginx configuration was not changed during this maintenance refresh. The
+documented verification path remains:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+## Issues Encountered And Resolved
+
+- A placeholder `.env` path was initially used literally. The resolution was to
+  locate the real checkout and edit `.env` from the actual repository path.
+- SSH authentication initially failed against an earlier host target. Verbose
+  SSH confirmed the failure was authentication-related rather than a network
+  problem; the replacement-VM hostname and a dedicated SSH key path resolved the
+  access workflow.
+- The client-side SSH config block was accidentally pasted into the remote
+  shell. The resolution was to keep `Host`, `HostName`, `User`, and
+  `IdentityFile` in the workstation SSH config only.
+- Windows SSH agent setup required elevated permissions. The immediate
+  resolution was to use `ssh -i` explicitly; agent setup can be handled later
+  from an elevated shell.
+- The deployed checkout was not named `main`, but it fast-forwarded cleanly to
+  `origin/main`. Future maintainers should stop if `--ff-only` fails.
+- A post-flush `pg_dump` attempt failed because it used the default Linux user
+  instead of the configured PostgreSQL role. Future backup commands should load
+  `.env` and pass `-U "$CYTOCV_DB_USER"` before any destructive reset.
+
+## What To Carry Forward
+
+- Confirm the exact VM hostname before debugging credentials.
+- Prefer dedicated SSH keys and keep public key material as a single line in
+  `authorized_keys`.
+- Locate existing checkouts with `find` before editing deployment files.
+- Use `git pull --ff-only origin main` for clean updates and stop on divergence.
+- Run `migrate`, `check`, and `collectstatic` after code refreshes.
+- Stop Gunicorn and both workers before intentionally flushing production data.
+- Back up PostgreSQL with the configured database role before flushing.
+- Treat `cytocv/staticfiles/` as deployment-generated output unless there is a
+  deliberate static-file cleanup plan.


### PR DESCRIPTION
This pull request adds comprehensive documentation for maintaining and refreshing existing CytoCV VM deployments, including new guidance for code updates and intentional database resets. It introduces a new historical record for the April 2026 cytocv2 maintenance refresh, and updates references throughout the documentation to reflect these additions. The changes aim to clarify operational procedures for maintainers and preserve important historical context.

**Documentation improvements for VM maintenance and refresh:**

* Added a new section on updating code and performing maintenance on existing VMs in `docs/ops/deployment-guide.md`, including safe `git` update patterns, Django deployment checks, and service restarts.
* Added detailed instructions for intentional database data resets, including backup, flush, and service management steps, in `docs/ops/deployment-guide.md`.
* Updated the VM deployment guide (`docs/vm-deployment-guide/README.md`) to reference new maintenance and data reset procedures, and clarified repository discovery for editing deployment files.

**Historical documentation and references:**

* Added a new sanitized historical record for the April 2026 cytocv2 maintenance refresh in `docs/vm-deployment-record-cytocv2-2026-04-maintenance/README.md`, detailing operational lessons and step-by-step actions taken during the refresh.
* Updated `README.md` and `docs/README.md` to reference the new historical maintenance record and clarify the handling of historical project records. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R210) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L17-R17) [[3]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R74)