### PR TITLE
Enhance Signal Quantification with migration, UI updates, and stats control

### DIFF
--- a/cytocv/accounts/preferences.py
+++ b/cytocv/accounts/preferences.py
@@ -408,7 +408,7 @@ def normalize_preferences_payload(raw_payload: Any) -> dict[str, Any]:
         signal_selection.alternate_nucleus_detection_enabled
     )
     normalized["experiment_defaults"]["selected_plugins"] = list(
-        signal_selection.selected_plugins
+        signal_selection.configured_plugins
     )
 
     normalized["auto_save_experiments"] = _as_bool(
@@ -642,7 +642,7 @@ def build_experiment_defaults_from_popup_payload(
             current.get("alternate_nucleus_detection_enabled", True)
         ),
     )
-    selected_plugins = list(signal_selection.selected_plugins)
+    selected_plugins = list(signal_selection.configured_plugins)
 
     show_legacy_plugins = _strict_bool(
         raw_payload.get("show_legacy_plugins"),

--- a/cytocv/accounts/preferences.py
+++ b/cytocv/accounts/preferences.py
@@ -7,12 +7,21 @@ import math
 from typing import Any
 
 from core.channel_roles import CHANNEL_ROLE_ORDER, channel_role_from_slug, channel_slug
+from core.services.biorientation_config import (
+    DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+)
 from core.services.puncta_line_mode import (
     DEFAULT_PUNCTA_LINE_MODE,
     normalize_puncta_line_mode,
 )
 from core.services.green_dot_split import (
     normalize_green_dot_split_mode,
+)
+from core.services.signal_quantification import (
+    DEFAULT_SIGNAL_SELECTED_PLUGINS,
+    SIGNAL_MODE_PUNCTA_DISTANCE,
+    SIGNAL_QUANTIFICATION_MODES,
+    resolve_signal_quantification_selection,
 )
 from core.stats_plugins import (
     ALWAYS_REQUIRED_CHANNELS,
@@ -35,13 +44,11 @@ class PreferenceValidationError(ValueError):
 
 DEFAULT_USER_PREFERENCES: dict[str, Any] = {
     "experiment_defaults": {
-        "selected_plugins": [
-            "PunctaDistance",
-            "CENDot",
-            "Biorientation",
-            "GreenRedIntensity",
-            "NuclearCellPairIntensity",
-        ],
+        "selected_plugins": list(DEFAULT_SIGNAL_SELECTED_PLUGINS),
+        "signal_quantification_enabled": True,
+        "signal_quantification_mode": SIGNAL_MODE_PUNCTA_DISTANCE,
+        "puncta_contour_intensity_enabled": True,
+        "alternate_nucleus_detection_enabled": True,
         "module_enabled": False,
         "enforce_layer_count": False,
         "enforce_wavelengths": False,
@@ -52,7 +59,7 @@ DEFAULT_USER_PREFERENCES: dict[str, Any] = {
         "cen_dot_proximity_radius": 13,
         "biorientation_red_min_distance": 0,
         "biorientation_red_max_distance": 37,
-        "biorientation_collinearity_threshold": 66,
+        "biorientation_collinearity_threshold": DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
         "green_dot_split_enabled": True,
         "green_dot_split_mode": "balanced",
         "puncta_line_mode": DEFAULT_PUNCTA_LINE_MODE,
@@ -234,6 +241,16 @@ def normalize_preferences_payload(raw_payload: Any) -> dict[str, Any]:
         ),
         default=False,
     )
+    normalized["experiment_defaults"]["alternate_nucleus_detection_enabled"] = _as_bool(
+        defaults_payload.get(
+            "alternate_nucleus_detection_enabled",
+            defaults_payload.get(
+                "alternate_red_detection",
+                defaults_payload.get("alternate_mcherry_detection"),
+            ),
+        ),
+        default=True,
+    )
 
     raw_required_channels = defaults_payload.get("manual_required_channels", [])
     if not isinstance(raw_required_channels, list):
@@ -330,7 +347,7 @@ def normalize_preferences_payload(raw_payload: Any) -> dict[str, Any]:
                 defaults_payload.get("gfp_threshold"),
             ),
         ),
-        default=66,
+        default=DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
         minimum=0,
     )
     normalized["experiment_defaults"]["green_dot_split_enabled"] = _as_bool(
@@ -367,6 +384,32 @@ def normalize_preferences_payload(raw_payload: Any) -> dict[str, Any]:
     if mode not in NUCLEAR_CELL_PAIR_MODES:
         mode = "green_nucleus"
     normalized["experiment_defaults"]["nuclear_cell_pair_mode"] = mode
+
+    signal_selection = resolve_signal_quantification_selection(
+        payload=defaults_payload,
+        selected_plugins=normalized["experiment_defaults"]["selected_plugins"],
+        nuclear_cell_pair_mode=mode,
+        puncta_line_mode=normalized["experiment_defaults"]["puncta_line_mode"],
+        default_alternate_nucleus_detection_enabled=normalized[
+            "experiment_defaults"
+        ]["alternate_nucleus_detection_enabled"],
+    )
+    normalized["experiment_defaults"]["signal_quantification_enabled"] = (
+        signal_selection.enabled
+    )
+    normalized["experiment_defaults"]["signal_quantification_mode"] = signal_selection.mode
+    normalized["experiment_defaults"]["puncta_contour_intensity_enabled"] = (
+        signal_selection.puncta_contour_intensity_enabled
+    )
+    normalized["experiment_defaults"]["alternate_nucleus_detection_enabled"] = (
+        signal_selection.alternate_nucleus_detection_enabled
+    )
+    normalized["experiment_defaults"]["alternate_red_detection"] = (
+        signal_selection.alternate_nucleus_detection_enabled
+    )
+    normalized["experiment_defaults"]["selected_plugins"] = list(
+        signal_selection.selected_plugins
+    )
 
     normalized["auto_save_experiments"] = _as_bool(
         raw_payload.get("auto_save_experiments"),
@@ -407,6 +450,10 @@ def build_experiment_defaults_from_popup_payload(
 
     allowed_fields = {
         "selected_plugins",
+        "signal_quantification_enabled",
+        "signal_quantification_mode",
+        "puncta_contour_intensity_enabled",
+        "alternate_nucleus_detection_enabled",
         "module_enabled",
         "enforce_layer_count",
         "enforce_wavelengths",
@@ -558,6 +605,45 @@ def build_experiment_defaults_from_popup_payload(
         allowed={"balanced", "aggressive"},
     )
 
+    signal_payload: dict[str, Any] = {}
+    if "signal_quantification_enabled" in raw_payload:
+        signal_payload["signal_quantification_enabled"] = _strict_bool(
+            raw_payload.get("signal_quantification_enabled"),
+            field="signal_quantification_enabled",
+        )
+    if "signal_quantification_mode" in raw_payload:
+        signal_payload["signal_quantification_mode"] = _strict_mode(
+            raw_payload.get("signal_quantification_mode"),
+            field="signal_quantification_mode",
+            allowed=set(SIGNAL_QUANTIFICATION_MODES),
+        )
+    if "puncta_contour_intensity_enabled" in raw_payload:
+        signal_payload["puncta_contour_intensity_enabled"] = _strict_bool(
+            raw_payload.get("puncta_contour_intensity_enabled"),
+            field="puncta_contour_intensity_enabled",
+        )
+    alternate_detection_field = (
+        "alternate_nucleus_detection_enabled"
+        if "alternate_nucleus_detection_enabled" in raw_payload
+        else "alternate_red_detection"
+    )
+    if alternate_detection_field in raw_payload:
+        signal_payload["alternate_nucleus_detection_enabled"] = _strict_bool(
+            raw_payload.get(alternate_detection_field),
+            field=alternate_detection_field,
+        )
+
+    signal_selection = resolve_signal_quantification_selection(
+        payload=signal_payload,
+        selected_plugins=selected_plugins,
+        nuclear_cell_pair_mode=nuclear_cell_pair_mode,
+        puncta_line_mode=puncta_line_mode,
+        default_alternate_nucleus_detection_enabled=bool(
+            current.get("alternate_nucleus_detection_enabled", True)
+        ),
+    )
+    selected_plugins = list(signal_selection.selected_plugins)
+
     show_legacy_plugins = _strict_bool(
         raw_payload.get("show_legacy_plugins"),
         field="show_legacy_plugins",
@@ -577,6 +663,14 @@ def build_experiment_defaults_from_popup_payload(
     next_defaults.update(
         {
             "selected_plugins": selected_plugins,
+            "signal_quantification_enabled": signal_selection.enabled,
+            "signal_quantification_mode": signal_selection.mode,
+            "puncta_contour_intensity_enabled": (
+                signal_selection.puncta_contour_intensity_enabled
+            ),
+            "alternate_nucleus_detection_enabled": (
+                signal_selection.alternate_nucleus_detection_enabled
+            ),
             "module_enabled": _strict_bool(
                 raw_payload.get("module_enabled"),
                 field="module_enabled",
@@ -600,9 +694,8 @@ def build_experiment_defaults_from_popup_payload(
                 field="green_dot_split_enabled",
             ),
             "green_dot_split_mode": green_dot_split_mode,
-            "alternate_red_detection": _strict_bool(
-                raw_payload.get("alternate_red_detection"),
-                field="alternate_red_detection",
+            "alternate_red_detection": (
+                signal_selection.alternate_nucleus_detection_enabled
             ),
             "puncta_line_width": puncta_line_width,
             "puncta_line_width_unit": puncta_line_width_unit,

--- a/cytocv/accounts/views/profile.py
+++ b/cytocv/accounts/views/profile.py
@@ -61,6 +61,7 @@ from core.services.puncta_line_mode import (
 )
 from core.services.green_dot_split import normalize_green_dot_split_mode
 from core.services.signal_quantification import (
+    resolve_signal_quantification_from_defaults,
     resolve_signal_quantification_selection,
 )
 from core.scale import (
@@ -1220,7 +1221,7 @@ def preferences_view(request: HttpRequest) -> HttpResponse:
                 ),
             )
             next_defaults = dict(defaults)
-            next_defaults["selected_plugins"] = list(signal_selection.selected_plugins)
+            next_defaults["selected_plugins"] = list(signal_selection.configured_plugins)
             next_defaults.update(
                 {
                     "signal_quantification_enabled": signal_selection.enabled,
@@ -1299,7 +1300,7 @@ def preferences_view(request: HttpRequest) -> HttpResponse:
                     )
                 ),
             )
-            selected_plugins = list(signal_selection.selected_plugins)
+            selected_plugins = list(signal_selection.configured_plugins)
 
             next_defaults = dict(defaults)
             next_defaults.update(
@@ -1372,7 +1373,9 @@ def preferences_view(request: HttpRequest) -> HttpResponse:
             return _preferences_redirect(request, section="saving")
 
     plugin_rows = []
-    selected_plugins = set(defaults.get("selected_plugins", []))
+    signal_defaults = resolve_signal_quantification_from_defaults(defaults)
+    selected_plugins = set(signal_defaults.configured_plugins)
+    effective_selected_plugins = set(signal_defaults.selected_plugins)
     for plugin_id in PLUGIN_UI_ORDER:
         definition = PLUGIN_DEFINITIONS[plugin_id]
         plugin_rows.append(
@@ -1392,7 +1395,7 @@ def preferences_view(request: HttpRequest) -> HttpResponse:
 
     required_channel_rows, plugin_requirement_summary = _build_required_channel_rows(
         defaults,
-        list(selected_plugins),
+        list(effective_selected_plugins),
     )
     plugin_dependency_payload = build_plugin_ui_payload()
 

--- a/cytocv/accounts/views/profile.py
+++ b/cytocv/accounts/views/profile.py
@@ -48,6 +48,9 @@ from core.services.artifact_storage import (
     refresh_user_storage_usage,
     sweep_user_run_artifacts,
 )
+from core.services.biorientation_config import (
+    DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+)
 from core.services.cell_statistics_payload import serialize_cell_statistics_payload
 from core.services.main_image_urls import build_main_image_paths
 from core.services.overlay_rendering import build_overlay_image_url, overlay_image_available
@@ -57,6 +60,9 @@ from core.services.puncta_line_mode import (
     normalize_puncta_line_mode,
 )
 from core.services.green_dot_split import normalize_green_dot_split_mode
+from core.services.signal_quantification import (
+    resolve_signal_quantification_selection,
+)
 from core.scale import (
     get_scale_context_payload,
     get_scale_sidebar_payload,
@@ -198,7 +204,7 @@ def _extract_measurement_defaults(
             "biorientation_collinearity_threshold",
             defaults.get("cen_dot_collinearity_threshold"),
         ),
-        default=66,
+        default=DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
         minimum=0,
     )
     current_microns_per_pixel = _parse_positive_float(
@@ -1168,10 +1174,63 @@ def preferences_view(request: HttpRequest) -> HttpResponse:
                     defaults.get("green_dot_split_mode"),
                 )
             )
+            signal_payload: dict[str, object] = {}
+            if "signal_quantification_enabled" in request.POST:
+                signal_payload["signal_quantification_enabled"] = _payload_bool(
+                    request.POST,
+                    "signal_quantification_enabled",
+                    default=bool(defaults.get("signal_quantification_enabled", True)),
+                )
+            if "signal_quantification_mode" in request.POST:
+                signal_payload["signal_quantification_mode"] = request.POST.get(
+                    "signal_quantification_mode",
+                    defaults.get("signal_quantification_mode", "puncta_distance"),
+                )
+            if "puncta_contour_intensity_enabled" in request.POST:
+                signal_payload["puncta_contour_intensity_enabled"] = _payload_bool(
+                    request.POST,
+                    "puncta_contour_intensity_enabled",
+                    default=bool(defaults.get("puncta_contour_intensity_enabled", True)),
+                )
+            if (
+                "alternate_nucleus_detection_enabled" in request.POST
+                or "alternate_red_detection" in request.POST
+            ):
+                signal_payload["alternate_nucleus_detection_enabled"] = _payload_bool(
+                    request.POST,
+                    "alternate_nucleus_detection_enabled",
+                    default=bool(
+                        defaults.get(
+                            "alternate_nucleus_detection_enabled",
+                            defaults.get("alternate_red_detection", False),
+                        )
+                    ),
+                    legacy_key="alternate_red_detection",
+                )
+            signal_selection = resolve_signal_quantification_selection(
+                payload=signal_payload,
+                selected_plugins=selected_plugins,
+                nuclear_cell_pair_mode=measurement_defaults.get(
+                    "nuclear_cell_pair_mode",
+                    defaults.get("nuclear_cell_pair_mode", "green_nucleus"),
+                ),
+                puncta_line_mode=measurement_defaults.get(
+                    "puncta_line_mode",
+                    defaults.get("puncta_line_mode", DEFAULT_PUNCTA_LINE_MODE),
+                ),
+            )
             next_defaults = dict(defaults)
-            next_defaults["selected_plugins"] = selected_plugins
+            next_defaults["selected_plugins"] = list(signal_selection.selected_plugins)
             next_defaults.update(
                 {
+                    "signal_quantification_enabled": signal_selection.enabled,
+                    "signal_quantification_mode": signal_selection.mode,
+                    "puncta_contour_intensity_enabled": (
+                        signal_selection.puncta_contour_intensity_enabled
+                    ),
+                    "alternate_nucleus_detection_enabled": (
+                        signal_selection.alternate_nucleus_detection_enabled
+                    ),
                     "green_contour_filter_enabled": _payload_bool(
                         request.POST,
                         "green_contour_filter_enabled",
@@ -1181,12 +1240,8 @@ def preferences_view(request: HttpRequest) -> HttpResponse:
                     ),
                     "green_dot_split_enabled": green_dot_split_enabled,
                     "green_dot_split_mode": green_dot_split_mode,
-                    "alternate_red_detection": _payload_bool(
-                        request.POST,
-                        "alternate_red_detection",
-                        default=bool(
-                            defaults.get("alternate_red_detection", False)
-                        ),
+                    "alternate_red_detection": (
+                        signal_selection.alternate_nucleus_detection_enabled
                     ),
                 }
             )
@@ -1226,11 +1281,41 @@ def preferences_view(request: HttpRequest) -> HttpResponse:
                         continue
                     kept_plugins.append(plugin_id)
                 selected_plugins = kept_plugins
+            signal_selection = resolve_signal_quantification_selection(
+                payload={},
+                selected_plugins=selected_plugins,
+                nuclear_cell_pair_mode=measurement_defaults.get(
+                    "nuclear_cell_pair_mode",
+                    defaults.get("nuclear_cell_pair_mode", "green_nucleus"),
+                ),
+                puncta_line_mode=measurement_defaults.get(
+                    "puncta_line_mode",
+                    defaults.get("puncta_line_mode", DEFAULT_PUNCTA_LINE_MODE),
+                ),
+                default_alternate_nucleus_detection_enabled=bool(
+                    defaults.get(
+                        "alternate_nucleus_detection_enabled",
+                        defaults.get("alternate_red_detection", False),
+                    )
+                ),
+            )
+            selected_plugins = list(signal_selection.selected_plugins)
 
             next_defaults = dict(defaults)
             next_defaults.update(
                 {
                     "selected_plugins": selected_plugins,
+                    "signal_quantification_enabled": signal_selection.enabled,
+                    "signal_quantification_mode": signal_selection.mode,
+                    "puncta_contour_intensity_enabled": (
+                        signal_selection.puncta_contour_intensity_enabled
+                    ),
+                    "alternate_nucleus_detection_enabled": (
+                        signal_selection.alternate_nucleus_detection_enabled
+                    ),
+                    "alternate_red_detection": (
+                        signal_selection.alternate_nucleus_detection_enabled
+                    ),
                     "module_enabled": module_enabled,
                     "enforce_layer_count": enforce_layer_count,
                     "enforce_wavelengths": enforce_wavelengths,

--- a/cytocv/core/cell_analysis/biorientation.py
+++ b/cytocv/core/cell_analysis/biorientation.py
@@ -1,6 +1,9 @@
 import logging
 import math
 
+from core.services.biorientation_config import (
+    DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+)
 from core.services.canonical_contours import (
     get_canonical_green_slots,
     get_canonical_red_slots,
@@ -68,8 +71,11 @@ class Biorientation(Analysis):
             default=37.0,
         )
         collinearity_threshold = _coerce_float(
-            properties.get("stats_biorientation_collinearity_threshold", 66),
-            default=66,
+            properties.get(
+                "stats_biorientation_collinearity_threshold",
+                DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+            ),
+            default=float(DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX),
         )
         min_unit = normalize_length_unit(
             properties.get("stats_biorientation_red_min_distance_unit"),
@@ -138,16 +144,18 @@ class Biorientation(Analysis):
             self.cp.off_axis_dots = 0
 
     @staticmethod
-    def _is_collinear(point, endpoint1, endpoint2, eps) -> bool:
+    def _is_collinear(point, endpoint1, endpoint2, threshold_px) -> bool:
         px, py = float(point[0]), float(point[1])
         x1, y1 = float(endpoint1[0]), float(endpoint1[1])
         x2, y2 = float(endpoint2[0]), float(endpoint2[1])
         dx = x2 - x1
         dy = y2 - y1
-        cross = (py - y1) * dx - (px - x1) * dy
-        if abs(cross) > eps:
-            return False
-
-        dot = (px - x1) * dx + (py - y1) * dy
         squared_dist = dx * dx + dy * dy
+        if squared_dist <= 0.0:
+            return False
+        cross = (py - y1) * dx - (px - x1) * dy
+        off_axis_distance = abs(cross) / math.sqrt(squared_dist)
+        if off_axis_distance > threshold_px:
+            return False
+        dot = (px - x1) * dx + (py - y1) * dy
         return not (dot < 0 or dot > squared_dist)

--- a/cytocv/core/cell_analysis/green_red_intensity.py
+++ b/cytocv/core/cell_analysis/green_red_intensity.py
@@ -6,9 +6,10 @@ from core.services.canonical_contours import (
     get_canonical_red_slots,
 )
 from core.services.measurement_contour_ratio import (
-    normalize_nuclear_cell_pair_mode,
+    normalize_measurement_contour_ratio_mode,
     store_measurement_contour_ratio_triplet,
 )
+from core.services.signal_quantification import measurement_ratio_mode_for_puncta_line_mode
 from .analysis import Analysis
 
 
@@ -45,8 +46,14 @@ class GreenRedIntensity(Analysis):
         if green_gray is None:
             green_gray = self.preprocessed_images.get_image("green")
         props = dict(getattr(self.cp, "properties", {}) or {})
-        mode = normalize_nuclear_cell_pair_mode(props.get("nuclear_cell_pair_mode"))
-        props["nuclear_cell_pair_mode"] = mode
+        if props.get("measurement_contour_ratio_mode"):
+            mode_source = props.get("measurement_contour_ratio_mode")
+        elif props.get("signal_quantification_mode") == "puncta_distance":
+            mode_source = measurement_ratio_mode_for_puncta_line_mode(props.get("puncta_line_mode"))
+        else:
+            mode_source = props.get("nuclear_cell_pair_mode")
+        mode = normalize_measurement_contour_ratio_mode(mode_source)
+        props["measurement_contour_ratio_mode"] = mode
         self.cp.properties = props
         if red_gray is None or green_gray is None:
             self._set_default_triplet("red_intensity")

--- a/cytocv/core/cell_analysis/nuclear_cell_pair_intensity.py
+++ b/cytocv/core/cell_analysis/nuclear_cell_pair_intensity.py
@@ -1,20 +1,19 @@
 import cv2
 import numpy as np
 
-from core.image_processing.dashed_line import draw_dashed_polyline
 from core.services.canonical_contours import (
+    CANONICAL_ALTERNATE_GREEN_SLOTS_KEY,
+    CANONICAL_ALTERNATE_RED_SLOTS_KEY,
     get_canonical_green_slots,
     get_canonical_red_slots,
     load_cell_mask,
 )
+from core.channel_roles import CHANNEL_ROLE_GREEN, CHANNEL_ROLE_RED
 from .analysis import Analysis
 
 
 class NuclearCellPairIntensity(Analysis):
     name = "Nuclear, Cell-Pair Intensity"
-
-    # Temporary release toggle: keep overlay logic available but disabled by default.
-    _DRAW_NUCLEAR_CONTOUR_OVERLAY = False
 
     _MODE_CONFIG = {
         "green_nucleus": (
@@ -39,18 +38,24 @@ class NuclearCellPairIntensity(Analysis):
         return None
 
     @staticmethod
-    def _draw_dashed_contour(image, contour, color=(0, 255, 255), dash_px=2, gap_px=2, thickness=1):
-        if image is None or contour is None or len(contour) < 2:
+    def _resolved_alternate_target_channel(props: dict) -> str | None:
+        raw_enabled = props.get("alternate_nucleus_detection_enabled")
+        if isinstance(raw_enabled, str):
+            normalized = raw_enabled.strip().lower()
+            if normalized in {"0", "false", "no", "off"}:
+                return None
+        elif raw_enabled is False or raw_enabled == 0:
+            return None
+        return props.get("alternate_nucleus_detection_channel")
+
+    @staticmethod
+    def _draw_nucleus_contour(red_image, green_image, contour, mode: str) -> None:
+        if contour is None or len(contour) < 2:
             return
-        draw_dashed_polyline(
-            image,
-            contour.reshape(-1, 2),
-            color,
-            closed=True,
-            dash_px=dash_px,
-            gap_px=gap_px,
-            thickness=thickness,
-        )
+        color = (0, 0, 255) if mode == "red_nucleus" else (0, 255, 0)
+        for image in (red_image, green_image):
+            if image is not None:
+                cv2.drawContours(image, [contour], -1, color, 1)
 
     def calculate_statistics(
         self,
@@ -100,11 +105,21 @@ class NuclearCellPairIntensity(Analysis):
 
         slot_payload = dict(contours_data or {})
         slot_payload["cell_mask"] = cell_mask
+        alternate_target_channel = self._resolved_alternate_target_channel(props)
         if mode == "red_nucleus":
-            source_slots = get_canonical_red_slots(slot_payload, (h, w), limit=1)
+            if alternate_target_channel == CHANNEL_ROLE_RED:
+                source_slots = list(slot_payload.get(CANONICAL_ALTERNATE_RED_SLOTS_KEY, []))[:1]
+                used_contour_source = "alternate_red_nucleus_slot_1"
+            else:
+                source_slots = get_canonical_red_slots(slot_payload, (h, w), limit=1)
+                used_contour_source = "canonical_slot_1"
         else:
-            source_slots = get_canonical_green_slots(slot_payload, (h, w), limit=1)
-        used_contour_source = "canonical_slot_1"
+            if alternate_target_channel == CHANNEL_ROLE_GREEN:
+                source_slots = list(slot_payload.get(CANONICAL_ALTERNATE_GREEN_SLOTS_KEY, []))[:1]
+                used_contour_source = "alternate_green_nucleus_slot_1"
+            else:
+                source_slots = get_canonical_green_slots(slot_payload, (h, w), limit=1)
+                used_contour_source = "canonical_slot_1"
 
         if not source_slots:
             self.cp.nucleus_intensity_sum = 0.0
@@ -144,8 +159,4 @@ class NuclearCellPairIntensity(Analysis):
         props["nuclear_cell_pair_status"] = "ok"
         self.cp.properties = props
 
-        if self._DRAW_NUCLEAR_CONTOUR_OVERLAY:
-            if red_image is not None:
-                self._draw_dashed_contour(red_image, largest_contour, color=(0, 255, 255), dash_px=2, gap_px=2, thickness=1)
-            if green_image is not None:
-                self._draw_dashed_contour(green_image, largest_contour, color=(0, 255, 255), dash_px=2, gap_px=2, thickness=1)
+        self._draw_nucleus_contour(red_image, green_image, largest_contour, mode)

--- a/cytocv/core/contour_processing/contour_operations.py
+++ b/cytocv/core/contour_processing/contour_operations.py
@@ -9,6 +9,11 @@ from skimage.segmentation import find_boundaries, watershed
 
 from core.contour_processing import get_largest
 from core.image_processing import GrayImage
+from core.channel_roles import (
+    CHANNEL_ROLE_GREEN,
+    CHANNEL_ROLE_RED,
+    normalize_channel_role,
+)
 from core.services.green_dot_split import (
     DEFAULT_GREEN_DOT_SPLIT_MODE,
     normalize_green_dot_split_mode,
@@ -2258,12 +2263,125 @@ def _split_merged_green_contours(
     return split_mask
 
 
+def _should_bridge_alternate_contours(gray_blue: np.ndarray | None) -> bool:
+    if gray_blue is None:
+        return False
+    gray_blue_blur = cv2.GaussianBlur(gray_blue, (9, 9), 0)
+    _, thresh_blue_blur = cv2.threshold(
+        gray_blue_blur,
+        40,
+        255,
+        cv2.THRESH_BINARY,
+    )
+    blue_blur_contours, _ = cv2.findContours(
+        thresh_blue_blur,
+        cv2.RETR_EXTERNAL,
+        cv2.CHAIN_APPROX_SIMPLE,
+    )
+    blue_blur_contours = [
+        cnt for cnt in blue_blur_contours if cv2.contourArea(cnt) >= 150
+    ]
+    return len(blue_blur_contours) < 2
+
+
+def _alternate_channel_contour_family(
+    *,
+    bright_image: np.ndarray | None,
+    base_image: np.ndarray | None,
+    bridge_contours: bool,
+) -> tuple[list[np.ndarray], list[np.ndarray], list[int], list[np.ndarray], list[int]]:
+    """Return alternate dot/base contour sets using the legacy low-threshold path."""
+
+    dot_contours: list[np.ndarray] = []
+    contours: list[np.ndarray] = []
+    contours_bright: list[np.ndarray] = []
+    best_contours: list[int] = []
+    best_contours_bright: list[int] = []
+    bright_thresh = None
+
+    if bright_image is not None:
+        blurred_bright = cv2.GaussianBlur(bright_image, (9, 9), 0)
+        _, bright_thresh = cv2.threshold(
+            blurred_bright,
+            5,
+            255,
+            cv2.THRESH_BINARY,
+        )
+        dot_contours, _ = cv2.findContours(
+            bright_thresh,
+            cv2.RETR_EXTERNAL,
+            cv2.CHAIN_APPROX_SIMPLE,
+        )
+
+    if bright_thresh is not None and base_image is not None:
+        _, thresh = cv2.threshold(
+            base_image,
+            5,
+            255,
+            cv2.THRESH_BINARY,
+        )
+        contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        contours_bright, _ = cv2.findContours(
+            bright_thresh,
+            cv2.RETR_EXTERNAL,
+            cv2.CHAIN_APPROX_SIMPLE,
+        )
+        best_contours = get_largest(contours)
+        best_contours_bright = get_largest(contours_bright)
+
+        if bridge_contours and (len(best_contours) > 1 or len(best_contours_bright) > 1):
+            _, bright_thresh = cv2.threshold(
+                bright_image,
+                4,
+                255,
+                cv2.THRESH_BINARY,
+            )
+            dot_contours, _ = cv2.findContours(
+                bright_thresh,
+                cv2.RETR_EXTERNAL,
+                cv2.CHAIN_APPROX_SIMPLE,
+            )
+            _, thresh = cv2.threshold(
+                base_image,
+                4,
+                255,
+                cv2.THRESH_BINARY,
+            )
+            contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+            contours_bright, _ = cv2.findContours(
+                bright_thresh,
+                cv2.RETR_EXTERNAL,
+                cv2.CHAIN_APPROX_SIMPLE,
+            )
+            best_contours = get_largest(contours)
+            best_contours_bright = get_largest(contours_bright)
+
+    return dot_contours, contours, best_contours, contours_bright, best_contours_bright
+
+
+def _alternate_nucleus_contours_from_family(
+    *,
+    bright_image: np.ndarray | None,
+    base_image: np.ndarray | None,
+    bridge_contours: bool,
+) -> list[np.ndarray]:
+    dot_contours, contours, _, _, _ = _alternate_channel_contour_family(
+        bright_image=bright_image,
+        base_image=base_image,
+        bridge_contours=bridge_contours,
+    )
+    return dot_contours or contours
+
+
 def find_contours(
     images: GrayImage,
     green_contour_filter_enabled: bool = False,
     alternate_red_detection: bool = False,
     green_dot_split_enabled: bool = True,
     green_dot_split_mode: str = DEFAULT_GREEN_DOT_SPLIT_MODE,
+    *,
+    alternate_detection_channel: str | None = None,
+    skip_standard_contour_channels=None,
 ):
     """
     Find red dot contours, blue nucleus contours, and green signal contours.
@@ -2282,9 +2400,28 @@ def find_contours(
     contours_red = []
     best_contours = []
     best_contours_red = []
+    alternate_nucleus_contours_red = []
+    alternate_nucleus_contours_green = []
+    normalized_alternate_channel = normalize_channel_role(alternate_detection_channel)
+    legacy_alternate_red_detection = (
+        bool(alternate_red_detection) and normalized_alternate_channel is None
+    )
+    skipped_standard_channels = {
+        normalized
+        for normalized in (
+            normalize_channel_role(channel)
+            for channel in (skip_standard_contour_channels or ())
+        )
+        if normalized
+    }
+    skip_standard_red = (
+        CHANNEL_ROLE_RED in skipped_standard_channels
+        and not legacy_alternate_red_detection
+    )
+    skip_standard_green = CHANNEL_ROLE_GREEN in skipped_standard_channels
 
-    if not alternate_red_detection:
-        if gray_red_3 is not None:
+    if not legacy_alternate_red_detection:
+        if gray_red_3 is not None and not skip_standard_red:
             low_val, _ = cv2.threshold(
                 gray_red_3,
                 0.65,
@@ -2306,7 +2443,7 @@ def find_contours(
 
         thresh_red = None
         thresh = None
-        if gray_red_3 is not None and gray_red is not None:
+        if gray_red_3 is not None and gray_red is not None and not skip_standard_red:
             thresh_red = cv2.Canny(gray_red_3, 50, 150)
             thresh = cv2.Canny(gray_red, 50, 150)
 
@@ -2334,90 +2471,25 @@ def find_contours(
             )
             best_contours = get_largest(contours)
             best_contours_red = get_largest(contours_red)
-    else: # Alternate mode
-        # Flag for trying to connect red signals
-        bridge_red = False
+    else:
+        (
+            dot_contours,
+            contours,
+            best_contours,
+            contours_red,
+            best_contours_red,
+        ) = _alternate_channel_contour_family(
+            bright_image=gray_red_3,
+            base_image=gray_red,
+            bridge_contours=_should_bridge_alternate_contours(gray_blue),
+        )
 
-        # Find the number of blue contours
-        if gray_blue is not None:
-            gray_blue_blur = cv2.GaussianBlur(gray_blue, (9, 9), 0)
-            _, thresh_blue_blur = cv2.threshold(
-                gray_blue_blur,
-                40,
-                255,
-                cv2.THRESH_BINARY,
-            )
-            blue_blur_contours, _ = cv2.findContours(
-                thresh_blue_blur,
-                cv2.RETR_EXTERNAL,
-                cv2.CHAIN_APPROX_SIMPLE,
-            )
-            blue_blur_contours = [cnt for cnt in blue_blur_contours if cv2.contourArea(cnt) >= 150]
-            bridge_red = len(blue_blur_contours) < 2
-
-        if gray_red_3 is not None:
-            gray_red_3 = cv2.GaussianBlur(gray_red_3, (9, 9), 0)
-            _, bright_thresh = cv2.threshold(
-                gray_red_3,
-                5,
-                255,
-                cv2.THRESH_BINARY,
-            )
-            # NOTE: Adaptive doesn't work well when there are strong signals
-            dot_contours, _ = cv2.findContours(
-                bright_thresh,
-                cv2.RETR_EXTERNAL,
-                cv2.CHAIN_APPROX_SIMPLE,
-            )
-        if gray_red_3 is not None and gray_red is not None:
-            _, thresh = cv2.threshold(
-                gray_red,
-                5,
-                255,
-                cv2.THRESH_BINARY,
-            )
-            thresh_red = bright_thresh
-            contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-            contours_red, _ = cv2.findContours(
-                thresh_red,
-                cv2.RETR_EXTERNAL,
-                cv2.CHAIN_APPROX_SIMPLE,
-            )
-            best_contours = get_largest(contours)
-            best_contours_red = get_largest(contours_red)
-
-            # Checking whether we need to try to connect red contours
-            if bridge_red and (len(best_contours) > 1 or len(best_contours_red) > 1):
-                # Try lower thresholds to connect red contours
-                # NOTE: Other approaches have been tried, such as morphological ops and geometric bridging.
-                # However, they were decided against due to basically making up the data.
-                if gray_red_3 is not None and gray_red is not None:
-                    _, bright_thresh = cv2.threshold(
-                        gray_red_3,
-                        4,
-                        255,
-                        cv2.THRESH_BINARY,
-                    )
-                    dot_contours, _ = cv2.findContours(
-                        bright_thresh,
-                        cv2.RETR_EXTERNAL,
-                        cv2.CHAIN_APPROX_SIMPLE,
-                    )
-                    _, thresh = cv2.threshold(
-                        gray_red,
-                        4,
-                        255,
-                        cv2.THRESH_BINARY,
-                    )
-                    thresh_red = bright_thresh
-                    contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-                    contours_red, _ = cv2.findContours(
-                        thresh_red,
-                        cv2.RETR_EXTERNAL,
-                        cv2.CHAIN_APPROX_SIMPLE,
-                    )
-                    best_contours = get_largest(contours)
-                    best_contours_red = get_largest(contours_red)
+    if normalized_alternate_channel == CHANNEL_ROLE_RED and not legacy_alternate_red_detection:
+        alternate_nucleus_contours_red = _alternate_nucleus_contours_from_family(
+            bright_image=gray_red_3,
+            base_image=gray_red,
+            bridge_contours=_should_bridge_alternate_contours(gray_blue),
+        )
 
 
     contours_blue = []
@@ -2465,7 +2537,7 @@ def find_contours(
         best_contours_blue_3 = get_largest(contours_blue_3) if contours_blue_3 else []
 
     contours_green = []
-    if gray_green is not None:
+    if gray_green is not None and not skip_standard_green:
         low_val, _ = cv2.threshold(
             gray_green,
             0.65,
@@ -2514,6 +2586,13 @@ def find_contours(
                 gray_green,
             )
 
+    if normalized_alternate_channel == CHANNEL_ROLE_GREEN:
+        alternate_nucleus_contours_green = _alternate_nucleus_contours_from_family(
+            bright_image=gray_green,
+            base_image=gray_green_no_bg if gray_green_no_bg is not None else gray_green,
+            bridge_contours=_should_bridge_alternate_contours(gray_blue),
+        )
+
     return {
         "best_contours": best_contours,
         "best_contours_red": best_contours_red,
@@ -2525,6 +2604,8 @@ def find_contours(
         "best_contours_blue_3": best_contours_blue_3,
         "dot_contours": dot_contours,
         "contours_green": contours_green,
+        "alternate_nucleus_contours_red": alternate_nucleus_contours_red,
+        "alternate_nucleus_contours_green": alternate_nucleus_contours_green,
     }
 
 

--- a/cytocv/core/services/analysis_context.py
+++ b/cytocv/core/services/analysis_context.py
@@ -9,6 +9,9 @@ from uuid import UUID
 from django.conf import settings
 
 from accounts.preferences import should_auto_save_experiments
+from core.services.biorientation_config import (
+    DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+)
 from core.services.puncta_line_mode import (
     DEFAULT_PUNCTA_LINE_MODE,
     normalize_puncta_line_mode,
@@ -17,10 +20,19 @@ from core.services.green_dot_split import (
     DEFAULT_GREEN_DOT_SPLIT_MODE,
     normalize_green_dot_split_mode,
 )
+from core.services.signal_quantification import (
+    SIGNAL_MODE_PUNCTA_DISTANCE,
+    resolve_signal_quantification_selection,
+)
 
 NUCLEAR_CELL_PAIR_MODES = frozenset({"green_nucleus", "red_nucleus"})
 DEFAULT_ANALYSIS_CONFIG_SNAPSHOT = {
     "selected_analysis": [],
+    "signalQuantificationEnabled": True,
+    "signalQuantificationMode": SIGNAL_MODE_PUNCTA_DISTANCE,
+    "punctaContourIntensityEnabled": True,
+    "alternateNucleusDetectionEnabled": False,
+    "alternateNucleusDetectionChannel": None,
     "punctaLineWidth": 1,
     "cenDotDistance": 37,
     "stats_puncta_line_width_unit": "px",
@@ -31,7 +43,7 @@ DEFAULT_ANALYSIS_CONFIG_SNAPSHOT = {
     "stats_cen_dot_distance_value": 37.0,
     "biorientationRedMinDistance": 0,
     "biorientationRedMaxDistance": 37,
-    "biorientationCollinearityThreshold": 66,
+    "biorientationCollinearityThreshold": DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
     "greenDotSplitEnabled": True,
     "greenDotSplitMode": DEFAULT_GREEN_DOT_SPLIT_MODE,
     "stats_biorientation_red_min_distance_unit": "px",
@@ -125,9 +137,10 @@ def normalize_execution_mode(value: object | None = None) -> str:
 def normalize_analysis_config_snapshot(snapshot: dict[str, object] | None) -> dict[str, object]:
     """Normalize a persisted analysis snapshot back into safe runtime values."""
 
+    source_snapshot = snapshot if isinstance(snapshot, dict) else {}
     payload = dict(DEFAULT_ANALYSIS_CONFIG_SNAPSHOT)
-    if snapshot:
-        payload.update(snapshot)
+    if source_snapshot:
+        payload.update(source_snapshot)
 
     selected_analysis = payload.get("selected_analysis") or []
     if not isinstance(selected_analysis, list):
@@ -151,9 +164,36 @@ def normalize_analysis_config_snapshot(snapshot: dict[str, object] | None) -> di
         ),
         default=DEFAULT_ANALYSIS_CONFIG_SNAPSHOT["puncta_line_mode"],
     )
+    signal_payload = {
+        key: payload.get(key)
+        for key in (
+            "signalQuantificationEnabled",
+            "signalQuantificationMode",
+            "punctaContourIntensityEnabled",
+            "alternateNucleusDetectionEnabled",
+            "alternateRedDetection",
+            "alternateMCherryDetection",
+        )
+        if key in source_snapshot
+    }
+    signal_selection = resolve_signal_quantification_selection(
+        payload=signal_payload,
+        selected_plugins=selected_analysis,
+        nuclear_cell_pair_mode=nuclear_cell_pair_mode,
+        puncta_line_mode=puncta_line_mode,
+        default_alternate_nucleus_detection_enabled=_parse_bool(
+            payload.get("alternateNucleusDetectionEnabled", payload.get("alternateRedDetection")),
+            default=False,
+        ),
+    )
 
     normalized = {
-        "selected_analysis": [str(item) for item in selected_analysis if str(item)],
+        "selected_analysis": list(signal_selection.selected_plugins),
+        "signalQuantificationEnabled": signal_selection.enabled,
+        "signalQuantificationMode": signal_selection.mode,
+        "punctaContourIntensityEnabled": signal_selection.puncta_contour_intensity_enabled,
+        "alternateNucleusDetectionEnabled": signal_selection.alternate_nucleus_detection_enabled,
+        "alternateNucleusDetectionChannel": signal_selection.alternate_nucleus_detection_channel,
         "punctaLineWidth": _parse_int(
             payload.get(
                 "punctaLineWidth",
@@ -256,10 +296,7 @@ def normalize_analysis_config_snapshot(snapshot: dict[str, object] | None) -> di
             payload.get("greenContourFilterEnabled", payload.get("gfpFilterEnabled")),
             default=False,
         ),
-        "alternateRedDetection": _parse_bool(
-            payload.get("alternateRedDetection", payload.get("alternateMCherryDetection")),
-            default=False,
-        ),
+        "alternateRedDetection": signal_selection.alternate_nucleus_detection_enabled,
         "auto_save_experiments": _parse_bool(
             payload.get("auto_save_experiments"),
             default=True,
@@ -274,6 +311,29 @@ def build_analysis_config_snapshot(request) -> dict[str, object]:
 
     snapshot = {
         "selected_analysis": request.session.get("selected_analysis", []),
+        "signalQuantificationEnabled": request.session.get(
+            "signalQuantificationEnabled",
+            request.session.get("signal_quantification_enabled", True),
+        ),
+        "signalQuantificationMode": request.session.get(
+            "signalQuantificationMode",
+            request.session.get("signal_quantification_mode", SIGNAL_MODE_PUNCTA_DISTANCE),
+        ),
+        "punctaContourIntensityEnabled": request.session.get(
+            "punctaContourIntensityEnabled",
+            request.session.get("puncta_contour_intensity_enabled", True),
+        ),
+        "alternateNucleusDetectionEnabled": request.session.get(
+            "alternateNucleusDetectionEnabled",
+            request.session.get(
+                "alternate_nucleus_detection_enabled",
+                request.session.get("alternateRedDetection", False),
+            ),
+        ),
+        "alternateNucleusDetectionChannel": request.session.get(
+            "alternateNucleusDetectionChannel",
+            request.session.get("alternate_nucleus_detection_channel"),
+        ),
         "punctaLineWidth": request.session.get(
             "punctaLineWidth",
             request.session.get("redLineWidth", request.session.get("mCherryWidth", 1)),
@@ -301,7 +361,10 @@ def build_analysis_config_snapshot(request) -> dict[str, object]:
         ),
         "biorientationCollinearityThreshold": request.session.get(
             "biorientationCollinearityThreshold",
-            request.session.get("cenDotCollinearityThreshold", 66),
+            request.session.get(
+                "cenDotCollinearityThreshold",
+                DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+            ),
         ),
         "greenDotSplitEnabled": request.session.get(
             "greenDotSplitEnabled",

--- a/cytocv/core/services/biorientation_config.py
+++ b/cytocv/core/services/biorientation_config.py
@@ -1,0 +1,5 @@
+"""Shared settings for biorientation collinearity classification."""
+
+from __future__ import annotations
+
+DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX = 3

--- a/cytocv/core/services/canonical_contours.py
+++ b/cytocv/core/services/canonical_contours.py
@@ -22,6 +22,8 @@ from core.services.neck_split import (
 CELL_MASK_KEY = "cell_mask"
 CANONICAL_RED_SLOTS_KEY = "canonical_red_slots"
 CANONICAL_GREEN_SLOTS_KEY = "canonical_green_slots"
+CANONICAL_ALTERNATE_RED_SLOTS_KEY = "canonical_alternate_red_slots"
+CANONICAL_ALTERNATE_GREEN_SLOTS_KEY = "canonical_alternate_green_slots"
 CANONICAL_BLUE_SLOTS_KEY = "canonical_blue_slots"
 NECK_SPLIT_KEY = "neck_split"
 MOTHER_MASK_KEY = "mother_mask"
@@ -218,6 +220,20 @@ def build_canonical_contour_payload(
         height_width,
         limit=limit,
     )
+    if payload.get("alternate_nucleus_contours_red") is not None:
+        payload[CANONICAL_ALTERNATE_RED_SLOTS_KEY] = build_canonical_contour_slots(
+            payload.get("alternate_nucleus_contours_red", []),
+            cell_mask,
+            height_width,
+            limit=limit,
+        )
+    if payload.get("alternate_nucleus_contours_green") is not None:
+        payload[CANONICAL_ALTERNATE_GREEN_SLOTS_KEY] = build_canonical_contour_slots(
+            payload.get("alternate_nucleus_contours_green", []),
+            cell_mask,
+            height_width,
+            limit=limit,
+        )
     payload[CANONICAL_BLUE_SLOTS_KEY] = build_canonical_contour_slots(
         _select_raw_blue_contours(payload, height_width),
         cell_mask,

--- a/cytocv/core/services/cell_statistics_payload.py
+++ b/cytocv/core/services/cell_statistics_payload.py
@@ -12,6 +12,7 @@ from core.services.measurement_contour_ratio import (
 )
 from core.services.puncta_line_mode import get_puncta_line_mode_metadata
 from core.services.cell_parentage import cell_parentage_payload_from_properties
+from core.services.signal_quantification import build_stat_visibility
 
 
 def normalize_channel_display_name(value: Any, default: str = "") -> str:
@@ -42,8 +43,37 @@ def serialize_cell_statistics_payload(
     puncta_line_metadata = get_puncta_line_mode_metadata(
         properties.get("puncta_line_mode")
     )
+    selected_analysis = properties.get("selected_analysis")
+    if isinstance(selected_analysis, list):
+        stat_visibility = build_stat_visibility(selected_analysis)
+    else:
+        stat_visibility = properties.get("stat_visibility")
+        if not isinstance(stat_visibility, dict):
+            stat_visibility = {
+                "puncta_distance": True,
+                "red_green_intensity": True,
+                "nuclear_cell_pair_intensity": True,
+                "cen_dot": True,
+                "biorientation": True,
+                "legacy_blue_intensity": True,
+            }
+    measurement_contour_ratio_mode = properties.get(
+        "measurement_contour_ratio_mode",
+        nuclear_cell_pair_mode,
+    )
 
     return {
+        "selected_analysis": selected_analysis if isinstance(selected_analysis, list) else [],
+        "stat_visibility": stat_visibility,
+        "signal_quantification_enabled": properties.get("signal_quantification_enabled"),
+        "signal_quantification_mode": properties.get("signal_quantification_mode"),
+        "puncta_contour_intensity_enabled": properties.get("puncta_contour_intensity_enabled"),
+        "alternate_nucleus_detection_enabled": properties.get(
+            "alternate_nucleus_detection_enabled"
+        ),
+        "alternate_nucleus_detection_channel": properties.get(
+            "alternate_nucleus_detection_channel"
+        ),
         "puncta_distance": cell_stat.puncta_distance,
         "puncta_line_intensity": cell_stat.puncta_line_intensity,
         "blue_contour_size": cell_stat.blue_contour_size,
@@ -120,6 +150,9 @@ def serialize_cell_statistics_payload(
             ),
             default="Red",
         ),
+        "nuclear_cell_pair_contour_source": properties.get(
+            "nuclear_cell_pair_contour_source"
+        ),
         "nuclear_cell_pair_status": properties.get(
             "nuclear_cell_pair_status",
             properties.get("nuclear_cellular_status", "unknown"),
@@ -140,6 +173,6 @@ def serialize_cell_statistics_payload(
         "off_axis_dots": cell_stat.off_axis_dots,
         **build_measurement_contour_ratio_payload(
             cell_stat,
-            mode=nuclear_cell_pair_mode,
+            mode=measurement_contour_ratio_mode,
         ),
     }

--- a/cytocv/core/services/measurement_contour_ratio.py
+++ b/cytocv/core/services/measurement_contour_ratio.py
@@ -8,6 +8,15 @@ from typing import Any
 
 DEFAULT_NUCLEAR_CELL_PAIR_MODE = "green_nucleus"
 VALID_NUCLEAR_CELL_PAIR_MODES = frozenset({"green_nucleus", "red_nucleus"})
+DEFAULT_MEASUREMENT_CONTOUR_RATIO_MODE = "green_contour"
+VALID_MEASUREMENT_CONTOUR_RATIO_MODES = frozenset(
+    {
+        "green_nucleus",
+        "red_nucleus",
+        "green_contour",
+        "red_contour",
+    }
+)
 
 _MODE_RATIO_CONFIG = {
     "red_nucleus": {
@@ -16,7 +25,19 @@ _MODE_RATIO_CONFIG = {
         "numerator_prefix": "green_intensity",
         "denominator_prefix": "red_intensity",
     },
+    "red_contour": {
+        "pair_label": "Green/Red",
+        "formula_text": "Green In Red / Red In Red",
+        "numerator_prefix": "green_intensity",
+        "denominator_prefix": "red_intensity",
+    },
     "green_nucleus": {
+        "pair_label": "Red/Green",
+        "formula_text": "Red In Green / Green In Green",
+        "numerator_prefix": "red_in_green_intensity",
+        "denominator_prefix": "green_in_green_intensity",
+    },
+    "green_contour": {
         "pair_label": "Red/Green",
         "formula_text": "Red In Green / Green In Green",
         "numerator_prefix": "red_in_green_intensity",
@@ -31,6 +52,16 @@ def normalize_nuclear_cell_pair_mode(
 ) -> str:
     """Return a supported nucleus/cell-pair mode."""
     if value in VALID_NUCLEAR_CELL_PAIR_MODES:
+        return str(value)
+    return default
+
+
+def normalize_measurement_contour_ratio_mode(
+    value: str | None,
+    default: str = DEFAULT_MEASUREMENT_CONTOUR_RATIO_MODE,
+) -> str:
+    """Return a supported measurement/contour ratio mode."""
+    if value in VALID_MEASUREMENT_CONTOUR_RATIO_MODES:
         return str(value)
     return default
 
@@ -50,7 +81,7 @@ def _float_or_zero(value: Any) -> float:
 
 def get_measurement_contour_ratio_metadata(mode: str | None = None) -> dict[str, str]:
     """Return the public label metadata for the selected ratio mode."""
-    normalized_mode = normalize_nuclear_cell_pair_mode(mode)
+    normalized_mode = normalize_measurement_contour_ratio_mode(mode)
     config = _MODE_RATIO_CONFIG[normalized_mode]
     pair_label = str(config["pair_label"])
     formula_text = str(config["formula_text"])
@@ -70,7 +101,13 @@ def calculate_measurement_contour_ratio_value(
 ) -> float:
     """Calculate a single measurement/contour ratio value from raw sums."""
     metadata = get_measurement_contour_ratio_metadata(
-        mode if mode is not None else _source_value(source, "nuclear_cell_pair_mode")
+        mode
+        if mode is not None
+        else _source_value(
+            source,
+            "measurement_contour_ratio_mode",
+        )
+        or _source_value(source, "nuclear_cell_pair_mode")
     )
     config = _MODE_RATIO_CONFIG[metadata["mode"]]
     numerator = _float_or_zero(
@@ -92,8 +129,8 @@ def calculate_measurement_contour_ratio_triplet(
     """Calculate all three measurement/contour ratio slots from raw sums."""
     normalized_mode = mode if mode is not None else _source_value(
         source,
-        "nuclear_cell_pair_mode",
-    )
+        "measurement_contour_ratio_mode",
+    ) or _source_value(source, "nuclear_cell_pair_mode")
     return tuple(
         calculate_measurement_contour_ratio_value(
             source,
@@ -123,7 +160,13 @@ def build_measurement_contour_ratio_payload(
 ) -> dict[str, Any]:
     """Expose public ratio keys and labels for display, dashboard, and export."""
     metadata = get_measurement_contour_ratio_metadata(
-        mode if mode is not None else _source_value(source, "nuclear_cell_pair_mode")
+        mode
+        if mode is not None
+        else _source_value(
+            source,
+            "measurement_contour_ratio_mode",
+        )
+        or _source_value(source, "nuclear_cell_pair_mode")
     )
     ratios = calculate_measurement_contour_ratio_triplet(source, mode=metadata["mode"])
     return {

--- a/cytocv/core/services/overlay_rendering.py
+++ b/cytocv/core/services/overlay_rendering.py
@@ -26,6 +26,9 @@ from core.channel_roles import (
 from core.config import input_dir
 from core.models import CellStatistics
 from core.services.artifact_storage import PNG_PROFILE_ANALYSIS_FAST, save_png_image
+from core.services.biorientation_config import (
+    DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+)
 from core.services.puncta_line_mode import (
     DEFAULT_PUNCTA_LINE_MODE,
     normalize_puncta_line_mode,
@@ -85,6 +88,11 @@ def _normalize_render_config_payload(payload: dict[str, object]) -> dict[str, ob
         normalized["green_contour_filter_enabled"] = normalized["gfp_filter_enabled"]
     if "alternate_mcherry_detection" in normalized and "alternate_red_detection" not in normalized:
         normalized["alternate_red_detection"] = normalized["alternate_mcherry_detection"]
+    if "alternate_nucleus_detection_enabled" not in normalized:
+        normalized["alternate_nucleus_detection_enabled"] = normalized.get(
+            "alternate_red_detection",
+            False,
+        )
     if "biorientation_green_split_enabled" in normalized and "green_dot_split_enabled" not in normalized:
         normalized["green_dot_split_enabled"] = normalized["biorientation_green_split_enabled"]
     normalized["green_dot_split_mode"] = normalize_green_dot_split_mode(
@@ -158,6 +166,11 @@ def build_overlay_render_config(
     cen_dot_distance_value_used: float,
     green_contour_filter_enabled: bool,
     alternate_red_detection: bool,
+    signal_quantification_enabled: bool = True,
+    signal_quantification_mode: str = "puncta_distance",
+    puncta_contour_intensity_enabled: bool = True,
+    alternate_nucleus_detection_enabled: bool | None = None,
+    alternate_nucleus_detection_channel: str | None = None,
     puncta_line_width_unit: str | None = None,
     cen_dot_distance_unit: str | None = None,
     cen_dot_proximity_radius: float | None = None,
@@ -166,7 +179,7 @@ def build_overlay_render_config(
     biorientation_red_min_distance_unit: str = "px",
     biorientation_red_max_distance_value: float = 37.0,
     biorientation_red_max_distance_unit: str = "px",
-    biorientation_collinearity_threshold: int = 66,
+    biorientation_collinearity_threshold: int = DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
     green_dot_split_enabled: bool = True,
     green_dot_split_mode: str = DEFAULT_GREEN_DOT_SPLIT_MODE,
 ) -> dict[str, object]:
@@ -190,6 +203,15 @@ def build_overlay_render_config(
         "biorientation_collinearity_threshold": int(biorientation_collinearity_threshold),
         "green_contour_filter_enabled": bool(green_contour_filter_enabled),
         "alternate_red_detection": bool(alternate_red_detection),
+        "signal_quantification_enabled": bool(signal_quantification_enabled),
+        "signal_quantification_mode": str(signal_quantification_mode),
+        "puncta_contour_intensity_enabled": bool(puncta_contour_intensity_enabled),
+        "alternate_nucleus_detection_enabled": bool(
+            alternate_red_detection
+            if alternate_nucleus_detection_enabled is None
+            else alternate_nucleus_detection_enabled
+        ),
+        "alternate_nucleus_detection_channel": alternate_nucleus_detection_channel,
         "green_dot_split_enabled": bool(green_dot_split_enabled),
         "green_dot_split_mode": normalize_green_dot_split_mode(green_dot_split_mode),
         "stats_biorientation_red_min_distance_value": float(biorientation_red_min_distance_value),
@@ -310,6 +332,24 @@ def _build_overlay_conf(run_uuid: str, render_config: dict[str, object]) -> dict
         "alternate_red_detection": bool(
             render_config.get("alternate_red_detection", False)
         ),
+        "signal_quantification_enabled": bool(
+            render_config.get("signal_quantification_enabled", True)
+        ),
+        "signal_quantification_mode": str(
+            render_config.get("signal_quantification_mode", "puncta_distance")
+        ),
+        "puncta_contour_intensity_enabled": bool(
+            render_config.get("puncta_contour_intensity_enabled", True)
+        ),
+        "alternate_nucleus_detection_enabled": bool(
+            render_config.get(
+                "alternate_nucleus_detection_enabled",
+                render_config.get("alternate_red_detection", False),
+            )
+        ),
+        "alternate_nucleus_detection_channel": render_config.get(
+            "alternate_nucleus_detection_channel"
+        ),
         "green_dot_split_enabled": bool(
             render_config.get(
                 "green_dot_split_enabled",
@@ -383,7 +423,7 @@ def render_overlay_images_for_cell(
     )
     render_cp.properties["stats_biorientation_collinearity_threshold"] = render_config.get(
         "biorientation_collinearity_threshold",
-        66,
+        DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
     )
     render_cp.properties["stats_green_dot_split_enabled"] = render_config.get(
         "green_dot_split_enabled",
@@ -391,6 +431,24 @@ def render_overlay_images_for_cell(
     )
     render_cp.properties["stats_green_dot_split_mode"] = normalize_green_dot_split_mode(
         render_config.get("green_dot_split_mode", DEFAULT_GREEN_DOT_SPLIT_MODE)
+    )
+    render_cp.properties["signal_quantification_enabled"] = bool(
+        render_config.get("signal_quantification_enabled", True)
+    )
+    render_cp.properties["signal_quantification_mode"] = str(
+        render_config.get("signal_quantification_mode", "puncta_distance")
+    )
+    render_cp.properties["puncta_contour_intensity_enabled"] = bool(
+        render_config.get("puncta_contour_intensity_enabled", True)
+    )
+    render_cp.properties["alternate_nucleus_detection_enabled"] = bool(
+        render_config.get(
+            "alternate_nucleus_detection_enabled",
+            render_config.get("alternate_red_detection", False),
+        )
+    )
+    render_cp.properties["alternate_nucleus_detection_channel"] = render_config.get(
+        "alternate_nucleus_detection_channel"
     )
     debug_red, debug_green, debug_blue = get_stats(
         render_cp,
@@ -400,7 +458,12 @@ def render_overlay_images_for_cell(
         float(render_config.get("cen_dot_distance_value_used", 37.0)),
         float(render_config.get("cen_dot_proximity_radius", 13)),
         bool(render_config.get("green_contour_filter_enabled", False)),
-        bool(render_config.get("alternate_red_detection", False)),
+        bool(
+            render_config.get(
+                "alternate_nucleus_detection_enabled",
+                render_config.get("alternate_red_detection", False),
+            )
+        ),
         bool(
             render_config.get(
                 "green_dot_split_enabled",
@@ -411,6 +474,7 @@ def render_overlay_images_for_cell(
             render_config.get("green_dot_split_mode", DEFAULT_GREEN_DOT_SPLIT_MODE)
         ),
         cached_images=images_to_use,
+        alternate_detection_channel=render_config.get("alternate_nucleus_detection_channel"),
     )
     return {
         "red": debug_red,

--- a/cytocv/core/services/segmentation_pipeline.py
+++ b/cytocv/core/services/segmentation_pipeline.py
@@ -65,6 +65,9 @@ from core.services.overlay_rendering import (
     persist_overlay_cache_images,
     write_overlay_render_config,
 )
+from core.services.biorientation_config import (
+    DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+)
 from core.services.puncta_line_mode import (
     DEFAULT_PUNCTA_LINE_MODE,
     normalize_puncta_line_mode,
@@ -72,6 +75,9 @@ from core.services.puncta_line_mode import (
 from core.services.green_dot_split import (
     DEFAULT_GREEN_DOT_SPLIT_MODE,
     normalize_green_dot_split_mode,
+)
+from core.services.signal_quantification import (
+    SIGNAL_MODE_PUNCTA_DISTANCE,
 )
 from core.stats_plugins import build_stats_execution_plan
 from core.views.segment_image import (
@@ -959,6 +965,31 @@ def run_segmentation_batch(
             "alternateRedDetection",
             config_snapshot.get("alternateMCherryDetection", False),
         )
+        alternate_red_detection = bool(alternate_red_detection)
+        signal_quantification_enabled = bool(
+            config_snapshot.get("signalQuantificationEnabled", True)
+        )
+        signal_quantification_mode = str(
+            config_snapshot.get(
+                "signalQuantificationMode",
+                SIGNAL_MODE_PUNCTA_DISTANCE,
+            )
+        )
+        puncta_contour_intensity_enabled = bool(
+            config_snapshot.get(
+                "punctaContourIntensityEnabled",
+                "GreenRedIntensity" in selected_analysis,
+            )
+        )
+        alternate_nucleus_detection_enabled = bool(
+            config_snapshot.get(
+                "alternateNucleusDetectionEnabled",
+                alternate_red_detection,
+            )
+        )
+        alternate_nucleus_detection_channel = config_snapshot.get(
+            "alternateNucleusDetectionChannel"
+        )
         biorientation_red_min_distance_unit = normalize_length_unit(
             str(config_snapshot.get("stats_biorientation_red_min_distance_unit", "px")),
             default="px",
@@ -985,12 +1016,15 @@ def run_segmentation_batch(
             biorientation_red_max_distance_value = 37.0
         try:
             biorientation_collinearity_threshold = int(
-                config_snapshot.get("biorientationCollinearityThreshold", 66)
+                config_snapshot.get(
+                    "biorientationCollinearityThreshold",
+                    DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+                )
             )
         except (TypeError, ValueError):
-            biorientation_collinearity_threshold = 66
+            biorientation_collinearity_threshold = DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX
         if biorientation_collinearity_threshold < 0:
-            biorientation_collinearity_threshold = 66
+            biorientation_collinearity_threshold = DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX
         green_dot_split_enabled = bool(
             config_snapshot.get(
                 "greenDotSplitEnabled",
@@ -1025,7 +1059,12 @@ def run_segmentation_batch(
                 config_snapshot.get("nuclear_cellular_mode", "green_nucleus"),
             ),
             "green_contour_filter_enabled": green_contour_filter_enabled,
-            "alternate_red_detection": alternate_red_detection,
+            "alternate_red_detection": alternate_nucleus_detection_enabled,
+            "signal_quantification_enabled": signal_quantification_enabled,
+            "signal_quantification_mode": signal_quantification_mode,
+            "puncta_contour_intensity_enabled": puncta_contour_intensity_enabled,
+            "alternate_nucleus_detection_enabled": alternate_nucleus_detection_enabled,
+            "alternate_nucleus_detection_channel": alternate_nucleus_detection_channel,
             "green_dot_split_enabled": green_dot_split_enabled,
             "green_dot_split_mode": green_dot_split_mode,
         }
@@ -1050,7 +1089,12 @@ def run_segmentation_batch(
                 puncta_line_width_px=puncta_line_width,
                 cen_dot_distance_value_used=cen_dot_distance,
                 green_contour_filter_enabled=bool(green_contour_filter_enabled),
-                alternate_red_detection=bool(alternate_red_detection),
+                alternate_red_detection=alternate_nucleus_detection_enabled,
+                signal_quantification_enabled=signal_quantification_enabled,
+                signal_quantification_mode=signal_quantification_mode,
+                puncta_contour_intensity_enabled=puncta_contour_intensity_enabled,
+                alternate_nucleus_detection_enabled=alternate_nucleus_detection_enabled,
+                alternate_nucleus_detection_channel=alternate_nucleus_detection_channel,
                 puncta_line_width_unit=puncta_line_width_unit,
                 cen_dot_distance_unit=cen_dot_distance_unit,
                 cen_dot_proximity_radius=cen_dot_proximity_radius,
@@ -1159,6 +1203,11 @@ def run_segmentation_batch(
             cp.properties["stats_biorientation_collinearity_threshold"] = biorientation_collinearity_threshold
             cp.properties["stats_green_dot_split_enabled"] = green_dot_split_enabled
             cp.properties["stats_green_dot_split_mode"] = green_dot_split_mode
+            cp.properties["signal_quantification_enabled"] = signal_quantification_enabled
+            cp.properties["signal_quantification_mode"] = signal_quantification_mode
+            cp.properties["puncta_contour_intensity_enabled"] = puncta_contour_intensity_enabled
+            cp.properties["alternate_nucleus_detection_enabled"] = alternate_nucleus_detection_enabled
+            cp.properties["alternate_nucleus_detection_channel"] = alternate_nucleus_detection_channel
 
             cp.properties["neck_split"] = _build_neck_split_properties(
                 pair_geometry_cache.get(cell_number)
@@ -1172,11 +1221,12 @@ def run_segmentation_batch(
                 cen_dot_distance,
                 cen_dot_proximity_radius,
                 green_contour_filter_enabled,
-                alternate_red_detection,
+                alternate_nucleus_detection_enabled,
                 green_dot_split_enabled,
                 green_dot_split_mode,
                 cached_images=cell_image_cache.get(cell_number),
                 cached_measurement_images=cell_measurement_image_cache.get(cell_number),
+                alternate_detection_channel=alternate_nucleus_detection_channel,
             )
             rendered_overlay_images = {
                 "red": debug_red,

--- a/cytocv/core/services/signal_quantification.py
+++ b/cytocv/core/services/signal_quantification.py
@@ -70,8 +70,10 @@ class SignalQuantificationSelection:
     puncta_contour_intensity_enabled: bool
     alternate_nucleus_detection_enabled: bool
     alternate_nucleus_detection_channel: str | None
+    configured_plugins: tuple[str, ...]
     selected_plugins: tuple[str, ...]
     independent_plugins: tuple[str, ...]
+    paused_plugins: tuple[str, ...]
     stat_visibility: dict[str, bool]
     measurement_contour_ratio_mode: str
 
@@ -246,16 +248,36 @@ def resolve_signal_quantification_selection(
         for plugin_id in legacy_plugins
         if plugin_id not in SIGNAL_QUANTIFICATION_PLUGIN_IDS
     )
-    selected: list[str] = []
+
+    configured: list[str] = []
     if enabled:
         if mode == SIGNAL_MODE_NUCLEAR_CELL_PAIR:
-            selected.append(NUCLEAR_CELL_PAIR_PLUGIN)
+            configured.append(NUCLEAR_CELL_PAIR_PLUGIN)
         else:
-            selected.append(PUNCTA_DISTANCE_PLUGIN)
+            configured.append(PUNCTA_DISTANCE_PLUGIN)
             if puncta_contour_intensity_enabled:
-                selected.append(GREEN_RED_INTENSITY_PLUGIN)
-    selected.extend(independent_plugins)
-    selected_plugins_tuple = tuple(expand_selected_plugins(selected))
+                configured.append(GREEN_RED_INTENSITY_PLUGIN)
+    configured.extend(independent_plugins)
+    configured_plugins_tuple = tuple(expand_selected_plugins(configured))
+
+    effective: list[str] = []
+    if enabled:
+        if mode == SIGNAL_MODE_NUCLEAR_CELL_PAIR:
+            effective.append(NUCLEAR_CELL_PAIR_PLUGIN)
+        else:
+            effective.append(PUNCTA_DISTANCE_PLUGIN)
+            if puncta_contour_intensity_enabled:
+                effective.append(GREEN_RED_INTENSITY_PLUGIN)
+            effective.extend(independent_plugins)
+    else:
+        effective.extend(independent_plugins)
+    selected_plugins_tuple = tuple(expand_selected_plugins(effective))
+    effective_plugin_set = set(selected_plugins_tuple)
+    paused_plugins_tuple = tuple(
+        plugin_id
+        for plugin_id in configured_plugins_tuple
+        if plugin_id not in effective_plugin_set
+    )
 
     return SignalQuantificationSelection(
         enabled=enabled,
@@ -266,8 +288,10 @@ def resolve_signal_quantification_selection(
             nuclear_cell_pair_mode,
             enabled=enabled and mode == SIGNAL_MODE_NUCLEAR_CELL_PAIR and alternate_enabled,
         ),
+        configured_plugins=configured_plugins_tuple,
         selected_plugins=selected_plugins_tuple,
         independent_plugins=tuple(expand_selected_plugins(independent_plugins)),
+        paused_plugins=paused_plugins_tuple,
         stat_visibility=build_stat_visibility(selected_plugins_tuple),
         measurement_contour_ratio_mode=measurement_ratio_mode_for_puncta_line_mode(
             puncta_line_mode

--- a/cytocv/core/services/signal_quantification.py
+++ b/cytocv/core/services/signal_quantification.py
@@ -1,0 +1,310 @@
+"""Shared Signal Quantification mode resolution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from core.channel_roles import CHANNEL_ROLE_GREEN, CHANNEL_ROLE_RED
+from core.services.puncta_line_mode import (
+    DEFAULT_PUNCTA_LINE_MODE,
+    normalize_puncta_line_mode,
+)
+
+
+SIGNAL_MODE_PUNCTA_DISTANCE = "puncta_distance"
+SIGNAL_MODE_NUCLEAR_CELL_PAIR = "nuclear_cell_pair"
+SIGNAL_QUANTIFICATION_MODES = frozenset(
+    {SIGNAL_MODE_PUNCTA_DISTANCE, SIGNAL_MODE_NUCLEAR_CELL_PAIR}
+)
+
+PUNCTA_DISTANCE_PLUGIN = "PunctaDistance"
+GREEN_RED_INTENSITY_PLUGIN = "GreenRedIntensity"
+NUCLEAR_CELL_PAIR_PLUGIN = "NuclearCellPairIntensity"
+CEN_DOT_PLUGIN = "CENDot"
+BIORIENTATION_PLUGIN = "Biorientation"
+LEGACY_BLUE_INTENSITY_PLUGIN_IDS = frozenset(
+    {"NucleusIntensity", "BlueNucleusIntensity", "RedBlueIntensity"}
+)
+
+SIGNAL_QUANTIFICATION_PLUGIN_IDS = frozenset(
+    {
+        PUNCTA_DISTANCE_PLUGIN,
+        GREEN_RED_INTENSITY_PLUGIN,
+        NUCLEAR_CELL_PAIR_PLUGIN,
+    }
+)
+
+DEFAULT_SIGNAL_SELECTED_PLUGINS = (
+    PUNCTA_DISTANCE_PLUGIN,
+    CEN_DOT_PLUGIN,
+    BIORIENTATION_PLUGIN,
+    GREEN_RED_INTENSITY_PLUGIN,
+)
+PLUGIN_ORDER = (
+    PUNCTA_DISTANCE_PLUGIN,
+    CEN_DOT_PLUGIN,
+    BIORIENTATION_PLUGIN,
+    GREEN_RED_INTENSITY_PLUGIN,
+    NUCLEAR_CELL_PAIR_PLUGIN,
+    "NucleusIntensity",
+    "BlueNucleusIntensity",
+    "RedBlueIntensity",
+)
+PLUGIN_ID_ALIASES = {
+    "MCherryLine": PUNCTA_DISTANCE_PLUGIN,
+    "RedLineIntensity": PUNCTA_DISTANCE_PLUGIN,
+    "GFPIntensity": CEN_DOT_PLUGIN,
+    "CenDotCollinearity": BIORIENTATION_PLUGIN,
+    "NuclearCellularIntensity": NUCLEAR_CELL_PAIR_PLUGIN,
+}
+
+RATIO_MODE_RED_CONTOUR = "red_contour"
+RATIO_MODE_GREEN_CONTOUR = "green_contour"
+
+
+@dataclass(frozen=True, slots=True)
+class SignalQuantificationSelection:
+    enabled: bool
+    mode: str
+    puncta_contour_intensity_enabled: bool
+    alternate_nucleus_detection_enabled: bool
+    alternate_nucleus_detection_channel: str | None
+    selected_plugins: tuple[str, ...]
+    independent_plugins: tuple[str, ...]
+    stat_visibility: dict[str, bool]
+    measurement_contour_ratio_mode: str
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in {0, 1}:
+        return bool(value)
+    if isinstance(value, float) and value in {0.0, 1.0}:
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _has_key(payload: dict[str, Any] | None, *keys: str) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    return any(key in payload for key in keys)
+
+
+def normalize_signal_quantification_mode(
+    value: Any,
+    default: str = SIGNAL_MODE_PUNCTA_DISTANCE,
+) -> str:
+    mode = str(value or "").strip()
+    aliases = {
+        "puncta": SIGNAL_MODE_PUNCTA_DISTANCE,
+        "puncta_distance": SIGNAL_MODE_PUNCTA_DISTANCE,
+        PUNCTA_DISTANCE_PLUGIN: SIGNAL_MODE_PUNCTA_DISTANCE,
+        "nuclear": SIGNAL_MODE_NUCLEAR_CELL_PAIR,
+        "nuclear_cell_pair": SIGNAL_MODE_NUCLEAR_CELL_PAIR,
+        NUCLEAR_CELL_PAIR_PLUGIN: SIGNAL_MODE_NUCLEAR_CELL_PAIR,
+    }
+    return aliases.get(mode, default)
+
+
+def expand_selected_plugins(selected_plugins: Iterable[Any]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    selected: list[str] = []
+    known = set(PLUGIN_ORDER)
+    for raw_plugin in selected_plugins or []:
+        plugin_id = PLUGIN_ID_ALIASES.get(str(raw_plugin).strip(), str(raw_plugin).strip())
+        if plugin_id not in known or plugin_id in seen:
+            continue
+        seen.add(plugin_id)
+        selected.append(plugin_id)
+    order = {plugin_id: index for index, plugin_id in enumerate(PLUGIN_ORDER)}
+    selected.sort(key=lambda plugin_id: order.get(plugin_id, len(order)))
+    return tuple(selected)
+
+
+def infer_signal_quantification_mode(selected_plugins: Iterable[Any]) -> str:
+    plugins = set(expand_selected_plugins(selected_plugins))
+    if PUNCTA_DISTANCE_PLUGIN in plugins:
+        return SIGNAL_MODE_PUNCTA_DISTANCE
+    if NUCLEAR_CELL_PAIR_PLUGIN in plugins:
+        return SIGNAL_MODE_NUCLEAR_CELL_PAIR
+    return SIGNAL_MODE_PUNCTA_DISTANCE
+
+
+def measurement_ratio_mode_for_puncta_line_mode(puncta_line_mode: Any) -> str:
+    mode = normalize_puncta_line_mode(
+        puncta_line_mode,
+        default=DEFAULT_PUNCTA_LINE_MODE,
+    )
+    if mode == "green_puncta":
+        return RATIO_MODE_GREEN_CONTOUR
+    return RATIO_MODE_RED_CONTOUR
+
+
+def alternate_detection_channel_for_nuclear_mode(
+    nuclear_cell_pair_mode: Any,
+    *,
+    enabled: bool,
+) -> str | None:
+    # Alternate contour selection only applies to the nuclear workflow.
+    if not enabled:
+        return None
+    return CHANNEL_ROLE_RED if str(nuclear_cell_pair_mode) == "red_nucleus" else CHANNEL_ROLE_GREEN
+
+
+def build_stat_visibility(selected_plugins: Iterable[Any]) -> dict[str, bool]:
+    plugins = set(expand_selected_plugins(selected_plugins))
+    return {
+        "puncta_distance": PUNCTA_DISTANCE_PLUGIN in plugins,
+        "red_green_intensity": GREEN_RED_INTENSITY_PLUGIN in plugins,
+        "nuclear_cell_pair_intensity": NUCLEAR_CELL_PAIR_PLUGIN in plugins,
+        "cen_dot": CEN_DOT_PLUGIN in plugins,
+        "biorientation": BIORIENTATION_PLUGIN in plugins,
+        "legacy_blue_intensity": bool(plugins & LEGACY_BLUE_INTENSITY_PLUGIN_IDS),
+    }
+
+
+def resolve_signal_quantification_selection(
+    *,
+    payload: dict[str, Any] | None = None,
+    selected_plugins: Iterable[Any] | None = None,
+    nuclear_cell_pair_mode: Any = "green_nucleus",
+    puncta_line_mode: Any = DEFAULT_PUNCTA_LINE_MODE,
+    default_enabled: bool | None = None,
+    default_mode: str | None = None,
+    default_puncta_contour_intensity_enabled: bool | None = None,
+    default_alternate_nucleus_detection_enabled: bool | None = None,
+) -> SignalQuantificationSelection:
+    """Resolve Signal Quantification fields and derived plugin selection."""
+
+    payload = payload if isinstance(payload, dict) else {}
+    legacy_plugins = tuple(expand_selected_plugins(selected_plugins or ()))
+    legacy_plugin_set = set(legacy_plugins)
+    has_primary_legacy = bool(legacy_plugin_set & SIGNAL_QUANTIFICATION_PLUGIN_IDS)
+
+    inferred_enabled = has_primary_legacy
+    if default_enabled is not None:
+        inferred_enabled = bool(default_enabled)
+    enabled = _as_bool(
+        payload.get(
+            "signal_quantification_enabled",
+            payload.get("signalQuantificationEnabled"),
+        ),
+        default=inferred_enabled,
+    )
+
+    inferred_mode = default_mode or infer_signal_quantification_mode(legacy_plugins)
+    mode = normalize_signal_quantification_mode(
+        payload.get(
+            "signal_quantification_mode",
+            payload.get("signalQuantificationMode"),
+        ),
+        default=inferred_mode,
+    )
+
+    if default_puncta_contour_intensity_enabled is None:
+        inferred_contour_enabled = GREEN_RED_INTENSITY_PLUGIN in legacy_plugin_set
+    else:
+        inferred_contour_enabled = bool(default_puncta_contour_intensity_enabled)
+    puncta_contour_intensity_enabled = _as_bool(
+        payload.get(
+            "puncta_contour_intensity_enabled",
+            payload.get("punctaContourIntensityEnabled"),
+        ),
+        default=inferred_contour_enabled,
+    )
+
+    legacy_alternate = payload.get(
+        "alternate_nucleus_detection_enabled",
+        payload.get(
+            "alternateNucleusDetectionEnabled",
+            payload.get(
+                "alternateRedDetection",
+                payload.get(
+                    "alternate_red_detection",
+                    payload.get("alternateMCherryDetection"),
+                ),
+            ),
+        ),
+    )
+    if default_alternate_nucleus_detection_enabled is None:
+        default_alternate_nucleus_detection_enabled = False
+    alternate_enabled = _as_bool(
+        legacy_alternate,
+        default=bool(default_alternate_nucleus_detection_enabled),
+    )
+
+    independent_plugins = tuple(
+        plugin_id
+        for plugin_id in legacy_plugins
+        if plugin_id not in SIGNAL_QUANTIFICATION_PLUGIN_IDS
+    )
+    selected: list[str] = []
+    if enabled:
+        if mode == SIGNAL_MODE_NUCLEAR_CELL_PAIR:
+            selected.append(NUCLEAR_CELL_PAIR_PLUGIN)
+        else:
+            selected.append(PUNCTA_DISTANCE_PLUGIN)
+            if puncta_contour_intensity_enabled:
+                selected.append(GREEN_RED_INTENSITY_PLUGIN)
+    selected.extend(independent_plugins)
+    selected_plugins_tuple = tuple(expand_selected_plugins(selected))
+
+    return SignalQuantificationSelection(
+        enabled=enabled,
+        mode=mode,
+        puncta_contour_intensity_enabled=puncta_contour_intensity_enabled,
+        alternate_nucleus_detection_enabled=alternate_enabled,
+        alternate_nucleus_detection_channel=alternate_detection_channel_for_nuclear_mode(
+            nuclear_cell_pair_mode,
+            enabled=enabled and mode == SIGNAL_MODE_NUCLEAR_CELL_PAIR and alternate_enabled,
+        ),
+        selected_plugins=selected_plugins_tuple,
+        independent_plugins=tuple(expand_selected_plugins(independent_plugins)),
+        stat_visibility=build_stat_visibility(selected_plugins_tuple),
+        measurement_contour_ratio_mode=measurement_ratio_mode_for_puncta_line_mode(
+            puncta_line_mode
+        ),
+    )
+
+
+def resolve_signal_quantification_from_defaults(
+    defaults: dict[str, Any] | None,
+) -> SignalQuantificationSelection:
+    defaults = defaults if isinstance(defaults, dict) else {}
+    selected_plugins = defaults.get("selected_plugins", DEFAULT_SIGNAL_SELECTED_PLUGINS)
+    return resolve_signal_quantification_selection(
+        payload=defaults,
+        selected_plugins=selected_plugins,
+        nuclear_cell_pair_mode=defaults.get("nuclear_cell_pair_mode", "green_nucleus"),
+        puncta_line_mode=defaults.get("puncta_line_mode", DEFAULT_PUNCTA_LINE_MODE),
+        default_enabled=(
+            _as_bool(defaults.get("signal_quantification_enabled"), default=True)
+            if _has_key(defaults, "signal_quantification_enabled")
+            else None
+        ),
+        default_mode=(
+            normalize_signal_quantification_mode(defaults.get("signal_quantification_mode"))
+            if _has_key(defaults, "signal_quantification_mode")
+            else None
+        ),
+        default_puncta_contour_intensity_enabled=(
+            _as_bool(defaults.get("puncta_contour_intensity_enabled"), default=True)
+            if _has_key(defaults, "puncta_contour_intensity_enabled")
+            else None
+        ),
+        default_alternate_nucleus_detection_enabled=_as_bool(
+            defaults.get(
+                "alternate_nucleus_detection_enabled",
+                defaults.get("alternate_red_detection"),
+            ),
+            default=False,
+        ),
+    )

--- a/cytocv/core/static/js/workflow_defaults.js
+++ b/cytocv/core/static/js/workflow_defaults.js
@@ -74,6 +74,7 @@
   const selectedPlugins = new Set(
     pluginToggles.filter((toggle) => toggle.checked).map((toggle) => toggle.value)
   );
+  const signalPrimaryPlugins = new Set(['PunctaDistance', 'GreenRedIntensity', 'NuclearCellPairIntensity']);
   const overrideBox = document.getElementById('overrideChannels');
   const overrides = new Set(
     [...(overrideBox ? overrideBox.querySelectorAll('input[name=\"override_required_channels\"]') : [])]
@@ -81,6 +82,13 @@
       .filter((value) => value)
   );
   const pluginForm = document.getElementById('pluginForm');
+  const signalSelectedPluginsBox = document.getElementById('signalSelectedPlugins');
+  const signalQuantificationEnabledInput = document.getElementById('signal_quantification_enabled');
+  const signalQuantificationModeInput = document.getElementById('signal_quantification_mode');
+  const signalQuantificationInline = document.getElementById('signalQuantificationInline');
+  const signalQuantificationModule = document.getElementById('signalQuantificationModule');
+  const punctaContourIntensityEnabledInput = document.getElementById('puncta_contour_intensity_enabled');
+  const alternateNucleusDetectionInput = document.getElementById('alternate_nucleus_detection_enabled');
   const advancedForm = document.getElementById('advancedForm');
   const savingForm = document.getElementById('savingForm');
   const sectionFormMap = {
@@ -287,6 +295,55 @@
       if (!pluginMap.has(dependencyId)) return;
       selectedPlugins.add(dependencyId);
       applyPluginDependencies(dependencyId);
+    });
+  };
+
+  const normalizeSignalMode = (value) =>
+    value === 'nuclear_cell_pair' ? 'nuclear_cell_pair' : 'puncta_distance';
+
+  const isSignalQuantificationEnabled = () =>
+    !!(signalQuantificationEnabledInput && signalQuantificationEnabledInput.checked);
+
+  const deriveSignalPluginIds = () => {
+    if (!isSignalQuantificationEnabled()) return [];
+    if (normalizeSignalMode(signalQuantificationModeInput?.value) === 'nuclear_cell_pair') {
+      return ['NuclearCellPairIntensity'];
+    }
+    const plugins = ['PunctaDistance'];
+    if (!punctaContourIntensityEnabledInput || punctaContourIntensityEnabledInput.checked) {
+      plugins.push('GreenRedIntensity');
+    }
+    return plugins;
+  };
+
+  const syncSignalSelectedPlugins = () => {
+    signalPrimaryPlugins.forEach((pluginId) => selectedPlugins.delete(pluginId));
+    deriveSignalPluginIds().forEach((pluginId) => selectedPlugins.add(pluginId));
+    if (!signalSelectedPluginsBox) return;
+    signalSelectedPluginsBox.innerHTML = '';
+    deriveSignalPluginIds().forEach((pluginId) => {
+      const input = document.createElement('input');
+      input.type = 'hidden';
+      input.name = 'selected_plugins';
+      input.value = pluginId;
+      signalSelectedPluginsBox.appendChild(input);
+    });
+  };
+
+  const syncSignalQuantificationPanels = () => {
+    const enabled = isSignalQuantificationEnabled();
+    const mode = normalizeSignalMode(signalQuantificationModeInput?.value);
+    if (signalQuantificationInline) {
+      signalQuantificationInline.classList.toggle('is-active', enabled);
+      signalQuantificationInline.setAttribute('aria-hidden', enabled ? 'false' : 'true');
+    }
+    if (signalQuantificationModule) {
+      signalQuantificationModule.classList.toggle('is-off', !enabled);
+    }
+    document.querySelectorAll('[data-signal-mode-panel]').forEach((panel) => {
+      const active = enabled && panel.dataset.signalModePanel === mode;
+      panel.classList.toggle('is-active', active);
+      panel.setAttribute('aria-hidden', active ? 'false' : 'true');
     });
   };
 
@@ -535,6 +592,8 @@
   };
 
   const syncRows = () => {
+    syncSignalSelectedPlugins();
+    syncSignalQuantificationPanels();
     const statsRequired = requiredByStatsChannels();
     channelToggles.forEach((toggle) => {
       const channel = toggle.dataset.channel;
@@ -593,6 +652,22 @@
       } else {
         selectedPlugins.delete(toggle.value);
       }
+      syncPluginToggles();
+      syncRows();
+    });
+  });
+
+  [
+    signalQuantificationEnabledInput,
+    signalQuantificationModeInput,
+    punctaContourIntensityEnabledInput,
+    alternateNucleusDetectionInput,
+    document.getElementById('puncta_line_mode'),
+    document.getElementById('nuclear_cell_pair_mode'),
+  ].forEach((input) => {
+    if (!input) return;
+    input.addEventListener('change', () => {
+      clearOverridesRequiredBySelectedPlugins();
       syncPluginToggles();
       syncRows();
     });
@@ -801,7 +876,7 @@
   const greenContourFilterEnabledInput = document.getElementById('green_contour_filter_enabled');
   const greenDotSplitEnabledInput = document.getElementById('green_dot_split_enabled');
   const greenDotSplitModeInput = document.getElementById('green_dot_split_mode');
-  const alternateRedDetectionInput = document.getElementById('alternate_red_detection');
+  const alternateRedDetectionInput = alternateNucleusDetectionInput;
   const autoSaveExperimentsInput = document.getElementById('auto_save_experiments');
   const showSavedFileChannelsInput = document.getElementById('show_saved_file_channels');
   const showSavedFileScalesInput = document.getElementById('show_saved_file_scales');
@@ -952,6 +1027,10 @@
     value === 'red_nucleus'
       ? 'Red Nucleus (Measure Green)'
       : 'Green Nucleus (Measure Red)';
+  const signalModeLabel = (value) =>
+    normalizeSignalMode(value) === 'nuclear_cell_pair'
+      ? 'Nuclear, Cell-Pair Intensity'
+      : 'Puncta Distance';
 
   const convertLengthValueToUnit = (value, fromUnit, toUnit, umPerPx) => {
     const sourceUnit = normalizeLengthUnit(fromUnit);
@@ -1071,6 +1150,14 @@
 
   const capturePluginSnapshot = () => ({
     selectedPlugins: sortByOrder([...selectedPlugins], pluginOrder),
+    signalQuantificationEnabled: isSignalQuantificationEnabled(),
+    signalQuantificationMode: normalizeSignalMode(signalQuantificationModeInput?.value),
+    punctaContourIntensityEnabled: !!(
+      punctaContourIntensityEnabledInput && punctaContourIntensityEnabledInput.checked
+    ),
+    alternateNucleusDetectionEnabled: !!(
+      alternateRedDetectionInput && alternateRedDetectionInput.checked
+    ),
     redWidth: captureNumericField(redWidthInput),
     redWidthUnit: normalizeLengthUnit(valueOrEmpty(redWidthUnit)),
     cenDotDistance: captureNumericField(cenDotDistanceInput),
@@ -1087,7 +1174,6 @@
     greenContourFilterEnabled: !!(greenContourFilterEnabledInput && greenContourFilterEnabledInput.checked),
     greenDotSplitEnabled: !!(greenDotSplitEnabledInput && greenDotSplitEnabledInput.checked),
     greenDotSplitMode: normalizeGreenDotSplitMode(valueOrEmpty(greenDotSplitModeInput)),
-    alternateRedDetection: !!(alternateRedDetectionInput && alternateRedDetectionInput.checked),
     micronsPerPixel: captureNumericField(prefsScaleInput),
     useMetadataScale: !!(useMetadataScaleInput && useMetadataScaleInput.checked),
   });
@@ -1117,6 +1203,23 @@
 
   const buildPluginChangeList = (fromSnapshot, toSnapshot) => {
     const changes = [];
+    pushToggleChange(
+      changes,
+      'Signal Quantification',
+      fromSnapshot.signalQuantificationEnabled,
+      toSnapshot.signalQuantificationEnabled
+    );
+    if (fromSnapshot.signalQuantificationMode !== toSnapshot.signalQuantificationMode) {
+      changes.push(
+        `Signal Quantification Mode: ${signalModeLabel(fromSnapshot.signalQuantificationMode)} -> ${signalModeLabel(toSnapshot.signalQuantificationMode)}`
+      );
+    }
+    pushToggleChange(
+      changes,
+      'Red/Green Contour Intensities',
+      fromSnapshot.punctaContourIntensityEnabled,
+      toSnapshot.punctaContourIntensityEnabled
+    );
     const before = new Set(fromSnapshot.selectedPlugins || []);
     const after = new Set(toSnapshot.selectedPlugins || []);
 
@@ -1183,9 +1286,9 @@
     }
     pushToggleChange(
       changes,
-      'Enable Alternate Red Detection',
-      fromSnapshot.alternateRedDetection,
-      toSnapshot.alternateRedDetection
+      'Alternate Nucleus Detection',
+      fromSnapshot.alternateNucleusDetectionEnabled,
+      toSnapshot.alternateNucleusDetectionEnabled
     );
     pushToggleChange(
       changes,
@@ -1353,6 +1456,9 @@
     if (!snapshot) return;
     selectedPlugins.clear();
     (snapshot.selectedPlugins || []).forEach((pluginId) => selectedPlugins.add(pluginId));
+    if (signalQuantificationEnabledInput) signalQuantificationEnabledInput.checked = snapshot.signalQuantificationEnabled;
+    if (signalQuantificationModeInput) signalQuantificationModeInput.value = normalizeSignalMode(snapshot.signalQuantificationMode);
+    if (punctaContourIntensityEnabledInput) punctaContourIntensityEnabledInput.checked = snapshot.punctaContourIntensityEnabled;
     syncPluginToggles();
     if (redWidthInput) redWidthInput.value = snapshot.redWidth.raw;
     if (redWidthUnit) {
@@ -1390,7 +1496,9 @@
     if (greenContourFilterEnabledInput) greenContourFilterEnabledInput.checked = snapshot.greenContourFilterEnabled;
     if (greenDotSplitEnabledInput) greenDotSplitEnabledInput.checked = snapshot.greenDotSplitEnabled;
     if (greenDotSplitModeInput) greenDotSplitModeInput.value = normalizeGreenDotSplitMode(snapshot.greenDotSplitMode);
-    if (alternateRedDetectionInput) alternateRedDetectionInput.checked = snapshot.alternateRedDetection;
+    if (alternateRedDetectionInput) {
+      alternateRedDetectionInput.checked = snapshot.alternateNucleusDetectionEnabled;
+    }
     if (prefsScaleInput) prefsScaleInput.value = snapshot.micronsPerPixel.raw;
     if (useMetadataScaleInput) useMetadataScaleInput.checked = snapshot.useMetadataScale;
     syncRows();

--- a/cytocv/core/static/js/workflow_defaults.js
+++ b/cytocv/core/static/js/workflow_defaults.js
@@ -87,6 +87,7 @@
   const signalQuantificationModeInput = document.getElementById('signal_quantification_mode');
   const signalQuantificationInline = document.getElementById('signalQuantificationInline');
   const signalQuantificationModule = document.getElementById('signalQuantificationModule');
+  const signalModePausedNote = document.getElementById('signalModePausedNote');
   const punctaContourIntensityEnabledInput = document.getElementById('puncta_contour_intensity_enabled');
   const alternateNucleusDetectionInput = document.getElementById('alternate_nucleus_detection_enabled');
   const advancedForm = document.getElementById('advancedForm');
@@ -216,7 +217,7 @@
 
   const requiredByStatsChannels = () => {
     const required = new Set(alwaysRequired);
-    selectedPlugins.forEach((pluginId) => {
+    effectiveSelectedPluginIds().forEach((pluginId) => {
       const plugin = pluginMap.get(pluginId);
       if (!plugin || !Array.isArray(plugin.required_channels)) return;
       plugin.required_channels.forEach((channel) => required.add(channel));
@@ -228,7 +229,7 @@
 
   const selectedPluginLabelsRequiringChannel = (channel) => {
     const labels = [];
-    selectedPlugins.forEach((pluginId) => {
+    effectiveSelectedPluginIds().forEach((pluginId) => {
       const plugin = pluginMap.get(pluginId);
       if (!plugin || !Array.isArray(plugin.required_channels)) return;
       if (plugin.required_channels.includes(channel)) {
@@ -304,6 +305,10 @@
   const isSignalQuantificationEnabled = () =>
     !!(signalQuantificationEnabledInput && signalQuantificationEnabledInput.checked);
 
+  const isNuclearSignalModeActive = () =>
+    isSignalQuantificationEnabled() &&
+    normalizeSignalMode(signalQuantificationModeInput?.value) === 'nuclear_cell_pair';
+
   const deriveSignalPluginIds = () => {
     if (!isSignalQuantificationEnabled()) return [];
     if (normalizeSignalMode(signalQuantificationModeInput?.value) === 'nuclear_cell_pair') {
@@ -316,12 +321,69 @@
     return plugins;
   };
 
+  const isPluginPausedBySignalMode = (pluginId) =>
+    isNuclearSignalModeActive() && pluginId !== 'NuclearCellPairIntensity';
+
+  const effectiveSelectedPluginIds = () => {
+    if (isNuclearSignalModeActive()) {
+      return new Set(['NuclearCellPairIntensity']);
+    }
+    return new Set(selectedPlugins);
+  };
+
+  const buildSignalModeNotice = (enabled, mode) => {
+    if (!enabled) return null;
+    if (mode === 'nuclear_cell_pair') {
+      return {
+        state: 'paused',
+        text: 'All other stat modules disabled in Nuclear, Cell-Pair mode.',
+      };
+    }
+    const activeSecondaries = [
+      selectedPlugins.has('CENDot') ? 'Cen Dot' : null,
+      selectedPlugins.has('Biorientation') ? 'Biorientation' : null,
+    ].filter(Boolean);
+    if (!activeSecondaries.length) return null;
+    const moduleText = activeSecondaries.length === 2
+      ? `${activeSecondaries[0]} and ${activeSecondaries[1]} modules enabled.`
+      : `${activeSecondaries[0]} module enabled.`;
+    return {
+      state: 'enabled',
+      text: moduleText,
+    };
+  };
+
+  const syncSignalModeNotice = (enabled, mode) => {
+    if (!signalModePausedNote) return;
+    const notice = buildSignalModeNotice(enabled, mode);
+    const state = notice ? notice.state : '';
+    const text = notice ? notice.text : '';
+    const changed = signalModePausedNote.dataset.state !== state || signalModePausedNote.textContent !== text;
+    signalModePausedNote.classList.remove('is-enabled', 'is-paused');
+    if (!notice) {
+      signalModePausedNote.classList.remove('is-active');
+      signalModePausedNote.setAttribute('aria-hidden', 'true');
+      signalModePausedNote.dataset.state = '';
+      signalModePausedNote.textContent = '';
+      return;
+    }
+    signalModePausedNote.textContent = text;
+    signalModePausedNote.dataset.state = state;
+    signalModePausedNote.classList.add(`is-${state}`);
+    signalModePausedNote.setAttribute('aria-hidden', 'false');
+    if (changed) {
+      signalModePausedNote.classList.remove('is-active');
+      void signalModePausedNote.offsetWidth;
+    }
+    signalModePausedNote.classList.add('is-active');
+  };
+
   const syncSignalSelectedPlugins = () => {
     signalPrimaryPlugins.forEach((pluginId) => selectedPlugins.delete(pluginId));
     deriveSignalPluginIds().forEach((pluginId) => selectedPlugins.add(pluginId));
     if (!signalSelectedPluginsBox) return;
     signalSelectedPluginsBox.innerHTML = '';
-    deriveSignalPluginIds().forEach((pluginId) => {
+    sortByOrder([...selectedPlugins], pluginOrder).forEach((pluginId) => {
       const input = document.createElement('input');
       input.type = 'hidden';
       input.name = 'selected_plugins';
@@ -345,10 +407,11 @@
       panel.classList.toggle('is-active', active);
       panel.setAttribute('aria-hidden', active ? 'false' : 'true');
     });
+    syncSignalModeNotice(enabled, mode);
   };
 
   const clearOverridesRequiredBySelectedPlugins = () => {
-    selectedPlugins.forEach((pluginId) => {
+    effectiveSelectedPluginIds().forEach((pluginId) => {
       const plugin = pluginMap.get(pluginId);
       if (!plugin || !Array.isArray(plugin.required_channels)) return;
       plugin.required_channels.forEach((channel) => overrides.delete(channel));
@@ -357,8 +420,9 @@
 
   const syncPluginToggles = () => {
     pluginToggles.forEach((toggle) => {
-      toggle.checked = selectedPlugins.has(toggle.value);
-      toggle.disabled = isPluginRequiredBySelection(toggle.value);
+      const paused = isPluginPausedBySignalMode(toggle.value);
+      toggle.checked = selectedPlugins.has(toggle.value) && !paused;
+      toggle.disabled = isPluginRequiredBySelection(toggle.value) || paused;
     });
   };
 
@@ -393,7 +457,7 @@
     [...document.querySelectorAll('[data-plugin-inline]')].forEach((panel) => {
       const pluginId = panel.dataset.pluginInline;
       const toggle = pluginToggles.find((item) => item.value === pluginId);
-      const isActive = !!(toggle && toggle.checked);
+      const isActive = !!(toggle && toggle.checked && !isPluginPausedBySignalMode(pluginId));
       panel.classList.toggle('is-active', isActive);
       panel.setAttribute('aria-hidden', isActive ? 'false' : 'true');
     });
@@ -402,6 +466,9 @@
   const syncWorkflowModuleVisualStates = () => {
     document.querySelectorAll('.plugin').forEach((row) => {
       const toggle = row.querySelector('.plugin-toggle');
+      const paused = !!(toggle && isPluginPausedBySignalMode(toggle.value));
+      row.classList.toggle('is-paused', paused);
+      row.setAttribute('aria-disabled', paused ? 'true' : 'false');
       row.classList.toggle('is-off', !!toggle && !toggle.checked);
     });
 
@@ -667,6 +734,7 @@
   ].forEach((input) => {
     if (!input) return;
     input.addEventListener('change', () => {
+      syncSignalSelectedPlugins();
       clearOverridesRequiredBySelectedPlugins();
       syncPluginToggles();
       syncRows();

--- a/cytocv/core/tables.py
+++ b/cytocv/core/tables.py
@@ -20,6 +20,7 @@ from core.services.measurement_contour_ratio import (
 )
 from core.services.puncta_line_mode import get_puncta_line_mode_metadata
 from core.services.cell_parentage import cell_parentage_payload_from_properties
+from core.services.signal_quantification import build_stat_visibility
 
 
 NUCLEAR_CELL_PAIR_LABELS = {
@@ -71,6 +72,47 @@ class CellTable(tables.Table):
         "distance_of_green_from_red_2": "distance",
         "distance_of_green_from_red_3": "distance",
     }
+    STAT_COLUMN_GROUPS = {
+        "puncta_distance": (
+            "puncta_distance",
+            "puncta_line_intensity",
+        ),
+        "red_green_intensity": (
+            "red_contour_1_size",
+            "red_contour_2_size",
+            "red_contour_3_size",
+            "green_contour_1_size",
+            "green_contour_2_size",
+            "green_contour_3_size",
+            "red_intensity_1",
+            "red_intensity_2",
+            "red_intensity_3",
+            "green_intensity_1",
+            "green_intensity_2",
+            "green_intensity_3",
+            "red_in_green_intensity_1",
+            "red_in_green_intensity_2",
+            "red_in_green_intensity_3",
+            "green_in_green_intensity_1",
+            "green_in_green_intensity_2",
+            "green_in_green_intensity_3",
+            "green_red_intensity_1",
+            "green_red_intensity_2",
+            "green_red_intensity_3",
+            "distance_of_green_from_red_1",
+            "distance_of_green_from_red_2",
+            "distance_of_green_from_red_3",
+        ),
+        "nuclear_cell_pair_intensity": (
+            "nuclear_cell_pair_contour_source",
+            "cell_pair_intensity_sum",
+            "nucleus_intensity_sum",
+            "cytoplasmic_intensity",
+        ),
+        "cen_dot": ("cell_parentage", "category_cen_dot"),
+        "biorientation": ("colinear_dots", "off_axis_dots"),
+        "legacy_blue_intensity": ("blue_contour_size",),
+    }
 
     cell_id = tables.Column(verbose_name="Cell ID")
     puncta_distance = NumberColumn(verbose_name="Distance Between Red Puncta")
@@ -109,6 +151,10 @@ class CellTable(tables.Table):
     distance_of_green_from_red_2 = NumberColumn(verbose_name="Distance Of Green From Red 2")
     distance_of_green_from_red_3 = NumberColumn(verbose_name="Distance Of Green From Red 3")
 
+    nuclear_cell_pair_contour_source = tables.Column(
+        verbose_name="Nucleus Contour Source",
+        empty_values=(),
+    )
     cell_pair_intensity_sum = NumberColumn(verbose_name=FALLBACK_NUCLEAR_CELL_PAIR_LABELS[0])
     nucleus_intensity_sum = NumberColumn(verbose_name=FALLBACK_NUCLEAR_CELL_PAIR_LABELS[1])
     cytoplasmic_intensity = NumberColumn(verbose_name="Cytoplasmic Intensity")
@@ -151,6 +197,7 @@ class CellTable(tables.Table):
             "distance_of_green_from_red_1",
             "distance_of_green_from_red_2",
             "distance_of_green_from_red_3",
+            "nuclear_cell_pair_contour_source",
             "cell_pair_intensity_sum",
             "nucleus_intensity_sum",
             "cytoplasmic_intensity",
@@ -166,11 +213,27 @@ class CellTable(tables.Table):
         *args,
         intensity_mode: str | None = None,
         puncta_line_mode: str | None = None,
+        stat_visibility: dict[str, bool] | None = None,
+        selected_plugins: list[str] | tuple[str, ...] | None = None,
         spatial_stats_unit: str = "px",
         scale_context: dict[str, object] | None = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
+        resolved_visibility = self._resolve_stat_visibility(
+            args[0] if args else kwargs.get("data"),
+            stat_visibility=stat_visibility,
+            selected_plugins=selected_plugins,
+        )
+        hidden_stat_columns: set[str] = set()
+        for visibility_key, field_names in self.STAT_COLUMN_GROUPS.items():
+            if resolved_visibility.get(visibility_key, True):
+                continue
+            for field_name in field_names:
+                if field_name in self.columns:
+                    self.columns.hide(field_name)
+                    hidden_stat_columns.add(field_name)
+        self._hidden_stat_columns = hidden_stat_columns
         self._spatial_stats_unit = normalize_spatial_stats_unit(spatial_stats_unit, default="px")
         resolved_scale_context = dict(scale_context or {})
         self._scale_context = {
@@ -197,12 +260,55 @@ class CellTable(tables.Table):
         self.columns["green_red_intensity_2"].column.verbose_name = ratio_headers[1]
         self.columns["green_red_intensity_3"].column.verbose_name = ratio_headers[2]
         for field_name, spatial_kind in self.SPATIAL_FIELDS.items():
+            if field_name not in self.columns:
+                continue
             column = self.columns[field_name].column
             column.verbose_name = format_spatial_stat_header(
                 str(column.verbose_name),
                 spatial_kind=spatial_kind,
                 unit=self._spatial_stats_unit,
             )
+
+    def as_values(self, exclude_columns=None):
+        hidden = set(getattr(self, "_hidden_stat_columns", set()))
+        if exclude_columns is not None:
+            hidden.update(exclude_columns)
+        yield from super().as_values(exclude_columns=hidden)
+
+    @classmethod
+    def _resolve_stat_visibility(
+        cls,
+        data,
+        *,
+        stat_visibility: dict[str, bool] | None = None,
+        selected_plugins: list[str] | tuple[str, ...] | None = None,
+    ) -> dict[str, bool]:
+        if isinstance(stat_visibility, dict):
+            return {
+                key: bool(stat_visibility.get(key, True))
+                for key in cls.STAT_COLUMN_GROUPS
+            }
+        if selected_plugins is not None:
+            return build_stat_visibility(selected_plugins)
+        first_record = None
+        if hasattr(data, "first"):
+            try:
+                first_record = data.first()
+            except Exception:
+                first_record = None
+        elif isinstance(data, (list, tuple)) and data:
+            first_record = data[0]
+        properties = getattr(first_record, "properties", {}) or {}
+        property_visibility = properties.get("stat_visibility")
+        if isinstance(property_visibility, dict):
+            return {
+                key: bool(property_visibility.get(key, True))
+                for key in cls.STAT_COLUMN_GROUPS
+            }
+        selected = properties.get("selected_analysis")
+        if isinstance(selected, list):
+            return build_stat_visibility(selected)
+        return {key: True for key in cls.STAT_COLUMN_GROUPS}
 
     @staticmethod
     def _has_no_nucleus_contour(record: CellStatistics) -> bool:
@@ -263,6 +369,18 @@ class CellTable(tables.Table):
         if self._has_no_nucleus_contour(record):
             return "N/A"
         return self._format_number(value)
+
+    @staticmethod
+    def _nuclear_cell_pair_contour_source(record: CellStatistics) -> str:
+        properties = getattr(record, "properties", {}) or {}
+        value = properties.get("nuclear_cell_pair_contour_source")
+        return str(value or "N/A")
+
+    def render_nuclear_cell_pair_contour_source(self, record: CellStatistics) -> str:
+        return self._nuclear_cell_pair_contour_source(record)
+
+    def value_nuclear_cell_pair_contour_source(self, record: CellStatistics) -> str:
+        return self._nuclear_cell_pair_contour_source(record)
 
     def render_cell_pair_intensity_sum(self, value: float, record: CellStatistics) -> str:
         return self._render_nuclear_cell_pair_value(record, value)

--- a/cytocv/core/tests/test_accounts_preferences.py
+++ b/cytocv/core/tests/test_accounts_preferences.py
@@ -243,6 +243,31 @@ class PreferenceNormalizationTests(TestCase):
         self.assertTrue(selection.alternate_nucleus_detection_enabled)
         self.assertEqual(selection.alternate_nucleus_detection_channel, CHANNEL_ROLE_GREEN)
 
+    def test_signal_quantification_nuclear_mode_preserves_configured_secondary_plugins(self):
+        selection = resolve_signal_quantification_selection(
+            payload={
+                "signal_quantification_enabled": True,
+                "signal_quantification_mode": "nuclear_cell_pair",
+                "puncta_contour_intensity_enabled": True,
+            },
+            selected_plugins=[
+                "PunctaDistance",
+                "GreenRedIntensity",
+                "CENDot",
+                "Biorientation",
+            ],
+            nuclear_cell_pair_mode="green_nucleus",
+        )
+
+        self.assertEqual(
+            selection.configured_plugins,
+            ("CENDot", "Biorientation", "NuclearCellPairIntensity"),
+        )
+        self.assertEqual(selection.selected_plugins, ("NuclearCellPairIntensity",))
+        self.assertEqual(selection.paused_plugins, ("CENDot", "Biorientation"))
+        self.assertFalse(selection.stat_visibility["cen_dot"])
+        self.assertFalse(selection.stat_visibility["biorientation"])
+
     def test_sidebar_spatial_stats_unit_falls_back_to_workflow_default(self):
         normalized = normalize_preferences_payload(
             {
@@ -2285,6 +2310,36 @@ class ChannelVisibilityPreferenceTests(TestCase):
         self.assertEqual(defaults["microns_per_pixel"], 0.25)
         self.assertTrue(defaults["use_metadata_scale"])
         self.assertEqual(defaults["spatial_stats_unit"], "um")
+
+    def test_plugin_settings_form_preserves_paused_secondary_plugins_in_nuclear_mode(self):
+        response = self.client.post(
+            reverse("workflow_defaults"),
+            {
+                "action": "save_plugin_defaults",
+                "selected_plugins": [
+                    "NuclearCellPairIntensity",
+                    "CENDot",
+                    "Biorientation",
+                ],
+                "signal_quantification_enabled": "1",
+                "signal_quantification_mode": "nuclear_cell_pair",
+                "puncta_contour_intensity_enabled": "1",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+
+        self.user.refresh_from_db()
+        defaults = get_user_preferences(self.user)["experiment_defaults"]
+        self.assertEqual(
+            defaults["selected_plugins"],
+            ["CENDot", "Biorientation", "NuclearCellPairIntensity"],
+        )
+        selection = resolve_signal_quantification_selection(
+            payload=defaults,
+            selected_plugins=defaults["selected_plugins"],
+            nuclear_cell_pair_mode=defaults["nuclear_cell_pair_mode"],
+        )
+        self.assertEqual(selection.selected_plugins, ("NuclearCellPairIntensity",))
 
     def test_advanced_settings_save_preserves_measurement_defaults(self):
         payload = get_user_preferences(self.user)

--- a/cytocv/core/tests/test_accounts_preferences.py
+++ b/cytocv/core/tests/test_accounts_preferences.py
@@ -21,6 +21,7 @@ from accounts.preferences import (
     should_auto_save_experiments,
     update_user_preferences,
 )
+from core.channel_roles import CHANNEL_ROLE_GREEN
 from core.models import (
     CellStatistics,
     DVLayerTifPreview,
@@ -29,6 +30,7 @@ from core.models import (
     get_guest_user,
 )
 from core.scale import apply_manual_override_scale, build_scale_info
+from core.services.signal_quantification import resolve_signal_quantification_selection
 from core.stats_plugins import PLUGIN_DEFINITIONS
 
 
@@ -43,9 +45,12 @@ class PreferenceNormalizationTests(TestCase):
                 "CENDot",
                 "Biorientation",
                 "GreenRedIntensity",
-                "NuclearCellPairIntensity",
             ],
         )
+        self.assertTrue(defaults["signal_quantification_enabled"])
+        self.assertEqual(defaults["signal_quantification_mode"], "puncta_distance")
+        self.assertTrue(defaults["puncta_contour_intensity_enabled"])
+        self.assertTrue(defaults["alternate_nucleus_detection_enabled"])
         self.assertEqual(defaults["puncta_line_mode"], "red_puncta")
         self.assertEqual(defaults["nuclear_cell_pair_mode"], "green_nucleus")
         self.assertTrue(defaults["green_dot_split_enabled"])
@@ -87,13 +92,16 @@ class PreferenceNormalizationTests(TestCase):
 
         defaults = normalized["experiment_defaults"]
         self.assertEqual(defaults["selected_plugins"], ["PunctaDistance"])
+        self.assertTrue(defaults["signal_quantification_enabled"])
+        self.assertEqual(defaults["signal_quantification_mode"], "puncta_distance")
+        self.assertFalse(defaults["puncta_contour_intensity_enabled"])
         self.assertTrue(defaults["module_enabled"])
         self.assertTrue(defaults["enforce_layer_count"])
         self.assertFalse(defaults["enforce_wavelengths"])
         self.assertEqual(defaults["manual_required_channels"], ["DIC"])
         self.assertEqual(defaults["puncta_line_width"], 1)
         self.assertEqual(defaults["cen_dot_distance"], 37)
-        self.assertEqual(defaults["biorientation_collinearity_threshold"], 66)
+        self.assertEqual(defaults["biorientation_collinearity_threshold"], 3)
         self.assertEqual(defaults["puncta_line_mode"], "red_puncta")
         self.assertEqual(defaults["nuclear_cell_pair_mode"], "green_nucleus")
         self.assertEqual(defaults["green_dot_split_mode"], "balanced")
@@ -127,6 +135,113 @@ class PreferenceNormalizationTests(TestCase):
             normalized["experiment_defaults"]["selected_plugins"],
             ["CENDot"],
         )
+        self.assertFalse(
+            normalized["experiment_defaults"]["signal_quantification_enabled"]
+        )
+
+    def test_normalize_preferences_migrates_legacy_primary_stats_to_puncta_mode(self):
+        normalized = normalize_preferences_payload(
+            {
+                "experiment_defaults": {
+                    "selected_plugins": [
+                        "PunctaDistance",
+                        "GreenRedIntensity",
+                        "NuclearCellPairIntensity",
+                        "CENDot",
+                    ],
+                }
+            }
+        )
+
+        defaults = normalized["experiment_defaults"]
+        self.assertEqual(
+            defaults["selected_plugins"],
+            ["PunctaDistance", "CENDot", "GreenRedIntensity"],
+        )
+        self.assertTrue(defaults["signal_quantification_enabled"])
+        self.assertEqual(defaults["signal_quantification_mode"], "puncta_distance")
+        self.assertTrue(defaults["puncta_contour_intensity_enabled"])
+
+    def test_normalize_preferences_migrates_legacy_nuclear_only_mode(self):
+        normalized = normalize_preferences_payload(
+            {
+                "experiment_defaults": {
+                    "selected_plugins": [
+                        "NuclearCellPairIntensity",
+                        "Biorientation",
+                    ],
+                }
+            }
+        )
+
+        defaults = normalized["experiment_defaults"]
+        self.assertEqual(
+            defaults["selected_plugins"],
+            ["Biorientation", "NuclearCellPairIntensity"],
+        )
+        self.assertTrue(defaults["signal_quantification_enabled"])
+        self.assertEqual(defaults["signal_quantification_mode"], "nuclear_cell_pair")
+        self.assertFalse(defaults["puncta_contour_intensity_enabled"])
+
+    def test_normalize_preferences_parent_off_keeps_independent_stats_only(self):
+        normalized = normalize_preferences_payload(
+            {
+                "experiment_defaults": {
+                    "selected_plugins": [
+                        "PunctaDistance",
+                        "GreenRedIntensity",
+                        "CENDot",
+                    ],
+                    "signal_quantification_enabled": False,
+                }
+            }
+        )
+
+        defaults = normalized["experiment_defaults"]
+        self.assertEqual(defaults["selected_plugins"], ["CENDot"])
+        self.assertFalse(defaults["signal_quantification_enabled"])
+
+    def test_normalize_preferences_accepts_legacy_alternate_detection_payload(self):
+        normalized = normalize_preferences_payload(
+            {
+                "experiment_defaults": {
+                    "selected_plugins": ["NuclearCellPairIntensity"],
+                    "alternate_red_detection": True,
+                }
+            }
+        )
+
+        defaults = normalized["experiment_defaults"]
+        self.assertTrue(defaults["alternate_nucleus_detection_enabled"])
+        self.assertTrue(defaults["alternate_red_detection"])
+
+    def test_signal_quantification_ignores_alternate_detection_in_puncta_mode(self):
+        selection = resolve_signal_quantification_selection(
+            payload={
+                "signal_quantification_enabled": True,
+                "signal_quantification_mode": "puncta_distance",
+                "alternate_nucleus_detection_enabled": True,
+            },
+            selected_plugins=["PunctaDistance", "GreenRedIntensity"],
+            nuclear_cell_pair_mode="green_nucleus",
+        )
+
+        self.assertTrue(selection.alternate_nucleus_detection_enabled)
+        self.assertIsNone(selection.alternate_nucleus_detection_channel)
+
+    def test_signal_quantification_applies_alternate_detection_in_nuclear_mode(self):
+        selection = resolve_signal_quantification_selection(
+            payload={
+                "signal_quantification_enabled": True,
+                "signal_quantification_mode": "nuclear_cell_pair",
+                "alternate_nucleus_detection_enabled": True,
+            },
+            selected_plugins=["NuclearCellPairIntensity"],
+            nuclear_cell_pair_mode="green_nucleus",
+        )
+
+        self.assertTrue(selection.alternate_nucleus_detection_enabled)
+        self.assertEqual(selection.alternate_nucleus_detection_channel, CHANNEL_ROLE_GREEN)
 
     def test_sidebar_spatial_stats_unit_falls_back_to_workflow_default(self):
         normalized = normalize_preferences_payload(
@@ -724,6 +839,42 @@ class DisplayManualSaveTests(TestCase):
         self.assertContains(response, 'Green In Green Raw Sums')
         self.assertContains(response, 'Raw Green-channel intensity summed inside each ranked Green contour slot')
         self.assertNotContains(response, 'Intensity + Green Output')
+
+    def test_display_view_serializes_nuclear_contour_source_without_stat_card_row(self):
+        saved_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="display_contour_source",
+        )
+        self._add_cell_stat(saved_uuid)
+        cell_stat = CellStatistics.objects.get(
+            segmented_image__UUID=saved_uuid,
+            cell_id=1,
+        )
+        properties = dict(cell_stat.properties or {})
+        properties.update(
+            {
+                "selected_analysis": ["NuclearCellPairIntensity"],
+                "nuclear_cell_pair_contour_channel": "Red",
+                "nuclear_cell_pair_measurement_channel": "Green",
+                "nuclear_cell_pair_contour_source": "alternate_red_nucleus_slot_1",
+                "nuclear_cell_pair_status": "ok",
+            }
+        )
+        cell_stat.properties = properties
+        cell_stat.save(update_fields=["properties"])
+
+        response = self.client.get(reverse("display", args=[saved_uuid]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'id="nucleusContourSource"', html=False)
+        self.assertNotContains(response, "Contour Source Used", html=False)
+        files_data = json.loads(response.context["files_data"])
+        payload = files_data[saved_uuid]["Statistics"]["1"]
+        self.assertEqual(
+            payload["nuclear_cell_pair_contour_source"],
+            "alternate_red_nucleus_slot_1",
+        )
 
     def test_dashboard_template_exposes_preferred_main_image_channel(self):
         self._create_display_file(
@@ -1589,9 +1740,20 @@ class ChannelVisibilityPreferenceTests(TestCase):
         self.assertContains(response, 'id="prefsGfpFilterExperimentalDot"', html=False)
         self.assertContains(response, 'id="green_dot_split_enabled"', html=False)
         self.assertContains(response, 'id="green_dot_split_mode"', html=False)
+        self.assertContains(response, "Signal Quantification")
+        self.assertContains(response, 'id="signal_quantification_enabled"', html=False)
+        self.assertContains(response, 'id="signal_quantification_mode"', html=False)
+        self.assertContains(response, "Red/Green Contour Intensities")
+        self.assertContains(response, "Alternate Nucleus Detection")
+        self.assertContains(
+            response,
+            "Only affects Nuclear, Cell-Pair Intensity. Uses the alternate contour detection path on the selected nucleus source channel only.",
+        )
+        self.assertContains(response, 'id="alternate_nucleus_detection_enabled"', html=False)
         self.assertNotContains(response, 'id="cell_parentage_mode"', html=False)
         self.assertNotContains(response, "Mother/Daughter Mode")
         self.assertNotContains(response, 'id="biorientation_green_split_enabled"', html=False)
+        self.assertNotContains(response, 'id="alternate_red_detection"', html=False)
         self.assertNotContains(response, 'data-workflow-card="channel-requirements"', html=False)
         html = response.content.decode()
         plugin_defaults_index = html.index('<div class="card" data-workflow-card="plugin-defaults"')
@@ -1629,7 +1791,7 @@ class ChannelVisibilityPreferenceTests(TestCase):
         )
         self.assertContains(
             response,
-            "Utilize an alternate Red detection mode where the tool attempts to find a single contour to surround all speckles.",
+            "Uses the alternate contour detection path on the selected nucleus source channel only.",
         )
         self.assertContains(response, 'id="reviewChangesBackdrop"', html=False)
         self.assertContains(response, 'class="review-backdrop popup-backdrop"', html=False)
@@ -1686,6 +1848,7 @@ class ChannelVisibilityPreferenceTests(TestCase):
         self.assertTrue(defaults["green_contour_filter_enabled"])
         self.assertFalse(defaults["green_dot_split_enabled"])
         self.assertEqual(defaults["green_dot_split_mode"], "aggressive")
+        self.assertTrue(defaults["alternate_nucleus_detection_enabled"])
         self.assertTrue(defaults["alternate_red_detection"])
         self.assertEqual(defaults["puncta_line_width"], 2.5)
         self.assertEqual(defaults["puncta_line_width_unit"], "um")
@@ -1770,6 +1933,40 @@ class ChannelVisibilityPreferenceTests(TestCase):
         self.assertEqual(rendered_defaults["green_dot_split_mode"], "aggressive")
         self.assertEqual(rendered_defaults["nuclear_cell_pair_mode"], "red_nucleus")
 
+    def test_experiment_page_restores_saved_nuclear_signal_quantification_defaults(self):
+        payload = self._build_experiment_workflow_defaults_payload()
+        payload.update(
+            {
+                "selected_plugins": ["CENDot"],
+                "signal_quantification_enabled": True,
+                "signal_quantification_mode": "nuclear_cell_pair",
+                "puncta_contour_intensity_enabled": False,
+                "alternate_nucleus_detection_enabled": True,
+                "alternate_red_detection": True,
+                "nuclear_cell_pair_mode": "green_nucleus",
+            }
+        )
+
+        response = self.client.post(
+            reverse("experiment_workflow_defaults"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        experiment_response = self.client.get(reverse("experiment"))
+        self.assertEqual(experiment_response.status_code, 200)
+        rendered_defaults = json.loads(experiment_response.context["user_preference_defaults_json"])
+        self.assertEqual(
+            rendered_defaults["selected_plugins"],
+            ["CENDot", "NuclearCellPairIntensity"],
+        )
+        self.assertTrue(rendered_defaults["signal_quantification_enabled"])
+        self.assertEqual(rendered_defaults["signal_quantification_mode"], "nuclear_cell_pair")
+        self.assertFalse(rendered_defaults["puncta_contour_intensity_enabled"])
+        self.assertTrue(rendered_defaults["alternate_nucleus_detection_enabled"])
+        self.assertEqual(rendered_defaults["nuclear_cell_pair_mode"], "green_nucleus")
+
     def test_preferences_plugin_payload_includes_exclusive_and_dependency_fields(self):
         response = self.client.get(reverse("workflow_defaults"))
         self.assertEqual(response.status_code, 200)
@@ -1793,7 +1990,6 @@ class ChannelVisibilityPreferenceTests(TestCase):
             "CENDot",
             "Biorientation",
             "GreenRedIntensity",
-            "NuclearCellPairIntensity",
         ):
             self.assertContains(response, PLUGIN_DEFINITIONS[plugin_id].label)
 
@@ -2028,9 +2224,11 @@ class ChannelVisibilityPreferenceTests(TestCase):
                 "CENDot",
                 "Biorientation",
                 "GreenRedIntensity",
-                "NuclearCellPairIntensity",
             ],
         )
+        self.assertTrue(defaults["signal_quantification_enabled"])
+        self.assertEqual(defaults["signal_quantification_mode"], "puncta_distance")
+        self.assertTrue(defaults["puncta_contour_intensity_enabled"])
         self.assertEqual(defaults["puncta_line_mode"], "red_puncta")
         self.assertEqual(defaults["nuclear_cell_pair_mode"], "green_nucleus")
         self.assertTrue(defaults["green_dot_split_enabled"])
@@ -2080,6 +2278,7 @@ class ChannelVisibilityPreferenceTests(TestCase):
         self.assertTrue(defaults["green_contour_filter_enabled"])
         self.assertFalse(defaults["green_dot_split_enabled"])
         self.assertEqual(defaults["green_dot_split_mode"], "aggressive")
+        self.assertTrue(defaults["alternate_nucleus_detection_enabled"])
         self.assertTrue(defaults["alternate_red_detection"])
         self.assertEqual(defaults["puncta_line_mode"], "green_puncta")
         self.assertEqual(defaults["nuclear_cell_pair_mode"], "red_nucleus")
@@ -2103,6 +2302,7 @@ class ChannelVisibilityPreferenceTests(TestCase):
                 "green_contour_filter_enabled": True,
                 "green_dot_split_enabled": False,
                 "green_dot_split_mode": "aggressive",
+                "alternate_nucleus_detection_enabled": True,
                 "alternate_red_detection": True,
                 "puncta_line_mode": "green_puncta",
                 "nuclear_cell_pair_mode": "red_nucleus",

--- a/cytocv/core/tests/test_analysis_async.py
+++ b/cytocv/core/tests/test_analysis_async.py
@@ -209,6 +209,72 @@ class AnalysisAsyncTestCase(TestCase):
             run_batch_mock.assert_called_once()
 
     @override_settings(ANALYSIS_EXECUTION_MODE="sync")
+    def test_pre_process_post_preserves_signal_quantification_alternate_detection(self):
+        with temporary_media_root() as media_root:
+            uploaded = self._create_uploaded_image(media_root, name="sync_signal_quant")
+
+            def run_batch_side_effect(*, user, context, progress, **_kwargs):
+                self.assertEqual(
+                    context.config_snapshot["selected_analysis"],
+                    ["CENDot", "NuclearCellPairIntensity"],
+                )
+                self.assertTrue(context.config_snapshot["signalQuantificationEnabled"])
+                self.assertEqual(
+                    context.config_snapshot["signalQuantificationMode"],
+                    "nuclear_cell_pair",
+                )
+                self.assertTrue(
+                    context.config_snapshot["alternateNucleusDetectionEnabled"]
+                )
+                self.assertEqual(
+                    context.config_snapshot["alternateNucleusDetectionChannel"],
+                    "channel_red",
+                )
+                self.assertEqual(
+                    context.config_snapshot["nuclear_cell_pair_mode"],
+                    "red_nucleus",
+                )
+                return SimpleNamespace(storage_warning_message="")
+
+            with patch(
+                "core.views.pre_process.ensure_preview_assets",
+                return_value=[],
+            ), patch(
+                "core.views.pre_process.run_analysis_batch",
+                side_effect=run_batch_side_effect,
+            ):
+                response = self.client.post(
+                    reverse("pre_process", args=[str(uploaded.uuid)]),
+                    {
+                        "selected_analysis": [
+                            "PunctaDistance",
+                            "GreenRedIntensity",
+                            "CENDot",
+                        ],
+                        "signalQuantificationEnabled": "true",
+                        "signalQuantificationMode": "nuclear_cell_pair",
+                        "punctaContourIntensityEnabled": "true",
+                        "alternateNucleusDetectionEnabled": "true",
+                        "nuclear_cell_pair_mode": "red_nucleus",
+                    },
+                    HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+                )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["status"], "succeeded")
+            self.assertEqual(
+                self.client.session.get("selected_analysis"),
+                ["CENDot", "NuclearCellPairIntensity"],
+            )
+            self.assertTrue(
+                self.client.session.get("alternateNucleusDetectionEnabled")
+            )
+            self.assertEqual(
+                self.client.session.get("alternateNucleusDetectionChannel"),
+                "channel_red",
+            )
+
+    @override_settings(ANALYSIS_EXECUTION_MODE="sync")
     def test_pre_process_sync_mode_cancel_returns_cancelled_without_segment_redirect(self):
         with temporary_media_root() as media_root:
             uploaded = self._create_uploaded_image(media_root, name="sync_cancel")

--- a/cytocv/core/tests/test_analysis_async.py
+++ b/cytocv/core/tests/test_analysis_async.py
@@ -216,7 +216,7 @@ class AnalysisAsyncTestCase(TestCase):
             def run_batch_side_effect(*, user, context, progress, **_kwargs):
                 self.assertEqual(
                     context.config_snapshot["selected_analysis"],
-                    ["CENDot", "NuclearCellPairIntensity"],
+                    ["NuclearCellPairIntensity"],
                 )
                 self.assertTrue(context.config_snapshot["signalQuantificationEnabled"])
                 self.assertEqual(
@@ -264,7 +264,7 @@ class AnalysisAsyncTestCase(TestCase):
             self.assertEqual(response.json()["status"], "succeeded")
             self.assertEqual(
                 self.client.session.get("selected_analysis"),
-                ["CENDot", "NuclearCellPairIntensity"],
+                ["NuclearCellPairIntensity"],
             )
             self.assertTrue(
                 self.client.session.get("alternateNucleusDetectionEnabled")

--- a/cytocv/core/tests/test_biorientation.py
+++ b/cytocv/core/tests/test_biorientation.py
@@ -64,7 +64,7 @@ class BiorientationTests(SimpleTestCase):
         cell_mask: np.ndarray | None = None,
         min_distance: float = 0.0,
         max_distance: float = 37.0,
-        threshold: int = 66,
+        threshold: int = 3,
     ):
         cp = SimpleNamespace(
             image_name="test.dv",
@@ -163,3 +163,60 @@ class BiorientationTests(SimpleTestCase):
 
         self.assertEqual(cp.colinear_dots, 2)
         self.assertEqual(cp.off_axis_dots, 0)
+
+    def test_perpendicular_offset_within_threshold_is_colinear(self):
+        cp = self._run(
+            red_centers=[(10, 20), (20, 20)],
+            green_centers=[(15, 22)],
+            threshold=3,
+        )
+
+        self.assertEqual(cp.colinear_dots, 1)
+        self.assertEqual(cp.off_axis_dots, 0)
+
+    def test_perpendicular_offset_beyond_threshold_is_off_axis(self):
+        cp = self._run(
+            red_centers=[(10, 20), (20, 20)],
+            green_centers=[(15, 25)],
+            threshold=3,
+        )
+
+        self.assertEqual(cp.colinear_dots, 0)
+        self.assertEqual(cp.off_axis_dots, 1)
+
+    def test_classification_is_invariant_to_red_red_distance(self):
+        short = self._run(
+            red_centers=[(10, 20), (20, 20)],
+            green_centers=[(15, 22)],
+            threshold=3,
+            max_distance=40,
+        )
+        long = self._run(
+            red_centers=[(5, 20), (35, 20)],
+            green_centers=[(20, 22)],
+            threshold=3,
+            max_distance=40,
+        )
+
+        self.assertEqual(
+            (short.colinear_dots, short.off_axis_dots),
+            (long.colinear_dots, long.off_axis_dots),
+        )
+        self.assertEqual(long.colinear_dots, 1)
+        self.assertEqual(long.off_axis_dots, 0)
+
+    def test_dot_on_infinite_line_outside_segment_is_off_axis(self):
+        cp = self._run(
+            red_centers=[(10, 20), (30, 20)],
+            green_centers=[(35, 20)],
+            threshold=3,
+            max_distance=40,
+        )
+
+        self.assertEqual(cp.colinear_dots, 0)
+        self.assertEqual(cp.off_axis_dots, 1)
+
+    def test_zero_length_axis_returns_false(self):
+        self.assertFalse(
+            Biorientation._is_collinear((10.0, 10.0), (5.0, 5.0), (5.0, 5.0), 3)
+        )

--- a/cytocv/core/tests/test_green_dot_split_config.py
+++ b/cytocv/core/tests/test_green_dot_split_config.py
@@ -26,6 +26,38 @@ class GreenDotSplitConfigTests(SimpleTestCase):
 
         self.assertEqual(normalized["greenDotSplitMode"], "balanced")
 
+    def test_analysis_snapshot_derives_puncta_without_contour_intensity(self):
+        normalized = normalize_analysis_config_snapshot(
+            {
+                "selected_analysis": ["PunctaDistance"],
+                "puncta_line_mode": "green_puncta",
+            }
+        )
+
+        self.assertEqual(normalized["selected_analysis"], ["PunctaDistance"])
+        self.assertTrue(normalized["signalQuantificationEnabled"])
+        self.assertEqual(normalized["signalQuantificationMode"], "puncta_distance")
+        self.assertFalse(normalized["punctaContourIntensityEnabled"])
+
+    def test_analysis_snapshot_derives_nuclear_mode_and_alternate_target(self):
+        normalized = normalize_analysis_config_snapshot(
+            {
+                "selected_analysis": ["PunctaDistance", "GreenRedIntensity", "CENDot"],
+                "signalQuantificationEnabled": True,
+                "signalQuantificationMode": "nuclear_cell_pair",
+                "alternateNucleusDetectionEnabled": True,
+                "nuclear_cell_pair_mode": "red_nucleus",
+            }
+        )
+
+        self.assertEqual(
+            normalized["selected_analysis"],
+            ["CENDot", "NuclearCellPairIntensity"],
+        )
+        self.assertEqual(normalized["signalQuantificationMode"], "nuclear_cell_pair")
+        self.assertTrue(normalized["alternateNucleusDetectionEnabled"])
+        self.assertEqual(normalized["alternateNucleusDetectionChannel"], "channel_red")
+
     def test_overlay_render_config_preserves_green_dot_split_mode(self):
         config = build_overlay_render_config(
             image_stem="sample",

--- a/cytocv/core/tests/test_modern_contour_statistics.py
+++ b/cytocv/core/tests/test_modern_contour_statistics.py
@@ -17,6 +17,7 @@ from core.services.canonical_contours import (
     build_canonical_contour_payload,
     flatten_slot_contours,
 )
+from core.services.signal_quantification import SIGNAL_MODE_NUCLEAR_CELL_PAIR
 from core.stats_plugins import build_stats_execution_plan
 from core.views.segment_image import get_stats
 
@@ -32,6 +33,25 @@ class ModernContourStatisticsTests(SimpleTestCase):
     @staticmethod
     def _rgb(image: np.ndarray) -> np.ndarray:
         return np.dstack([image, image, image]).astype(np.uint8)
+
+    @staticmethod
+    def _dominant_red_pixel_count(image: np.ndarray) -> int:
+        return int(np.count_nonzero((image[:, :, 0] > image[:, :, 1]) & (image[:, :, 0] > image[:, :, 2])))
+
+    @staticmethod
+    def _dominant_green_pixel_count(image: np.ndarray) -> int:
+        return int(np.count_nonzero((image[:, :, 1] > image[:, :, 0]) & (image[:, :, 1] > image[:, :, 2])))
+
+    @staticmethod
+    def _colored_outline_pixel_count(
+        image: np.ndarray,
+        contour: np.ndarray,
+        rgb_color: tuple[int, int, int],
+    ) -> int:
+        mask = np.zeros(image.shape[:2], dtype=np.uint8)
+        cv2.drawContours(mask, [contour], -1, 255, 1)
+        color = np.array(rgb_color, dtype=np.uint8)
+        return int(np.count_nonzero((mask > 0) & np.all(image == color, axis=2)))
 
     @staticmethod
     def _write_outline(output_dir: Path, *, image_stem: str = "test", cell_id: int = 1, y_range=range(0), x_range=range(0)) -> None:
@@ -60,8 +80,9 @@ class ModernContourStatisticsTests(SimpleTestCase):
         mode: str,
         analysis: list[str],
         puncta_line_mode: str = "red_puncta",
+        signal_quantification_mode: str | None = None,
     ) -> dict:
-        return {
+        conf = {
             "input_dir": output_dir,
             "output_dir": output_dir,
             "kernel_size": 3,
@@ -72,6 +93,9 @@ class ModernContourStatisticsTests(SimpleTestCase):
             "puncta_line_mode": puncta_line_mode,
             "nuclear_cell_pair_mode": mode,
         }
+        if signal_quantification_mode is not None:
+            conf["signal_quantification_mode"] = signal_quantification_mode
+        return conf
 
     def _run_get_stats(
         self,
@@ -86,6 +110,9 @@ class ModernContourStatisticsTests(SimpleTestCase):
         green_no_bg_gray: np.ndarray | None = None,
         puncta_line_mode: str = "red_puncta",
         cen_dot_distance: float = 37.0,
+        alternate_enabled: bool = False,
+        alternate_channel: str | None = None,
+        signal_quantification_mode: str | None = None,
     ):
         cp = SimpleNamespace(
             image_name="test.dv",
@@ -130,13 +157,128 @@ class ModernContourStatisticsTests(SimpleTestCase):
                         mode=mode,
                         analysis=selected_analysis,
                         puncta_line_mode=puncta_line_mode,
+                        signal_quantification_mode=signal_quantification_mode,
                     ),
                     execution_plan,
                     puncta_line_width=1,
                     cen_dot_distance=cen_dot_distance,
+                    alternate_red_detection=alternate_enabled,
+                    alternate_detection_channel=alternate_channel,
                 )
 
         return cp, np.array(debug_red), np.array(debug_green), np.array(debug_blue)
+
+    def _run_live_get_stats(
+        self,
+        *,
+        mode: str,
+        selected_analysis: list[str],
+        preprocessed: GrayImage,
+        y_range,
+        x_range,
+        puncta_line_mode: str = "red_puncta",
+        alternate_enabled: bool = False,
+        alternate_channel: str | None = None,
+    ):
+        cp = SimpleNamespace(
+            image_name="test.dv",
+            cell_id=1,
+            properties={},
+        )
+        red_gray = preprocessed.get_image("gray_red")
+        green_gray = preprocessed.get_image("green")
+        assert red_gray is not None
+        assert green_gray is not None
+        images = {
+            "red": self._rgb(red_gray),
+            "green": self._rgb(green_gray),
+            "blue": self._rgb(np.zeros_like(red_gray)),
+        }
+        execution_plan = build_stats_execution_plan(selected_analysis)
+
+        with TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir)
+            self._write_outline(
+                output_dir,
+                y_range=y_range,
+                x_range=x_range,
+            )
+            with patch("core.views.segment_image.load_image", return_value=images), patch(
+                "core.views.segment_image.preprocess_image_to_gray",
+                return_value=preprocessed,
+            ):
+                debug_red, debug_green, debug_blue = get_stats(
+                    cp,
+                    self._conf(
+                        temp_dir,
+                        mode=mode,
+                        analysis=selected_analysis,
+                        puncta_line_mode=puncta_line_mode,
+                    ),
+                    execution_plan,
+                    puncta_line_width=1,
+                    cen_dot_distance=37.0,
+                    alternate_red_detection=alternate_enabled,
+                    alternate_detection_channel=alternate_channel,
+                )
+
+        return cp, np.array(debug_red), np.array(debug_green), np.array(debug_blue)
+
+    @staticmethod
+    def _build_live_alternate_detection_images(shape: tuple[int, int] = (40, 40)) -> GrayImage:
+        red_gray = np.zeros(shape, dtype=np.uint8)
+        green_gray = np.zeros(shape, dtype=np.uint8)
+        raw_red = np.zeros(shape, dtype=np.uint16)
+        raw_green = np.zeros(shape, dtype=np.uint16)
+
+        red_gray[10:25, 10:25] = 20
+        red_gray[13:19, 13:19] = 255
+        green_gray[10:25, 10:25] = 20
+        green_gray[13:19, 13:19] = 255
+        raw_red[10:25, 10:25] = 90
+        raw_green[10:25, 10:25] = 60
+
+        return GrayImage(
+            img={
+                "red_no_bg": red_gray,
+                "gray_red": red_gray,
+                "gray_red_3": red_gray,
+                "green": green_gray,
+                "green_no_bg": green_gray,
+                "raw_red": raw_red,
+                "raw_green": raw_green,
+                "gray_blue": np.zeros(shape, dtype=np.uint8),
+                "gray_blue_3": np.zeros(shape, dtype=np.uint8),
+            }
+        )
+
+    @staticmethod
+    def _build_live_puncta_images(shape: tuple[int, int] = (36, 36)) -> GrayImage:
+        red_gray = np.zeros(shape, dtype=np.uint8)
+        green_gray = np.zeros(shape, dtype=np.uint8)
+        raw_red = np.zeros(shape, dtype=np.uint16)
+        raw_green = np.zeros(shape, dtype=np.uint16)
+
+        red_gray[8:12, 8:12] = 255
+        red_gray[22:26, 22:26] = 255
+        green_gray[9:25, 9:25] = 30
+        raw_red[8:12, 8:12] = 50
+        raw_red[22:26, 22:26] = 60
+        raw_green[9:25, 9:25] = 30
+
+        return GrayImage(
+            img={
+                "red_no_bg": red_gray,
+                "gray_red": red_gray,
+                "gray_red_3": red_gray,
+                "green": green_gray,
+                "green_no_bg": green_gray,
+                "raw_red": raw_red,
+                "raw_green": raw_green,
+                "gray_blue": np.zeros(shape, dtype=np.uint8),
+                "gray_blue_3": np.zeros(shape, dtype=np.uint8),
+            }
+        )
 
     @staticmethod
     def _tightening_support_and_core_images(
@@ -331,6 +473,395 @@ class ModernContourStatisticsTests(SimpleTestCase):
         self.assertEqual(cp.properties["puncta_line_measurement_channel"], "channel_red")
         self.assertAlmostEqual(cp.puncta_distance, 6.0, places=4)
         self.assertEqual(cp.puncta_line_intensity, 14.0)
+
+    def test_live_nuclear_mode_red_nucleus_alternate_detection_uses_alternate_red_source(self):
+        preprocessed = self._build_live_alternate_detection_images()
+        cp_off, debug_red_off, _, _ = self._run_live_get_stats(
+            mode="red_nucleus",
+            selected_analysis=["NuclearCellPairIntensity"],
+            preprocessed=preprocessed,
+            y_range=range(8, 28),
+            x_range=range(8, 28),
+            alternate_enabled=False,
+            alternate_channel=CHANNEL_ROLE_RED,
+        )
+        cp_on, debug_red_on, _, _ = self._run_live_get_stats(
+            mode="red_nucleus",
+            selected_analysis=["NuclearCellPairIntensity"],
+            preprocessed=preprocessed,
+            y_range=range(8, 28),
+            x_range=range(8, 28),
+            alternate_enabled=True,
+            alternate_channel=CHANNEL_ROLE_RED,
+        )
+
+        self.assertEqual(cp_on.properties["selected_analysis"], ["NuclearCellPairIntensity"])
+        self.assertTrue(cp_on.properties["alternate_nucleus_detection_enabled"])
+        self.assertEqual(cp_on.properties["alternate_nucleus_detection_channel"], CHANNEL_ROLE_RED)
+        self.assertEqual(cp_off.properties["nuclear_cell_pair_contour_source"], "canonical_slot_1")
+        self.assertEqual(
+            cp_on.properties["nuclear_cell_pair_contour_source"],
+            "alternate_red_nucleus_slot_1",
+        )
+        self.assertGreater(cp_on.nucleus_intensity_sum, cp_off.nucleus_intensity_sum)
+        self.assertGreater(
+            self._dominant_red_pixel_count(debug_red_on),
+            self._dominant_red_pixel_count(debug_red_off),
+        )
+
+    def test_live_nuclear_mode_green_nucleus_alternate_detection_uses_alternate_green_source(self):
+        preprocessed = self._build_live_alternate_detection_images()
+        cp_off, debug_red_off, _, _ = self._run_live_get_stats(
+            mode="green_nucleus",
+            selected_analysis=["NuclearCellPairIntensity"],
+            preprocessed=preprocessed,
+            y_range=range(8, 28),
+            x_range=range(8, 28),
+            alternate_enabled=False,
+            alternate_channel=CHANNEL_ROLE_GREEN,
+        )
+        cp_on, debug_red_on, _, _ = self._run_live_get_stats(
+            mode="green_nucleus",
+            selected_analysis=["NuclearCellPairIntensity"],
+            preprocessed=preprocessed,
+            y_range=range(8, 28),
+            x_range=range(8, 28),
+            alternate_enabled=True,
+            alternate_channel=CHANNEL_ROLE_GREEN,
+        )
+
+        self.assertEqual(cp_on.properties["selected_analysis"], ["NuclearCellPairIntensity"])
+        self.assertTrue(cp_on.properties["alternate_nucleus_detection_enabled"])
+        self.assertEqual(cp_on.properties["alternate_nucleus_detection_channel"], CHANNEL_ROLE_GREEN)
+        self.assertEqual(cp_off.properties["nuclear_cell_pair_contour_source"], "canonical_slot_1")
+        self.assertEqual(
+            cp_on.properties["nuclear_cell_pair_contour_source"],
+            "alternate_green_nucleus_slot_1",
+        )
+        self.assertGreater(cp_on.nucleus_intensity_sum, cp_off.nucleus_intensity_sum)
+        self.assertGreater(
+            self._dominant_green_pixel_count(debug_red_on),
+            self._dominant_green_pixel_count(debug_red_off),
+        )
+
+    def test_find_contours_skips_standard_red_when_alternate_red_is_requested(self):
+        contours_data = find_contours(
+            self._build_live_alternate_detection_images(),
+            alternate_red_detection=True,
+            alternate_detection_channel=CHANNEL_ROLE_RED,
+            skip_standard_contour_channels={CHANNEL_ROLE_RED},
+        )
+
+        self.assertEqual(contours_data["dot_contours"], [])
+        self.assertEqual(contours_data["contours"], [])
+        self.assertTrue(contours_data["alternate_nucleus_contours_red"])
+
+    def test_find_contours_skips_standard_green_when_alternate_green_is_requested(self):
+        contours_data = find_contours(
+            self._build_live_alternate_detection_images(),
+            alternate_red_detection=True,
+            alternate_detection_channel=CHANNEL_ROLE_GREEN,
+            skip_standard_contour_channels={CHANNEL_ROLE_GREEN},
+        )
+
+        self.assertEqual(contours_data["contours_green"], [])
+        self.assertTrue(contours_data["alternate_nucleus_contours_green"])
+
+    def test_nuclear_only_alternate_red_requests_standard_red_skip(self):
+        shape = (32, 32)
+        red_gray = np.zeros(shape, dtype=np.uint8)
+        green_gray = np.zeros(shape, dtype=np.uint8)
+        cp = SimpleNamespace(image_name="test.dv", cell_id=1, properties={})
+        images = {
+            "red": self._rgb(red_gray),
+            "green": self._rgb(green_gray),
+            "blue": self._rgb(np.zeros_like(red_gray)),
+        }
+        preprocessed = GrayImage(
+            img={
+                "red_no_bg": red_gray,
+                "gray_red": red_gray,
+                "gray_red_3": red_gray,
+                "green": green_gray,
+                "green_no_bg": green_gray,
+                "raw_green": green_gray,
+                "gray_blue": np.zeros_like(red_gray),
+                "gray_blue_3": np.zeros_like(red_gray),
+            }
+        )
+        alternate_contour = self._rect_contour(8, 8, 24, 24)
+
+        with TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir)
+            self._write_outline(output_dir, y_range=range(0, shape[0]), x_range=range(0, shape[1]))
+            with patch("core.views.segment_image.load_image", return_value=images), patch(
+                "core.views.segment_image.preprocess_image_to_gray",
+                return_value=preprocessed,
+            ), patch(
+                "core.views.segment_image.find_contours",
+                return_value={
+                    "dot_contours": [],
+                    "contours_green": [],
+                    "alternate_nucleus_contours_red": [alternate_contour],
+                },
+            ) as find_mock:
+                get_stats(
+                    cp,
+                    self._conf(
+                        temp_dir,
+                        mode="red_nucleus",
+                        analysis=["NuclearCellPairIntensity"],
+                        signal_quantification_mode=SIGNAL_MODE_NUCLEAR_CELL_PAIR,
+                    ),
+                    build_stats_execution_plan(["NuclearCellPairIntensity"]),
+                    puncta_line_width=1,
+                    cen_dot_distance=37.0,
+                    alternate_red_detection=True,
+                    alternate_detection_channel=CHANNEL_ROLE_RED,
+                )
+
+        self.assertEqual(
+            set(find_mock.call_args.kwargs["skip_standard_contour_channels"]),
+            {CHANNEL_ROLE_RED},
+        )
+
+    def test_nuclear_only_alternate_green_requests_standard_green_skip(self):
+        shape = (32, 32)
+        red_gray = np.zeros(shape, dtype=np.uint8)
+        green_gray = np.zeros(shape, dtype=np.uint8)
+        cp = SimpleNamespace(image_name="test.dv", cell_id=1, properties={})
+        images = {
+            "red": self._rgb(red_gray),
+            "green": self._rgb(green_gray),
+            "blue": self._rgb(np.zeros_like(red_gray)),
+        }
+        preprocessed = GrayImage(
+            img={
+                "red_no_bg": red_gray,
+                "gray_red": red_gray,
+                "gray_red_3": red_gray,
+                "green": green_gray,
+                "green_no_bg": green_gray,
+                "raw_red": red_gray,
+                "gray_blue": np.zeros_like(red_gray),
+                "gray_blue_3": np.zeros_like(red_gray),
+            }
+        )
+        alternate_contour = self._rect_contour(8, 8, 24, 24)
+
+        with TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir)
+            self._write_outline(
+                output_dir,
+                y_range=range(0, shape[0]),
+                x_range=range(0, shape[1]),
+            )
+            with patch("core.views.segment_image.load_image", return_value=images), patch(
+                "core.views.segment_image.preprocess_image_to_gray",
+                return_value=preprocessed,
+            ), patch(
+                "core.views.segment_image.find_contours",
+                return_value={
+                    "dot_contours": [],
+                    "contours_green": [],
+                    "alternate_nucleus_contours_green": [alternate_contour],
+                },
+            ) as find_mock:
+                get_stats(
+                    cp,
+                    self._conf(
+                        temp_dir,
+                        mode="green_nucleus",
+                        analysis=["NuclearCellPairIntensity"],
+                        signal_quantification_mode=SIGNAL_MODE_NUCLEAR_CELL_PAIR,
+                    ),
+                    build_stats_execution_plan(["NuclearCellPairIntensity"]),
+                    puncta_line_width=1,
+                    cen_dot_distance=37.0,
+                    alternate_red_detection=True,
+                    alternate_detection_channel=CHANNEL_ROLE_GREEN,
+                )
+
+        self.assertEqual(
+            set(find_mock.call_args.kwargs["skip_standard_contour_channels"]),
+            {CHANNEL_ROLE_GREEN},
+        )
+
+    def test_nuclear_with_cen_dot_keeps_standard_contours_for_independent_stats(self):
+        shape = (32, 32)
+        red_gray = np.zeros(shape, dtype=np.uint8)
+        green_gray = np.zeros(shape, dtype=np.uint8)
+        cp = SimpleNamespace(image_name="test.dv", cell_id=1, properties={})
+        images = {
+            "red": self._rgb(red_gray),
+            "green": self._rgb(green_gray),
+            "blue": self._rgb(np.zeros_like(red_gray)),
+        }
+        preprocessed = GrayImage(
+            img={
+                "red_no_bg": red_gray,
+                "gray_red": red_gray,
+                "gray_red_3": red_gray,
+                "green": green_gray,
+                "green_no_bg": green_gray,
+                "raw_green": green_gray,
+                "gray_blue": np.zeros_like(red_gray),
+                "gray_blue_3": np.zeros_like(red_gray),
+            }
+        )
+        standard_contour = self._rect_contour(13, 13, 17, 17)
+        alternate_contour = self._rect_contour(8, 8, 24, 24)
+
+        with TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir)
+            self._write_outline(output_dir, y_range=range(0, shape[0]), x_range=range(0, shape[1]))
+            with patch("core.views.segment_image.load_image", return_value=images), patch(
+                "core.views.segment_image.preprocess_image_to_gray",
+                return_value=preprocessed,
+            ), patch(
+                "core.views.segment_image.find_contours",
+                return_value={
+                    "dot_contours": [standard_contour],
+                    "contours_green": [],
+                    "alternate_nucleus_contours_red": [alternate_contour],
+                },
+            ) as find_mock:
+                get_stats(
+                    cp,
+                    self._conf(
+                        temp_dir,
+                        mode="red_nucleus",
+                        analysis=["NuclearCellPairIntensity", "CENDot"],
+                        signal_quantification_mode=SIGNAL_MODE_NUCLEAR_CELL_PAIR,
+                    ),
+                    build_stats_execution_plan(["NuclearCellPairIntensity", "CENDot"]),
+                    puncta_line_width=1,
+                    cen_dot_distance=37.0,
+                    alternate_red_detection=True,
+                    alternate_detection_channel=CHANNEL_ROLE_RED,
+                )
+
+        self.assertEqual(
+            cp.properties["nuclear_cell_pair_contour_source"],
+            "alternate_red_nucleus_slot_1",
+        )
+        self.assertEqual(cp.properties["selected_analysis"], ["CENDot", "NuclearCellPairIntensity"])
+        self.assertEqual(
+            set(find_mock.call_args.kwargs["skip_standard_contour_channels"]),
+            set(),
+        )
+
+    def test_nuclear_red_alternate_suppresses_standard_red_overlay(self):
+        shape = (32, 32)
+        red_gray = np.zeros(shape, dtype=np.uint8)
+        green_gray = np.zeros(shape, dtype=np.uint8)
+        standard_contour = self._rect_contour(13, 13, 17, 17)
+        alternate_contour = self._rect_contour(8, 8, 24, 24)
+
+        cp, debug_red, _, _ = self._run_get_stats(
+            mode="red_nucleus",
+            selected_analysis=["NuclearCellPairIntensity"],
+            red_gray=red_gray,
+            green_gray=green_gray,
+            contours_data={
+                "dot_contours": [standard_contour],
+                "contours_green": [],
+                "alternate_nucleus_contours_red": [alternate_contour],
+            },
+            y_range=range(0, shape[0]),
+            x_range=range(0, shape[1]),
+            alternate_enabled=True,
+            alternate_channel=CHANNEL_ROLE_RED,
+            signal_quantification_mode=SIGNAL_MODE_NUCLEAR_CELL_PAIR,
+        )
+
+        self.assertEqual(
+            cp.properties["nuclear_cell_pair_contour_source"],
+            "alternate_red_nucleus_slot_1",
+        )
+        self.assertGreater(
+            self._colored_outline_pixel_count(debug_red, alternate_contour, (255, 0, 0)),
+            0,
+        )
+        self.assertEqual(
+            self._colored_outline_pixel_count(debug_red, standard_contour, (255, 0, 0)),
+            0,
+        )
+
+    def test_nuclear_green_alternate_suppresses_standard_green_overlay(self):
+        shape = (32, 32)
+        red_gray = np.zeros(shape, dtype=np.uint8)
+        green_gray = np.zeros(shape, dtype=np.uint8)
+        standard_contour = self._rect_contour(13, 13, 17, 17)
+        alternate_contour = self._rect_contour(8, 8, 24, 24)
+
+        cp, debug_red, _, _ = self._run_get_stats(
+            mode="green_nucleus",
+            selected_analysis=["NuclearCellPairIntensity"],
+            red_gray=red_gray,
+            green_gray=green_gray,
+            contours_data={
+                "dot_contours": [],
+                "contours_green": [standard_contour],
+                "alternate_nucleus_contours_green": [alternate_contour],
+            },
+            y_range=range(0, shape[0]),
+            x_range=range(0, shape[1]),
+            alternate_enabled=True,
+            alternate_channel=CHANNEL_ROLE_GREEN,
+            signal_quantification_mode=SIGNAL_MODE_NUCLEAR_CELL_PAIR,
+        )
+
+        self.assertEqual(
+            cp.properties["nuclear_cell_pair_contour_source"],
+            "alternate_green_nucleus_slot_1",
+        )
+        self.assertGreater(
+            self._colored_outline_pixel_count(debug_red, alternate_contour, (0, 255, 0)),
+            0,
+        )
+        self.assertEqual(
+            self._colored_outline_pixel_count(debug_red, standard_contour, (0, 255, 0)),
+            0,
+        )
+
+    def test_live_puncta_mode_is_unchanged_by_alternate_nucleus_detection_and_gates_red_green_intensity(self):
+        preprocessed = self._build_live_puncta_images()
+        cp_off, _, _, _ = self._run_live_get_stats(
+            mode="red_nucleus",
+            selected_analysis=["PunctaDistance"],
+            preprocessed=preprocessed,
+            y_range=range(0, 36),
+            x_range=range(0, 36),
+            alternate_enabled=False,
+            alternate_channel=CHANNEL_ROLE_RED,
+        )
+        cp_on, _, _, _ = self._run_live_get_stats(
+            mode="red_nucleus",
+            selected_analysis=["PunctaDistance"],
+            preprocessed=preprocessed,
+            y_range=range(0, 36),
+            x_range=range(0, 36),
+            alternate_enabled=True,
+            alternate_channel=CHANNEL_ROLE_RED,
+        )
+        cp_with_intensity, _, _, _ = self._run_live_get_stats(
+            mode="red_nucleus",
+            selected_analysis=["PunctaDistance", "GreenRedIntensity"],
+            preprocessed=preprocessed,
+            y_range=range(0, 36),
+            x_range=range(0, 36),
+            alternate_enabled=True,
+            alternate_channel=CHANNEL_ROLE_RED,
+        )
+
+        self.assertAlmostEqual(cp_off.puncta_distance, cp_on.puncta_distance, places=4)
+        self.assertAlmostEqual(cp_off.puncta_line_intensity, cp_on.puncta_line_intensity, places=4)
+        self.assertNotIn("nuclear_cell_pair_contour_source", cp_on.properties)
+        self.assertEqual(getattr(cp_on, "red_intensity_1", 0.0), 0.0)
+        self.assertEqual(getattr(cp_on, "green_intensity_1", 0.0), 0.0)
+        self.assertGreater(getattr(cp_with_intensity, "red_intensity_1", 0.0), 0.0)
+        self.assertGreater(getattr(cp_with_intensity, "green_intensity_1", 0.0), 0.0)
 
     def test_aggressive_tightened_green_slots_drive_stats_and_debug_contours(self):
         shape = (96, 128)

--- a/cytocv/core/tests/test_nuclear_cell_pair_intensity.py
+++ b/cytocv/core/tests/test_nuclear_cell_pair_intensity.py
@@ -7,7 +7,9 @@ import cv2
 import numpy as np
 
 from core.cell_analysis import NuclearCellPairIntensity
+from core.channel_roles import CHANNEL_ROLE_GREEN, CHANNEL_ROLE_RED
 from core.image_processing import GrayImage
+from core.services.canonical_contours import build_canonical_contour_payload
 
 
 class NuclearCellPairIntensityPluginTests(SimpleTestCase):
@@ -64,6 +66,45 @@ class NuclearCellPairIntensityPluginTests(SimpleTestCase):
             plugin.calculate_statistics({}, contours_data, red_debug, green_debug, 1, 37)
             return cp, red_debug, green_debug
 
+    def _run_plugin_with_alternate_target(self, mode: str, alternate_channel: str):
+        plugin = NuclearCellPairIntensity()
+        cp = SimpleNamespace(
+            image_name="test.dv",
+            cell_id=1,
+            properties={
+                "nuclear_cell_pair_mode": mode,
+                "alternate_nucleus_detection_channel": alternate_channel,
+            },
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir)
+            self._write_outline(output_dir)
+            preprocessed = self._build_gray_images()
+            standard_contour = self._rect_contour(8, 8, 12, 12)
+            alternate_contour = self._rect_contour(8, 8, 16, 16)
+            contours_data = build_canonical_contour_payload(
+                {
+                    "dot_contours": [standard_contour],
+                    "contours_green": [standard_contour],
+                    "alternate_nucleus_contours_red": [alternate_contour],
+                    "alternate_nucleus_contours_green": [alternate_contour],
+                },
+                image_name="test.dv",
+                cell_id=1,
+                output_dir=str(output_dir),
+                shape=(24, 24),
+            )
+            plugin.setting_up(cp, preprocessed, str(output_dir))
+            plugin.calculate_statistics(
+                {},
+                contours_data,
+                np.zeros((24, 24, 3), dtype=np.uint8),
+                np.zeros((24, 24, 3), dtype=np.uint8),
+                1,
+                37,
+            )
+            return cp, preprocessed, standard_contour, alternate_contour
+
     def test_red_nucleus_sets_expected_contour_and_measurement_channels(self):
         cp, _, _ = self._run_plugin("red_nucleus")
         self.assertEqual(cp.properties["nuclear_cell_pair_contour_channel"], "Red")
@@ -80,10 +121,117 @@ class NuclearCellPairIntensityPluginTests(SimpleTestCase):
         self.assertEqual(cp.properties["nuclear_cell_pair_status"], "ok")
         self.assertEqual(cp.properties["nuclear_cell_pair_contour_source"], "canonical_slot_1")
 
-    def test_debug_overlay_is_disabled_even_when_precomputed_contour_exists(self):
-        _, red_debug, green_debug = self._run_plugin("red_nucleus")
+    def test_alternate_detection_targets_red_nucleus_contours_for_red_nucleus_mode(self):
+        cp, preprocessed, _, alternate_contour = self._run_plugin_with_alternate_target(
+            "red_nucleus",
+            CHANNEL_ROLE_RED,
+        )
+        green_image = preprocessed.get_image("green_no_bg")
+        nucleus_mask = np.zeros(green_image.shape, dtype=np.uint8)
+        cv2.drawContours(nucleus_mask, [alternate_contour], 0, 255, -1)
+
+        self.assertEqual(
+            cp.properties["nuclear_cell_pair_contour_source"],
+            "alternate_red_nucleus_slot_1",
+        )
+        self.assertEqual(
+            cp.nucleus_intensity_sum,
+            float(np.sum(green_image[nucleus_mask > 0])),
+        )
+
+    def test_alternate_detection_targets_green_nucleus_contours_for_green_nucleus_mode(self):
+        cp, preprocessed, _, alternate_contour = self._run_plugin_with_alternate_target(
+            "green_nucleus",
+            CHANNEL_ROLE_GREEN,
+        )
+        red_image = preprocessed.get_image("red_no_bg")
+        nucleus_mask = np.zeros(red_image.shape, dtype=np.uint8)
+        cv2.drawContours(nucleus_mask, [alternate_contour], 0, 255, -1)
+
+        self.assertEqual(
+            cp.properties["nuclear_cell_pair_contour_source"],
+            "alternate_green_nucleus_slot_1",
+        )
+        self.assertEqual(
+            cp.nucleus_intensity_sum,
+            float(np.sum(red_image[nucleus_mask > 0])),
+        )
+
+    def test_alternate_detection_ignores_unselected_nucleus_channel(self):
+        cp, preprocessed, standard_contour, _ = self._run_plugin_with_alternate_target(
+            "green_nucleus",
+            CHANNEL_ROLE_RED,
+        )
+        red_image = preprocessed.get_image("red_no_bg")
+        nucleus_mask = np.zeros(red_image.shape, dtype=np.uint8)
+        cv2.drawContours(nucleus_mask, [standard_contour], 0, 255, -1)
+
+        self.assertEqual(cp.properties["nuclear_cell_pair_contour_source"], "canonical_slot_1")
+        self.assertEqual(
+            cp.nucleus_intensity_sum,
+            float(np.sum(red_image[nucleus_mask > 0])),
+        )
+
+    def test_alternate_detection_without_alternate_slot_does_not_fallback_to_canonical(self):
+        plugin = NuclearCellPairIntensity()
+        cp = SimpleNamespace(
+            image_name="test.dv",
+            cell_id=1,
+            properties={
+                "nuclear_cell_pair_mode": "red_nucleus",
+                "alternate_nucleus_detection_enabled": True,
+                "alternate_nucleus_detection_channel": CHANNEL_ROLE_RED,
+            },
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir)
+            self._write_outline(output_dir)
+            preprocessed = self._build_gray_images()
+            standard_contour = self._rect_contour(8, 8, 16, 16)
+            contours_data = build_canonical_contour_payload(
+                {
+                    "dot_contours": [standard_contour],
+                    "contours_green": [],
+                },
+                image_name="test.dv",
+                cell_id=1,
+                output_dir=str(output_dir),
+                shape=(24, 24),
+            )
+            red_debug = np.zeros((24, 24, 3), dtype=np.uint8)
+            green_debug = np.zeros((24, 24, 3), dtype=np.uint8)
+            plugin.setting_up(cp, preprocessed, str(output_dir))
+            plugin.calculate_statistics(
+                {},
+                contours_data,
+                red_debug,
+                green_debug,
+                1,
+                37,
+            )
+
+        self.assertEqual(cp.properties["nuclear_cell_pair_status"], "no_nucleus_contour")
+        self.assertEqual(
+            cp.properties["nuclear_cell_pair_contour_source"],
+            "alternate_red_nucleus_slot_1",
+        )
+        self.assertEqual(cp.nucleus_intensity_sum, 0.0)
         self.assertFalse(np.any(red_debug > 0))
         self.assertFalse(np.any(green_debug > 0))
+
+    def test_debug_overlay_draws_selected_red_nucleus_contour(self):
+        _, red_debug, green_debug = self._run_plugin("red_nucleus")
+        red_pixels = np.array([0, 0, 255], dtype=np.uint8)
+
+        self.assertTrue(np.any(np.all(red_debug == red_pixels, axis=2)))
+        self.assertTrue(np.any(np.all(green_debug == red_pixels, axis=2)))
+
+    def test_debug_overlay_draws_selected_green_nucleus_contour(self):
+        _, red_debug, green_debug = self._run_plugin("green_nucleus")
+        green_pixels = np.array([0, 255, 0], dtype=np.uint8)
+
+        self.assertTrue(np.any(np.all(red_debug == green_pixels, axis=2)))
+        self.assertTrue(np.any(np.all(green_debug == green_pixels, axis=2)))
 
     def test_hard_cutoff_marks_no_nucleus_contour_without_fallback(self):
         cp, red_debug, green_debug = self._run_plugin("red_nucleus", include_precomputed=False)

--- a/cytocv/core/tests/test_scale_upload_initialization.py
+++ b/cytocv/core/tests/test_scale_upload_initialization.py
@@ -193,7 +193,7 @@ class UploadScaleInitializationTests(TestCase):
 
         self.assertEqual(
             self.client.session.get("selected_analysis"),
-            ["CENDot", "NuclearCellPairIntensity"],
+            ["NuclearCellPairIntensity"],
         )
         self.assertEqual(self.client.session.get("signalQuantificationMode"), "nuclear_cell_pair")
         self.assertTrue(self.client.session.get("alternateNucleusDetectionEnabled"))
@@ -225,7 +225,7 @@ class UploadScaleInitializationTests(TestCase):
 
         self.assertEqual(
             self.client.session.get("selected_analysis"),
-            ["Biorientation", "NuclearCellPairIntensity"],
+            ["NuclearCellPairIntensity"],
         )
         self.assertEqual(self.client.session.get("signalQuantificationMode"), "nuclear_cell_pair")
         self.assertTrue(self.client.session.get("alternateNucleusDetectionEnabled"))

--- a/cytocv/core/tests/test_scale_upload_initialization.py
+++ b/cytocv/core/tests/test_scale_upload_initialization.py
@@ -36,6 +36,7 @@ class UploadScaleInitializationTests(TestCase):
         metadata_payload: dict,
         use_metadata_scale: bool,
         puncta_line_mode: str = "red_puncta",
+        extra_payload: dict | None = None,
     ) -> UploadedImage:
         upload_file = SimpleUploadedFile(
             "sample.dv",
@@ -72,19 +73,22 @@ class UploadScaleInitializationTests(TestCase):
                                 "core.services.upload_preparation.generate_preview_assets",
                                 return_value=None,
                             ):
+                                post_data = {
+                                    "files": [upload_file],
+                                    "selected_analysis": ["PunctaDistance"],
+                                    "stats_puncta_line_width_value": "1",
+                                    "stats_cen_dot_distance_value": "37",
+                                    "stats_puncta_line_width_unit": "px",
+                                    "stats_cen_dot_distance_unit": "px",
+                                    "puncta_line_mode": puncta_line_mode,
+                                    "stats_microns_per_pixel": "0.2",
+                                    "stats_use_metadata_scale": "1" if use_metadata_scale else "0",
+                                }
+                                if extra_payload:
+                                    post_data.update(extra_payload)
                                 response = self.client.post(
                                     reverse("experiment"),
-                                    data={
-                                        "files": [upload_file],
-                                        "selected_analysis": ["PunctaDistance"],
-                                        "stats_puncta_line_width_value": "1",
-                                        "stats_cen_dot_distance_value": "37",
-                                        "stats_puncta_line_width_unit": "px",
-                                        "stats_cen_dot_distance_unit": "px",
-                                        "puncta_line_mode": puncta_line_mode,
-                                        "stats_microns_per_pixel": "0.2",
-                                        "stats_use_metadata_scale": "1" if use_metadata_scale else "0",
-                                    },
+                                    data=post_data,
                                 )
                                 self.assertEqual(response.status_code, 200)
                                 payload = response.json()
@@ -161,3 +165,99 @@ class UploadScaleInitializationTests(TestCase):
         )
 
         self.assertEqual(self.client.session.get("puncta_line_mode"), "green_puncta")
+        self.assertEqual(self.client.session.get("selected_analysis"), ["PunctaDistance"])
+        self.assertTrue(self.client.session.get("signalQuantificationEnabled"))
+        self.assertEqual(self.client.session.get("signalQuantificationMode"), "puncta_distance")
+        self.assertFalse(self.client.session.get("punctaContourIntensityEnabled"))
+
+    def test_upload_signal_quantification_nuclear_mode_derives_session_selection(self):
+        self._post_upload(
+            metadata_payload={
+                "metadata_um_per_px": 0.11,
+                "status": "ok",
+                "dx": 0.11,
+                "dy": 0.11,
+                "dz": 0.2,
+                "note": "",
+            },
+            use_metadata_scale=True,
+            extra_payload={
+                "selected_analysis": ["PunctaDistance", "GreenRedIntensity", "CENDot"],
+                "signalQuantificationEnabled": "true",
+                "signalQuantificationMode": "nuclear_cell_pair",
+                "punctaContourIntensityEnabled": "true",
+                "alternateNucleusDetectionEnabled": "true",
+                "nuclear_cell_pair_mode": "red_nucleus",
+            },
+        )
+
+        self.assertEqual(
+            self.client.session.get("selected_analysis"),
+            ["CENDot", "NuclearCellPairIntensity"],
+        )
+        self.assertEqual(self.client.session.get("signalQuantificationMode"), "nuclear_cell_pair")
+        self.assertTrue(self.client.session.get("alternateNucleusDetectionEnabled"))
+        self.assertEqual(
+            self.client.session.get("alternateNucleusDetectionChannel"),
+            "channel_red",
+        )
+
+    def test_upload_signal_quantification_green_nuclear_mode_derives_session_selection(self):
+        self._post_upload(
+            metadata_payload={
+                "metadata_um_per_px": 0.11,
+                "status": "ok",
+                "dx": 0.11,
+                "dy": 0.11,
+                "dz": 0.2,
+                "note": "",
+            },
+            use_metadata_scale=True,
+            extra_payload={
+                "selected_analysis": ["PunctaDistance", "Biorientation"],
+                "signalQuantificationEnabled": "true",
+                "signalQuantificationMode": "nuclear_cell_pair",
+                "punctaContourIntensityEnabled": "false",
+                "alternateNucleusDetectionEnabled": "true",
+                "nuclear_cell_pair_mode": "green_nucleus",
+            },
+        )
+
+        self.assertEqual(
+            self.client.session.get("selected_analysis"),
+            ["Biorientation", "NuclearCellPairIntensity"],
+        )
+        self.assertEqual(self.client.session.get("signalQuantificationMode"), "nuclear_cell_pair")
+        self.assertTrue(self.client.session.get("alternateNucleusDetectionEnabled"))
+        self.assertEqual(
+            self.client.session.get("alternateNucleusDetectionChannel"),
+            "channel_green",
+        )
+
+    def test_upload_signal_quantification_nuclear_mode_off_clears_alternate_channel(self):
+        self._post_upload(
+            metadata_payload={
+                "metadata_um_per_px": 0.11,
+                "status": "ok",
+                "dx": 0.11,
+                "dy": 0.11,
+                "dz": 0.2,
+                "note": "",
+            },
+            use_metadata_scale=True,
+            extra_payload={
+                "selected_analysis": ["NuclearCellPairIntensity"],
+                "signalQuantificationEnabled": "true",
+                "signalQuantificationMode": "nuclear_cell_pair",
+                "punctaContourIntensityEnabled": "false",
+                "alternateNucleusDetectionEnabled": "false",
+                "nuclear_cell_pair_mode": "red_nucleus",
+            },
+        )
+
+        self.assertEqual(
+            self.client.session.get("selected_analysis"),
+            ["NuclearCellPairIntensity"],
+        )
+        self.assertFalse(self.client.session.get("alternateNucleusDetectionEnabled"))
+        self.assertIsNone(self.client.session.get("alternateNucleusDetectionChannel"))

--- a/cytocv/core/tests/test_tables.py
+++ b/cytocv/core/tests/test_tables.py
@@ -147,6 +147,67 @@ class CellTableNuclearCellPairRenderingTests(SimpleTestCase):
         self.assertIn("Distance Between Green Puncta (px)", header_row)
         self.assertIn("Red Intensity Over Green Line", header_row)
 
+    def test_nuclear_mode_hides_puncta_contour_cen_and_biorientation_columns(self):
+        header_row = list(
+            CellTable(
+                [],
+                intensity_mode="green_nucleus",
+                selected_plugins=["NuclearCellPairIntensity"],
+            ).as_values()
+        )[0]
+
+        self.assertIn("Nucleus Contour Source", header_row)
+        self.assertIn("Red Cell-Pair Intensity", header_row)
+        self.assertIn("Red Nuclear Intensity", header_row)
+        self.assertIn("Cytoplasmic Intensity", header_row)
+        self.assertNotIn("Distance Between Red Puncta (px)", header_row)
+        self.assertNotIn("Green Intensity Over Red Line", header_row)
+        self.assertNotIn("Red In Red Intensity 1", header_row)
+        self.assertNotIn("Measurement/Contour Ratio 1 (Red/Green)", header_row)
+        self.assertNotIn("Distance Of Green From Red 1 (px)", header_row)
+        self.assertNotIn("Cell Parentage", header_row)
+        self.assertNotIn("Cen Dot Location", header_row)
+        self.assertNotIn("Colinear Dots", header_row)
+        self.assertNotIn("Blue Contour Size (px²)", header_row)
+
+    def test_puncta_mode_without_contour_intensity_hides_raw_sums_and_ratios(self):
+        header_row = list(
+            CellTable(
+                [],
+                puncta_line_mode="red_puncta",
+                selected_plugins=["PunctaDistance"],
+            ).as_values()
+        )[0]
+
+        self.assertIn("Distance Between Red Puncta (px)", header_row)
+        self.assertIn("Green Intensity Over Red Line", header_row)
+        self.assertNotIn("Red In Red Intensity 1", header_row)
+        self.assertNotIn("Measurement/Contour Ratio 1 (Red/Green)", header_row)
+        self.assertNotIn("Distance Of Green From Red 1 (px)", header_row)
+        self.assertNotIn("Nucleus Contour Source", header_row)
+        self.assertNotIn("Measured Cell-Pair Intensity", header_row)
+
+    def test_nuclear_contour_source_exports_from_record_properties(self):
+        record = SimpleNamespace(
+            category_cen_dot=0,
+            properties={
+                "selected_analysis": ["NuclearCellPairIntensity"],
+                "nuclear_cell_pair_contour_source": "alternate_green_nucleus_slot_1",
+                "nuclear_cell_pair_status": "ok",
+            },
+        )
+
+        table = CellTable([record], intensity_mode="green_nucleus")
+        row = list(table.rows)[0]
+        values = list(table.as_values())
+        header = values[0]
+
+        self.assertEqual(row.get_cell("nuclear_cell_pair_contour_source"), "alternate_green_nucleus_slot_1")
+        self.assertEqual(
+            values[1][header.index("Nucleus Contour Source")],
+            "alternate_green_nucleus_slot_1",
+        )
+
     def test_ratio_values_are_derived_from_raw_sums_not_stale_stored_values(self):
         record = SimpleNamespace(
             green_red_intensity_1=99.0,

--- a/cytocv/core/views/experiment.py
+++ b/cytocv/core/views/experiment.py
@@ -33,6 +33,9 @@ from core.scale import (
     normalize_length_unit,
     parse_microns_per_pixel,
 )
+from core.services.biorientation_config import (
+    DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+)
 from core.services.puncta_line_mode import (
     DEFAULT_PUNCTA_LINE_MODE,
     normalize_puncta_line_mode,
@@ -40,6 +43,9 @@ from core.services.puncta_line_mode import (
 from core.services.green_dot_split import (
     DEFAULT_GREEN_DOT_SPLIT_MODE,
     normalize_green_dot_split_mode,
+)
+from core.services.signal_quantification import (
+    resolve_signal_quantification_selection,
 )
 from core.services.artifact_storage import (
     delete_uploaded_run_by_uuid,
@@ -443,6 +449,13 @@ def _getlist(payload, key: str) -> list[str]:
     return [value]
 
 
+def _has_payload_key(payload, key: str) -> bool:
+    try:
+        return key in payload
+    except TypeError:
+        return False
+
+
 def _parse_experiment_submission(payload, user_preferences: dict) -> tuple[dict[str, object], dict[str, object]]:
     """Parse upload settings once for session persistence and worker execution."""
 
@@ -453,8 +466,8 @@ def _parse_experiment_submission(payload, user_preferences: dict) -> tuple[dict[
     )
     default_use_metadata_scale = bool(experiment_defaults.get("use_metadata_scale", True))
 
-    selected_analysis = normalize_selected_plugins(_getlist(payload, "selected_analysis"))
-    requirement_summary = build_requirement_summary(selected_analysis)
+    has_selected_analysis_payload = _has_payload_key(payload, "selected_analysis")
+    raw_selected_analysis = normalize_selected_plugins(_getlist(payload, "selected_analysis"))
 
     posted_microns_per_pixel = parse_microns_per_pixel(
         payload.get("stats_microns_per_pixel"),
@@ -561,12 +574,15 @@ def _parse_experiment_submission(payload, user_preferences: dict) -> tuple[dict[
     )
     try:
         biorientation_collinearity_threshold = int(
-            payload.get("biorientationCollinearityThreshold", "66")
+            payload.get(
+                "biorientationCollinearityThreshold",
+                str(DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX),
+            )
         )
     except (TypeError, ValueError):
-        biorientation_collinearity_threshold = 66
+        biorientation_collinearity_threshold = DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX
     if biorientation_collinearity_threshold < 0:
-        biorientation_collinearity_threshold = 66
+        biorientation_collinearity_threshold = DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX
 
     green_dot_split_enabled = _parse_bool(
         payload.get("greenDotSplitEnabled", payload.get("biorientationGreenSplitEnabled")),
@@ -575,13 +591,12 @@ def _parse_experiment_submission(payload, user_preferences: dict) -> tuple[dict[
     green_dot_split_mode = normalize_green_dot_split_mode(
         payload.get("greenDotSplitMode", DEFAULT_GREEN_DOT_SPLIT_MODE)
     )
-    green_contour_filter_enabled = payload.get(
-        "greenContourFilterEnabled",
-        payload.get("gfpFilterEnabled", False),
-    )
-    alternate_red_detection = payload.get(
-        "alternateRedDetection",
-        payload.get("alternateMCherryDetection", False),
+    green_contour_filter_enabled = _parse_bool(
+        payload.get(
+            "greenContourFilterEnabled",
+            payload.get("gfpFilterEnabled", False),
+        ),
+        default=False,
     )
     puncta_line_mode = _parse_puncta_line_mode(
         payload.get("puncta_line_mode"),
@@ -591,6 +606,56 @@ def _parse_experiment_submission(payload, user_preferences: dict) -> tuple[dict[
         payload.get("nuclear_cell_pair_mode", payload.get("nuclear_cellular_mode")),
         default="green_nucleus",
     )
+    signal_selection = resolve_signal_quantification_selection(
+        payload={
+            "signal_quantification_enabled": payload.get(
+                "signalQuantificationEnabled",
+                payload.get("signal_quantification_enabled"),
+            ),
+            "signal_quantification_mode": payload.get(
+                "signalQuantificationMode",
+                payload.get("signal_quantification_mode"),
+            ),
+            "puncta_contour_intensity_enabled": payload.get(
+                "punctaContourIntensityEnabled",
+                payload.get("puncta_contour_intensity_enabled"),
+            ),
+            "alternate_nucleus_detection_enabled": payload.get(
+                "alternateNucleusDetectionEnabled",
+                payload.get(
+                    "alternate_nucleus_detection_enabled",
+                    payload.get(
+                        "alternateRedDetection",
+                        payload.get("alternateMCherryDetection"),
+                    ),
+                ),
+            ),
+        },
+        selected_plugins=raw_selected_analysis,
+        nuclear_cell_pair_mode=nuclear_cell_pair_mode,
+        puncta_line_mode=puncta_line_mode,
+        default_enabled=(
+            None
+            if has_selected_analysis_payload
+            else experiment_defaults.get("signal_quantification_enabled")
+        ),
+        default_mode=(
+            None
+            if has_selected_analysis_payload
+            else experiment_defaults.get("signal_quantification_mode")
+        ),
+        default_puncta_contour_intensity_enabled=(
+            None
+            if has_selected_analysis_payload
+            else experiment_defaults.get("puncta_contour_intensity_enabled")
+        ),
+        default_alternate_nucleus_detection_enabled=experiment_defaults.get(
+            "alternate_nucleus_detection_enabled",
+            experiment_defaults.get("alternate_red_detection", False),
+        ),
+    )
+    selected_analysis = list(signal_selection.selected_plugins)
+    requirement_summary = build_requirement_summary(selected_analysis)
 
     module_enabled = _parse_bool(payload.get("cytocv_analysis_enabled"), default=False)
     enforce_layer_count = module_enabled and _parse_bool(
@@ -631,9 +696,15 @@ def _parse_experiment_submission(payload, user_preferences: dict) -> tuple[dict[
         "puncta_line_mode": puncta_line_mode,
         "nuclear_cell_pair_mode": nuclear_cell_pair_mode,
         "greenContourFilterEnabled": green_contour_filter_enabled,
-        "alternateRedDetection": alternate_red_detection,
+        "alternateRedDetection": signal_selection.alternate_nucleus_detection_enabled,
+        "alternateNucleusDetectionEnabled": signal_selection.alternate_nucleus_detection_enabled,
+        "alternateNucleusDetectionChannel": signal_selection.alternate_nucleus_detection_channel,
+        "signalQuantificationEnabled": signal_selection.enabled,
+        "signalQuantificationMode": signal_selection.mode,
+        "punctaContourIntensityEnabled": signal_selection.puncta_contour_intensity_enabled,
     }
     config_snapshot = {
+        **session_values,
         "selected_analysis": requirement_summary["selected_plugins"],
         "manual_um_per_px": posted_microns_per_pixel,
         "prefer_metadata_scale": stats_use_metadata_scale,

--- a/cytocv/core/views/pre_process.py
+++ b/cytocv/core/views/pre_process.py
@@ -37,6 +37,9 @@ from core.services.analysis_progress_contract import (
     progress_log_ref,
     validate_progress_status,
 )
+from core.services.biorientation_config import (
+    DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+)
 from core.services.puncta_line_mode import (
     DEFAULT_PUNCTA_LINE_MODE,
     normalize_puncta_line_mode,
@@ -44,6 +47,9 @@ from core.services.puncta_line_mode import (
 from core.services.green_dot_split import (
     DEFAULT_GREEN_DOT_SPLIT_MODE,
     normalize_green_dot_split_mode,
+)
+from core.services.signal_quantification import (
+    resolve_signal_quantification_selection,
 )
 from .utils import (
     tif_to_jpg,
@@ -92,6 +98,16 @@ class ProgressRequestError(Exception):
         super().__init__(message)
         self.message = message
         self.status_code = status_code
+
+
+def _parse_bool(value, default: bool = False) -> bool:
+    """Parse common truthy/falsy request/session values."""
+
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _current_owner_filter(request) -> dict:
@@ -497,7 +513,10 @@ def pre_process(request, uuids):
         )
         biorientation_collinearity_threshold_raw = request.POST.get(
             'biorientationCollinearityThreshold',
-            request.session.get('biorientationCollinearityThreshold', 66),
+            request.session.get(
+                'biorientationCollinearityThreshold',
+                DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+            ),
         )
         green_dot_split_enabled_raw = request.POST.get(
             'greenDotSplitEnabled',
@@ -532,12 +551,64 @@ def pre_process(request, uuids):
             'greenContourFilterEnabled',
             request.session.get('greenContourFilterEnabled', request.session.get('gfpFilterEnabled', 'False')),
         )
-        green_contour_filter_enabled = green_contour_filter_enabled_raw == 'true'
-        alternate_red_detection_raw = request.POST.get(
-            'alternateRedDetection',
-            request.session.get('alternateRedDetection', request.session.get('alternateMCherryDetection', 'False')),
+        green_contour_filter_enabled = _parse_bool(green_contour_filter_enabled_raw, default=False)
+        signal_selection = resolve_signal_quantification_selection(
+            payload={
+                "signalQuantificationEnabled": request.POST.get(
+                    "signalQuantificationEnabled",
+                    request.session.get(
+                        "signalQuantificationEnabled",
+                        request.session.get("signal_quantification_enabled"),
+                    ),
+                ),
+                "signalQuantificationMode": request.POST.get(
+                    "signalQuantificationMode",
+                    request.session.get(
+                        "signalQuantificationMode",
+                        request.session.get("signal_quantification_mode"),
+                    ),
+                ),
+                "punctaContourIntensityEnabled": request.POST.get(
+                    "punctaContourIntensityEnabled",
+                    request.session.get(
+                        "punctaContourIntensityEnabled",
+                        request.session.get("puncta_contour_intensity_enabled"),
+                    ),
+                ),
+                "alternateNucleusDetectionEnabled": request.POST.get(
+                    "alternateNucleusDetectionEnabled",
+                    request.POST.get(
+                        "alternateRedDetection",
+                        request.session.get(
+                            "alternateNucleusDetectionEnabled",
+                            request.session.get(
+                                "alternate_nucleus_detection_enabled",
+                                request.session.get(
+                                    "alternateRedDetection",
+                                    request.session.get("alternateMCherryDetection", False),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            },
+            selected_plugins=selected_analysis,
+            nuclear_cell_pair_mode=nuclear_cell_pair_mode,
+            puncta_line_mode=puncta_line_mode,
+            default_alternate_nucleus_detection_enabled=_parse_bool(
+                request.session.get(
+                    "alternateNucleusDetectionEnabled",
+                    request.session.get(
+                        "alternate_nucleus_detection_enabled",
+                        request.session.get(
+                            "alternateRedDetection",
+                            request.session.get("alternateMCherryDetection", False),
+                        ),
+                    ),
+                ),
+                default=False,
+            ),
         )
-        alternate_red_detection = alternate_red_detection_raw == 'true'
         try:
             puncta_line_width = int(puncta_line_width_raw)
         except (TypeError, ValueError):
@@ -579,9 +650,9 @@ def pre_process(request, uuids):
                 biorientation_collinearity_threshold_raw
             )
         except (TypeError, ValueError):
-            biorientation_collinearity_threshold = 66
+            biorientation_collinearity_threshold = DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX
         if biorientation_collinearity_threshold < 0:
-            biorientation_collinearity_threshold = 66
+            biorientation_collinearity_threshold = DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX
         green_dot_split_enabled = (
             green_dot_split_enabled_raw
             if isinstance(green_dot_split_enabled_raw, bool)
@@ -589,7 +660,7 @@ def pre_process(request, uuids):
             in {"1", "true", "yes", "on"}
         )
 
-        request.session['selected_analysis'] = selected_analysis
+        request.session['selected_analysis'] = list(signal_selection.selected_plugins)
         request.session['punctaLineWidth'] = puncta_line_width
         request.session['cenDotDistance'] = cen_dot_distance
         request.session['stats_biorientation_red_min_distance_value'] = biorientation_red_min_distance_value
@@ -602,7 +673,18 @@ def pre_process(request, uuids):
         request.session["puncta_line_mode"] = puncta_line_mode
         request.session["nuclear_cell_pair_mode"] = nuclear_cell_pair_mode
         request.session['greenContourFilterEnabled'] = green_contour_filter_enabled
-        request.session['alternateRedDetection'] = alternate_red_detection
+        request.session['alternateRedDetection'] = signal_selection.alternate_nucleus_detection_enabled
+        request.session['alternateNucleusDetectionEnabled'] = (
+            signal_selection.alternate_nucleus_detection_enabled
+        )
+        request.session['alternateNucleusDetectionChannel'] = (
+            signal_selection.alternate_nucleus_detection_channel
+        )
+        request.session['signalQuantificationEnabled'] = signal_selection.enabled
+        request.session['signalQuantificationMode'] = signal_selection.mode
+        request.session['punctaContourIntensityEnabled'] = (
+            signal_selection.puncta_contour_intensity_enabled
+        )
         context = build_analysis_batch_context(request, uuid_list)
         batch_key = context.batch_key
         is_ajax = request.headers.get('X-Requested-With') == 'XMLHttpRequest'

--- a/cytocv/core/views/segment_image.py
+++ b/cytocv/core/views/segment_image.py
@@ -108,6 +108,9 @@ from core.services.overlay_rendering import (
     persist_overlay_cache_images,
     write_overlay_render_config,
 )
+from core.services.biorientation_config import (
+    DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+)
 from core.services.puncta_line_mode import (
     DEFAULT_PUNCTA_LINE_MODE,
     get_puncta_line_mode_metadata,
@@ -116,6 +119,16 @@ from core.services.puncta_line_mode import (
 from core.services.green_dot_split import (
     DEFAULT_GREEN_DOT_SPLIT_MODE,
     normalize_green_dot_split_mode,
+)
+from core.services.signal_quantification import (
+    BIORIENTATION_PLUGIN,
+    CEN_DOT_PLUGIN,
+    GREEN_RED_INTENSITY_PLUGIN,
+    NUCLEAR_CELL_PAIR_PLUGIN,
+    PUNCTA_DISTANCE_PLUGIN,
+    SIGNAL_MODE_NUCLEAR_CELL_PAIR,
+    build_stat_visibility,
+    measurement_ratio_mode_for_puncta_line_mode,
 )
 
 logger = logging.getLogger(__name__)
@@ -129,8 +142,94 @@ PROCESSING_STORAGE_FULL_MESSAGE = (
 STATS_CACHE_CHANNELS = frozenset(
     {CHANNEL_ROLE_RED, CHANNEL_ROLE_GREEN, CHANNEL_ROLE_BLUE, CHANNEL_ROLE_DIC}
 )
+STANDARD_RED_CONTOUR_CONSUMER_PLUGINS = frozenset(
+    {
+        PUNCTA_DISTANCE_PLUGIN,
+        GREEN_RED_INTENSITY_PLUGIN,
+        CEN_DOT_PLUGIN,
+        BIORIENTATION_PLUGIN,
+        "RedBlueIntensity",
+    }
+)
+STANDARD_GREEN_CONTOUR_CONSUMER_PLUGINS = frozenset(
+    {
+        PUNCTA_DISTANCE_PLUGIN,
+        GREEN_RED_INTENSITY_PLUGIN,
+        CEN_DOT_PLUGIN,
+        BIORIENTATION_PLUGIN,
+    }
+)
 
 ## progress helpers moved to core.views.utils
+
+
+def _truthy_config_flag(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and value in {0, 1, 0.0, 1.0}:
+        return bool(value)
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _alternate_nucleus_overlay_suppression_channel(
+    *,
+    selected_plugins,
+    signal_quantification_mode,
+    nuclear_cell_pair_mode,
+    alternate_nucleus_detection_enabled,
+    alternate_nucleus_detection_channel,
+):
+    if not _truthy_config_flag(alternate_nucleus_detection_enabled):
+        return None
+
+    selected_plugin_set = set(selected_plugins or [])
+    if NUCLEAR_CELL_PAIR_PLUGIN not in selected_plugin_set:
+        return None
+
+    normalized_signal_mode = str(signal_quantification_mode or "").strip()
+    if normalized_signal_mode:
+        if normalized_signal_mode != SIGNAL_MODE_NUCLEAR_CELL_PAIR:
+            return None
+    elif selected_plugin_set & {PUNCTA_DISTANCE_PLUGIN, GREEN_RED_INTENSITY_PLUGIN}:
+        return None
+
+    normalized_nuclear_mode = str(nuclear_cell_pair_mode or "").strip()
+    if (
+        normalized_nuclear_mode == "red_nucleus"
+        and alternate_nucleus_detection_channel == CHANNEL_ROLE_RED
+    ):
+        return CHANNEL_ROLE_RED
+    if (
+        normalized_nuclear_mode == "green_nucleus"
+        and alternate_nucleus_detection_channel == CHANNEL_ROLE_GREEN
+    ):
+        return CHANNEL_ROLE_GREEN
+    return None
+
+
+def _alternate_nucleus_standard_contour_skip_channels(
+    *,
+    selected_plugins,
+    signal_quantification_mode,
+    nuclear_cell_pair_mode,
+    alternate_nucleus_detection_enabled,
+    alternate_nucleus_detection_channel,
+):
+    channel = _alternate_nucleus_overlay_suppression_channel(
+        selected_plugins=selected_plugins,
+        signal_quantification_mode=signal_quantification_mode,
+        nuclear_cell_pair_mode=nuclear_cell_pair_mode,
+        alternate_nucleus_detection_enabled=alternate_nucleus_detection_enabled,
+        alternate_nucleus_detection_channel=alternate_nucleus_detection_channel,
+    )
+    selected_plugin_set = set(selected_plugins or [])
+    if channel == CHANNEL_ROLE_RED:
+        if not (selected_plugin_set & STANDARD_RED_CONTOUR_CONSUMER_PLUGINS):
+            return frozenset({CHANNEL_ROLE_RED})
+    elif channel == CHANNEL_ROLE_GREEN:
+        if not (selected_plugin_set & STANDARD_GREEN_CONTOUR_CONSUMER_PLUGINS):
+            return frozenset({CHANNEL_ROLE_GREEN})
+    return frozenset()
 
 
 def _build_layer_channel_lookup(channel_config: dict[str, object]) -> dict[int, str]:
@@ -196,6 +295,7 @@ def get_stats(
     green_dot_split_mode=DEFAULT_GREEN_DOT_SPLIT_MODE,
     cached_images=None,
     cached_measurement_images=None,
+    alternate_detection_channel=None,
 ):
     # loading configuration
     kernel_size_input, puncta_line_width_input, kernel_deviation_input, _ = set_options(conf)
@@ -211,9 +311,47 @@ def get_stats(
     cp.properties["puncta_line_mode"] = puncta_line_metadata["mode"]
     cp.properties["puncta_line_source_channel"] = puncta_line_metadata["source_channel"]
     cp.properties["puncta_line_measurement_channel"] = puncta_line_metadata["measurement_channel"]
+    configured_signal_mode = conf.get(
+        "signal_quantification_mode",
+        conf.get("signalQuantificationMode"),
+    )
+    cp.properties["signal_quantification_enabled"] = bool(
+        conf.get(
+            "signal_quantification_enabled",
+            conf.get("signalQuantificationEnabled", configured_signal_mode is not None),
+        )
+    )
+    if configured_signal_mode is not None:
+        cp.properties["signal_quantification_mode"] = configured_signal_mode
+    cp.properties["puncta_contour_intensity_enabled"] = bool(
+        conf.get(
+            "puncta_contour_intensity_enabled",
+            conf.get("punctaContourIntensityEnabled", False),
+        )
+    )
+    if configured_signal_mode == "puncta_distance" or conf.get("measurement_contour_ratio_mode"):
+        cp.properties["measurement_contour_ratio_mode"] = conf.get(
+            "measurement_contour_ratio_mode",
+            measurement_ratio_mode_for_puncta_line_mode(puncta_line_metadata["mode"]),
+        )
 
     if execution_plan is None:
         execution_plan = build_stats_execution_plan(conf.get("analysis", []))
+    selected_plugins = list(execution_plan.selected_plugins)
+    alternate_detection_channel = (
+        alternate_detection_channel
+        or conf.get("alternate_nucleus_detection_channel")
+        or conf.get("alternateNucleusDetectionChannel")
+    )
+    cp.properties["selected_analysis"] = selected_plugins
+    cp.properties["stat_visibility"] = build_stat_visibility(selected_plugins)
+    cp.properties["alternate_nucleus_detection_enabled"] = _truthy_config_flag(
+        conf.get(
+            "alternate_nucleus_detection_enabled",
+            conf.get("alternateNucleusDetectionEnabled", alternate_red_detection),
+        )
+    )
+    cp.properties["alternate_nucleus_detection_channel"] = alternate_detection_channel
     stats_required_channels = {
         channel
         for channel in execution_plan.required_channels
@@ -283,12 +421,36 @@ def get_stats(
         cp.properties["intensity_pixel_source"] = "raw_dv_v1"
         cp.properties["intensity_display_scaled"] = False
         cp.properties["intensity_background_subtracted"] = False
+    suppressed_overlay_channel = _alternate_nucleus_overlay_suppression_channel(
+        selected_plugins=selected_plugins,
+        signal_quantification_mode=cp.properties.get("signal_quantification_mode"),
+        nuclear_cell_pair_mode=cp.properties.get("nuclear_cell_pair_mode"),
+        alternate_nucleus_detection_enabled=cp.properties.get(
+            "alternate_nucleus_detection_enabled"
+        ),
+        alternate_nucleus_detection_channel=cp.properties.get(
+            "alternate_nucleus_detection_channel"
+        ),
+    )
+    skipped_standard_contour_channels = _alternate_nucleus_standard_contour_skip_channels(
+        selected_plugins=selected_plugins,
+        signal_quantification_mode=cp.properties.get("signal_quantification_mode"),
+        nuclear_cell_pair_mode=cp.properties.get("nuclear_cell_pair_mode"),
+        alternate_nucleus_detection_enabled=cp.properties.get(
+            "alternate_nucleus_detection_enabled"
+        ),
+        alternate_nucleus_detection_channel=cp.properties.get(
+            "alternate_nucleus_detection_channel"
+        ),
+    )
     contours_data = find_contours(
         preprocessed_images,
         green_contour_filter_enabled,
         alternate_red_detection,
         green_dot_split_enabled,
         green_dot_split_mode,
+        alternate_detection_channel=alternate_detection_channel,
+        skip_standard_contour_channels=skipped_standard_contour_channels,
     )
     contours_data = build_canonical_contour_payload(
         contours_data,
@@ -305,7 +467,7 @@ def get_stats(
     canonical_blue_contours = flatten_slot_contours(canonical_blue_slots)
     cp.blue_contour_size = float(canonical_blue_slots[0].area) if canonical_blue_slots else 0.0
 
-    if canonical_red_contours:
+    if canonical_red_contours and suppressed_overlay_channel != CHANNEL_ROLE_RED:
         cv2.drawContours(edit_red_img, canonical_red_contours, -1, (0, 0, 255), 1)
         cv2.drawContours(edit_green_img, canonical_red_contours, -1, (0, 0, 255), 1)
         cv2.drawContours(edit_blue_img, canonical_red_contours, -1, (0, 0, 255), 1)
@@ -313,7 +475,7 @@ def get_stats(
     if canonical_blue_contours:
         cv2.drawContours(edit_blue_img, canonical_blue_contours, -1, (255, 0, 0), 1)
 
-    if canonical_green_contours:
+    if canonical_green_contours and suppressed_overlay_channel != CHANNEL_ROLE_GREEN:
         cv2.drawContours(edit_red_img, canonical_green_contours, -1, (0, 255, 0), 1)
         cv2.drawContours(edit_green_img, canonical_green_contours, -1, (0, 255, 0), 1)
         cv2.drawContours(edit_blue_img, canonical_green_contours, -1, (0, 255, 0), 1)
@@ -1121,6 +1283,11 @@ def segment_image(request, uuids):
             'alternateRedDetection',
             request.session.get('alternateMCherryDetection', 'False'),
         )
+        alternate_red_detection_bool = (
+            alternate_red_detection
+            if isinstance(alternate_red_detection, bool)
+            else str(alternate_red_detection).strip().lower() in {"1", "true", "yes", "on"}
+        )
 
         biorientation_red_min_distance_unit = normalize_length_unit(
             request.session.get('stats_biorientation_red_min_distance_unit', 'px'),
@@ -1148,12 +1315,15 @@ def segment_image(request, uuids):
             biorientation_red_max_distance_value = 37.0
         try:
             biorientation_collinearity_threshold = int(
-                request.session.get('biorientationCollinearityThreshold', 66)
+                request.session.get(
+                    'biorientationCollinearityThreshold',
+                    DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
+                )
             )
         except (TypeError, ValueError):
-            biorientation_collinearity_threshold = 66
+            biorientation_collinearity_threshold = DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX
         if biorientation_collinearity_threshold < 0:
-            biorientation_collinearity_threshold = 66
+            biorientation_collinearity_threshold = DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX
         green_dot_split_enabled_raw = request.session.get(
             'greenDotSplitEnabled',
             request.session.get('biorientationGreenSplitEnabled', True),
@@ -1166,6 +1336,34 @@ def segment_image(request, uuids):
         )
         green_dot_split_mode = normalize_green_dot_split_mode(
             request.session.get("greenDotSplitMode", DEFAULT_GREEN_DOT_SPLIT_MODE)
+        )
+        signal_quantification_enabled = request.session.get("signalQuantificationEnabled", True)
+        signal_quantification_enabled = (
+            signal_quantification_enabled
+            if isinstance(signal_quantification_enabled, bool)
+            else str(signal_quantification_enabled).strip().lower() in {"1", "true", "yes", "on"}
+        )
+        signal_quantification_mode = request.session.get("signalQuantificationMode", "puncta_distance")
+        puncta_contour_intensity_enabled = request.session.get(
+            "punctaContourIntensityEnabled",
+            "GreenRedIntensity" in selected_analysis,
+        )
+        puncta_contour_intensity_enabled = (
+            puncta_contour_intensity_enabled
+            if isinstance(puncta_contour_intensity_enabled, bool)
+            else str(puncta_contour_intensity_enabled).strip().lower() in {"1", "true", "yes", "on"}
+        )
+        alternate_nucleus_detection_enabled = request.session.get(
+            "alternateNucleusDetectionEnabled",
+            alternate_red_detection_bool,
+        )
+        alternate_nucleus_detection_enabled = (
+            alternate_nucleus_detection_enabled
+            if isinstance(alternate_nucleus_detection_enabled, bool)
+            else str(alternate_nucleus_detection_enabled).strip().lower() in {"1", "true", "yes", "on"}
+        )
+        alternate_nucleus_detection_channel = request.session.get(
+            "alternateNucleusDetectionChannel"
         )
         configured_puncta_line_width = _process_config_value(
             configuration,
@@ -1192,7 +1390,12 @@ def segment_image(request, uuids):
                 request.session.get("nuclear_cellular_mode", "green_nucleus"),
             ),
             'green_contour_filter_enabled': green_contour_filter_enabled,
-            'alternate_red_detection': alternate_red_detection,
+            'alternate_red_detection': alternate_nucleus_detection_enabled,
+            'signal_quantification_enabled': signal_quantification_enabled,
+            'signal_quantification_mode': signal_quantification_mode,
+            'puncta_contour_intensity_enabled': puncta_contour_intensity_enabled,
+            'alternate_nucleus_detection_enabled': alternate_nucleus_detection_enabled,
+            'alternate_nucleus_detection_channel': alternate_nucleus_detection_channel,
             'green_dot_split_enabled': green_dot_split_enabled,
             'green_dot_split_mode': green_dot_split_mode,
         }
@@ -1221,11 +1424,12 @@ def segment_image(request, uuids):
                     if isinstance(green_contour_filter_enabled, bool)
                     else str(green_contour_filter_enabled).strip().lower() in {"1", "true", "yes", "on"}
                 ),
-                alternate_red_detection=(
-                    alternate_red_detection
-                    if isinstance(alternate_red_detection, bool)
-                    else str(alternate_red_detection).strip().lower() in {"1", "true", "yes", "on"}
-                ),
+                alternate_red_detection=alternate_nucleus_detection_enabled,
+                signal_quantification_enabled=signal_quantification_enabled,
+                signal_quantification_mode=signal_quantification_mode,
+                puncta_contour_intensity_enabled=puncta_contour_intensity_enabled,
+                alternate_nucleus_detection_enabled=alternate_nucleus_detection_enabled,
+                alternate_nucleus_detection_channel=alternate_nucleus_detection_channel,
                 puncta_line_width_unit=puncta_line_width_unit,
                 cen_dot_distance_unit=cen_dot_distance_unit,
                 cen_dot_proximity_radius=cen_dot_proximity_radius,
@@ -1317,6 +1521,11 @@ def segment_image(request, uuids):
             cp.properties["stats_biorientation_collinearity_threshold"] = biorientation_collinearity_threshold
             cp.properties["stats_green_dot_split_enabled"] = green_dot_split_enabled
             cp.properties["stats_green_dot_split_mode"] = green_dot_split_mode
+            cp.properties["signal_quantification_enabled"] = signal_quantification_enabled
+            cp.properties["signal_quantification_mode"] = signal_quantification_mode
+            cp.properties["puncta_contour_intensity_enabled"] = puncta_contour_intensity_enabled
+            cp.properties["alternate_nucleus_detection_enabled"] = alternate_nucleus_detection_enabled
+            cp.properties["alternate_nucleus_detection_channel"] = alternate_nucleus_detection_channel
             # Call get_stats to do the real work
             debug_red, debug_green, debug_blue = get_stats(
                 cp,
@@ -1326,11 +1535,12 @@ def segment_image(request, uuids):
                 cen_dot_distance,
                 cen_dot_proximity_radius,
                 green_contour_filter_enabled,
-                alternate_red_detection,
+                alternate_nucleus_detection_enabled,
                 green_dot_split_enabled,
                 green_dot_split_mode,
                 cached_images=cell_image_cache.get(cell_number),
                 cached_measurement_images=cell_measurement_image_cache.get(cell_number),
+                alternate_detection_channel=alternate_nucleus_detection_channel,
             )
 
             try:

--- a/cytocv/templates/dashboard.html
+++ b/cytocv/templates/dashboard.html
@@ -1988,7 +1988,7 @@
                                                 <span class="metric-value" id="contourStateValue">On</span>
                                             </div>
                                         </div>
-                                        <div class="cell-stats-section">
+                                        <div class="cell-stats-section" data-stat-section="biorientation">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Biorientation</p>
                                                 <span
@@ -2007,7 +2007,7 @@
                                                 <span class="metric-value" id="offAxisDots"></span>
                                             </div>
                                         </div>
-                                        <div class="cell-stats-section raw-sum-section">
+                                        <div class="cell-stats-section raw-sum-section" data-stat-section="red_green_intensity">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Red In Red Raw Sums</p>
                                                 <span
@@ -2032,7 +2032,7 @@
                                         </div>
                                     </div>
                                     <div class="cell-stats-column">
-                                        <div class="cell-stats-section">
+                                        <div class="cell-stats-section" data-stat-section="nuclear_cell_pair_intensity">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Nucleus + Measurement</p>
                                                 <span
@@ -2067,7 +2067,7 @@
                                                 <span class="metric-value" id="cytoplasmicIntensity"></span>
                                             </div>
                                         </div>
-                                        <div class="cell-stats-section raw-sum-section">
+                                        <div class="cell-stats-section raw-sum-section" data-stat-section="red_green_intensity">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Green In Red Raw Sums</p>
                                                 <span
@@ -2092,7 +2092,7 @@
                                         </div>
                                     </div>
                                     <div class="cell-stats-column">
-                                        <div class="cell-stats-section">
+                                        <div class="cell-stats-section" data-stat-section="cen_puncta">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">CEN Dot Measurements</p>
                                                 <span
@@ -2102,24 +2102,24 @@
                                                     title="CEN Dot Measurement Details"
                                                 >i</span>
                                             </div>
-                                            <div class="metric-row">
+                                            <div class="metric-row" data-stat-row="puncta_distance">
                                                 <span class="metric-label" id="distanceLabel">Distance Between Red Puncta</span>
                                                 <span class="metric-value" id="distance"></span>
                                             </div>
-                                            <div class="metric-row">
+                                            <div class="metric-row" data-stat-row="puncta_distance">
                                                 <span class="metric-label" id="lineIntensityLabel">Green Intensity Over Red Line</span>
                                                 <span class="metric-value" id="punctaLineIntensity"></span>
                                             </div>
-                                            <div class="metric-row">
+                                            <div class="metric-row" data-stat-row="cen_dot">
                                                 <span class="metric-label">Cell Parentage</span>
                                                 <span class="metric-value" id="cellParentage"></span>
                                             </div>
-                                            <div class="metric-row">
+                                            <div class="metric-row" data-stat-row="cen_dot">
                                                 <span class="metric-label">Cen Dot Location</span>
                                                 <span class="metric-value" id="cenDot"></span>
                                             </div>
                                         </div>
-                                        <div class="cell-stats-section raw-sum-section">
+                                        <div class="cell-stats-section raw-sum-section" data-stat-section="red_green_intensity">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Red In Green Raw Sums</p>
                                                 <span
@@ -2144,7 +2144,7 @@
                                         </div>
                                     </div>
                                     <div class="cell-stats-column">
-                                        <div class="cell-stats-section">
+                                        <div class="cell-stats-section" data-stat-section="red_green_intensity">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Measurement/Contour</p>
                                                 <span
@@ -2171,7 +2171,7 @@
                                                 <span class="metric-value" id="measurementContourRatio3"></span>
                                             </div>
                                         </div>
-                                        <div class="cell-stats-section raw-sum-section">
+                                        <div class="cell-stats-section raw-sum-section" data-stat-section="red_green_intensity">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Green In Green Raw Sums</p>
                                                 <span
@@ -2378,6 +2378,43 @@
             'colinear_dots',
             'off_axis_dots',
         ];
+        const statFieldGroups = {
+            puncta_distance: ['puncta_distance', 'puncta_line_intensity'],
+            legacy_blue_intensity: ['blue_contour_size'],
+            red_green_intensity: [
+                'red_contour_1_size',
+                'red_contour_2_size',
+                'red_contour_3_size',
+                'green_contour_1_size',
+                'green_contour_2_size',
+                'green_contour_3_size',
+                'red_intensity_1',
+                'red_intensity_2',
+                'red_intensity_3',
+                'green_intensity_1',
+                'green_intensity_2',
+                'green_intensity_3',
+                'red_in_green_intensity_1',
+                'red_in_green_intensity_2',
+                'red_in_green_intensity_3',
+                'green_in_green_intensity_1',
+                'green_in_green_intensity_2',
+                'green_in_green_intensity_3',
+                'measurement_contour_ratio_1',
+                'measurement_contour_ratio_2',
+                'measurement_contour_ratio_3',
+                'distance_of_green_from_red_1',
+                'distance_of_green_from_red_2',
+                'distance_of_green_from_red_3',
+            ],
+            nuclear_cell_pair_intensity: [
+                'cell_pair_intensity_sum',
+                'nucleus_intensity_sum',
+                'cytoplasmic_intensity',
+            ],
+            cen_dot: ['cell_parentage', 'category_cen_dot'],
+            biorientation: ['colinear_dots', 'off_axis_dots'],
+        };
         const spatialHeaderBaseLabels = {
             blue_contour_size: 'Blue Contour Size',
             red_contour_1_size: 'Red Contour 1 Size',
@@ -2657,6 +2694,65 @@
             return indices.map((index) => imageUrls[index] || noCellPlaceholder);
         }
 
+        function defaultStatVisibility() {
+            return {
+                puncta_distance: true,
+                red_green_intensity: true,
+                nuclear_cell_pair_intensity: true,
+                cen_dot: true,
+                biorientation: true,
+                legacy_blue_intensity: true,
+            };
+        }
+
+        function getStatVisibility(cellStats) {
+            const defaults = defaultStatVisibility();
+            const visibility = cellStats && typeof cellStats.stat_visibility === 'object'
+                ? cellStats.stat_visibility
+                : null;
+            return {
+                puncta_distance: visibility ? visibility.puncta_distance !== false : defaults.puncta_distance,
+                red_green_intensity: visibility ? visibility.red_green_intensity !== false : defaults.red_green_intensity,
+                nuclear_cell_pair_intensity: visibility ? visibility.nuclear_cell_pair_intensity !== false : defaults.nuclear_cell_pair_intensity,
+                cen_dot: visibility ? visibility.cen_dot !== false : defaults.cen_dot,
+                biorientation: visibility ? visibility.biorientation !== false : defaults.biorientation,
+                legacy_blue_intensity: visibility ? visibility.legacy_blue_intensity !== false : defaults.legacy_blue_intensity,
+            };
+        }
+
+        function getStatisticsVisibility(statistics) {
+            const firstStats = Object.values(statistics || {}).find((row) => row);
+            return getStatVisibility(firstStats || null);
+        }
+
+        function isTableFieldVisible(fieldName, visibility) {
+            for (const [key, fields] of Object.entries(statFieldGroups)) {
+                if (fields.includes(fieldName)) {
+                    return visibility[key] !== false;
+                }
+            }
+            return true;
+        }
+
+        function getVisibleTableFieldOrder(statistics) {
+            const visibility = getStatisticsVisibility(statistics);
+            return tableFieldOrder.filter((fieldName) => isTableFieldVisible(fieldName, visibility));
+        }
+
+        function applyMetricVisibility(visibility) {
+            document.querySelectorAll('[data-stat-section]').forEach((section) => {
+                const key = section.dataset.statSection;
+                if (key === 'cen_puncta') {
+                    section.hidden = visibility.puncta_distance === false && visibility.cen_dot === false;
+                    return;
+                }
+                section.hidden = visibility[key] === false;
+            });
+            document.querySelectorAll('[data-stat-row]').forEach((row) => {
+                row.hidden = visibility[row.dataset.statRow] === false;
+            });
+        }
+
         function getCellDisplayState(cellPairImages, statistics, { showContours = getContourToggleState(), cellNumber = currentCellNumber } = {}) {
             const safeCellPairImages = cellPairImages || {};
             const safeStatistics = statistics || {};
@@ -2673,10 +2769,12 @@
             const labels = getNuclearLabelPair(mode);
             const distanceLabel = cellStats ? (cellStats.puncta_distance_label || 'Distance Between Red Puncta') : 'Distance Between Red Puncta';
             const lineIntensityLabel = cellStats ? (cellStats.puncta_line_intensity_label || 'Green Intensity Over Red Line') : 'Green Intensity Over Red Line';
+            const statVisibility = getStatVisibility(cellStats);
 
             return {
                 visibleImageUrls,
                 cellId: imageUrls ? cellNumber : (maxCells > 0 ? cellNumber : 0),
+                statVisibility,
                 metricValues: {
                     distance: formatFieldValue('puncta_distance', cellStats ? cellStats.puncta_distance : null, cellStats, scaleContext),
                     punctaLineIntensity: formatStatValue(cellStats ? cellStats.puncta_line_intensity : null),
@@ -2725,6 +2823,7 @@
             document.getElementById('lineIntensityLabel').textContent = state.labels.lineIntensityLabel;
             document.getElementById('nucleusIntensityLabel').textContent = state.labels.nucleusIntensityLabel;
             document.getElementById('cellularIntensityLabel').textContent = state.labels.cellularIntensityLabel;
+            applyMetricVisibility(state.statVisibility || defaultStatVisibility());
 
             const imageIds = ['cellImage1', 'cellImage2', 'cellImage3', 'cellImage4'];
             const imageUpdates = imageIds.map((id, index) =>
@@ -2951,7 +3050,8 @@
             });
 
             const headers = Array.from(document.querySelectorAll('#celltable thead th'));
-            tableFieldOrder.forEach((fieldName, index) => {
+            const visibleFieldOrder = getVisibleTableFieldOrder(fileData?.Statistics || {});
+            visibleFieldOrder.forEach((fieldName, index) => {
                 if (!Object.prototype.hasOwnProperty.call(spatialFieldKinds, fieldName) || !headers[index]) {
                     return;
                 }
@@ -3019,6 +3119,7 @@
             ]);
             const scaleContext = getScaleContext(fileData);
             updateSpatialUnitControls(fileData);
+            const visibleFieldOrder = getVisibleTableFieldOrder(statistics);
 
             const ids = Object.keys(statistics || {})
                 .map((k) => Number(k))
@@ -3039,7 +3140,7 @@
             for (const id of ids) {
                 const rowStats = statistics[String(id)] || null;
                 const tr = document.createElement('tr');
-                for (const fieldName of tableFieldOrder) {
+                for (const fieldName of visibleFieldOrder) {
                     const td = document.createElement('td');
                     if (fieldName === 'cell_id') {
                         td.textContent = String(id);

--- a/cytocv/templates/display.html
+++ b/cytocv/templates/display.html
@@ -1943,7 +1943,7 @@
                                                 <span class="metric-value" id="contourStateValue">On</span>
                                             </div>
                                         </div>
-                                        <div class="cell-stats-section">
+                                        <div class="cell-stats-section" data-stat-section="biorientation">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Biorientation</p>
                                                 <span
@@ -1962,7 +1962,7 @@
                                                 <span class="metric-value" id="offAxisDots"></span>
                                             </div>
                                         </div>
-                                        <div class="cell-stats-section raw-sum-section">
+                                        <div class="cell-stats-section raw-sum-section" data-stat-section="red_green_intensity">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Red In Red Raw Sums</p>
                                                 <span
@@ -1987,18 +1987,18 @@
                                         </div>
                                     </div>
                                     <div class="cell-stats-column">
-                                        <div class="cell-stats-section">
+                                        <div class="cell-stats-section" data-stat-section="nuclear_cell_pair_intensity">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Nucleus + Measurement</p>
                                                 <span
                                                     class="selection-info-dot metric-info-dot"
-                                                    data-info-text="Shows which contour family is used as the nucleus, which fluorescence channel is measured, whether a nucleus contour is available, and the nuclear, whole cell-pair, and cytoplasmic intensity values."
+                                                    data-info-text="Shows the selected nucleus contour channel, which fluorescence channel is measured, whether a nucleus contour is available, and the nuclear, whole cell-pair, and cytoplasmic intensity values."
                                                     aria-label="Nucleus And Measurement Details"
                                                     title="Nucleus And Measurement Details"
                                                 >i</span>
                                             </div>
                                             <div class="metric-row">
-                                                <span class="metric-label">Nucleus Contour Source</span>
+                                                <span class="metric-label">Nucleus Contour Channel</span>
                                                 <span class="metric-value" id="nucleusContourChannel"></span>
                                             </div>
                                             <div class="metric-row">
@@ -2022,7 +2022,7 @@
                                                 <span class="metric-value" id="cytoplasmicIntensity"></span>
                                             </div>
                                         </div>
-                                        <div class="cell-stats-section raw-sum-section">
+                                        <div class="cell-stats-section raw-sum-section" data-stat-section="red_green_intensity">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Green In Red Raw Sums</p>
                                                 <span
@@ -2047,7 +2047,7 @@
                                         </div>
                                     </div>
                                     <div class="cell-stats-column">
-                                        <div class="cell-stats-section">
+                                        <div class="cell-stats-section" data-stat-section="cen_puncta">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">CEN Dot Measurements</p>
                                                 <span
@@ -2057,24 +2057,24 @@
                                                     title="CEN Dot Measurement Details"
                                                 >i</span>
                                             </div>
-                                            <div class="metric-row">
+                                            <div class="metric-row" data-stat-row="puncta_distance">
                                                 <span class="metric-label" id="distanceLabel">Distance Between Red Puncta</span>
                                                 <span class="metric-value" id="distance"></span>
                                             </div>
-                                            <div class="metric-row">
+                                            <div class="metric-row" data-stat-row="puncta_distance">
                                                 <span class="metric-label" id="lineIntensityLabel">Green Intensity Over Red Line</span>
                                                 <span class="metric-value" id="punctaLineIntensity"></span>
                                             </div>
-                                            <div class="metric-row">
+                                            <div class="metric-row" data-stat-row="cen_dot">
                                                 <span class="metric-label">Cell Parentage</span>
                                                 <span class="metric-value" id="cellParentage"></span>
                                             </div>
-                                            <div class="metric-row">
+                                            <div class="metric-row" data-stat-row="cen_dot">
                                                 <span class="metric-label">Cen Dot Location</span>
                                                 <span class="metric-value" id="cenDot"></span>
                                             </div>
                                         </div>
-                                        <div class="cell-stats-section raw-sum-section">
+                                        <div class="cell-stats-section raw-sum-section" data-stat-section="red_green_intensity">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Red In Green Raw Sums</p>
                                                 <span
@@ -2099,7 +2099,7 @@
                                         </div>
                                     </div>
                                     <div class="cell-stats-column">
-                                        <div class="cell-stats-section">
+                                        <div class="cell-stats-section" data-stat-section="red_green_intensity">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Measurement/Contour</p>
                                                 <span
@@ -2126,7 +2126,7 @@
                                                 <span class="metric-value" id="measurementContourRatio3"></span>
                                             </div>
                                         </div>
-                                        <div class="cell-stats-section raw-sum-section">
+                                        <div class="cell-stats-section raw-sum-section" data-stat-section="red_green_intensity">
                                             <div class="metric-lead-row">
                                                 <p class="metric-lead">Green In Green Raw Sums</p>
                                                 <span
@@ -2331,6 +2331,7 @@
             'distance_of_green_from_red_1',
             'distance_of_green_from_red_2',
             'distance_of_green_from_red_3',
+            'nuclear_cell_pair_contour_source',
             'cell_pair_intensity_sum',
             'nucleus_intensity_sum',
             'cytoplasmic_intensity',
@@ -2339,6 +2340,44 @@
             'colinear_dots',
             'off_axis_dots',
         ];
+        const statFieldGroups = {
+            puncta_distance: ['puncta_distance', 'puncta_line_intensity'],
+            legacy_blue_intensity: ['blue_contour_size'],
+            red_green_intensity: [
+                'red_contour_1_size',
+                'red_contour_2_size',
+                'red_contour_3_size',
+                'green_contour_1_size',
+                'green_contour_2_size',
+                'green_contour_3_size',
+                'red_intensity_1',
+                'red_intensity_2',
+                'red_intensity_3',
+                'green_intensity_1',
+                'green_intensity_2',
+                'green_intensity_3',
+                'red_in_green_intensity_1',
+                'red_in_green_intensity_2',
+                'red_in_green_intensity_3',
+                'green_in_green_intensity_1',
+                'green_in_green_intensity_2',
+                'green_in_green_intensity_3',
+                'measurement_contour_ratio_1',
+                'measurement_contour_ratio_2',
+                'measurement_contour_ratio_3',
+                'distance_of_green_from_red_1',
+                'distance_of_green_from_red_2',
+                'distance_of_green_from_red_3',
+            ],
+            nuclear_cell_pair_intensity: [
+                'nuclear_cell_pair_contour_source',
+                'cell_pair_intensity_sum',
+                'nucleus_intensity_sum',
+                'cytoplasmic_intensity',
+            ],
+            cen_dot: ['cell_parentage', 'category_cen_dot'],
+            biorientation: ['colinear_dots', 'off_axis_dots'],
+        };
         const spatialHeaderBaseLabels = {
             blue_contour_size: 'Blue Contour Size',
             red_contour_1_size: 'Red Contour 1 Size',
@@ -2618,6 +2657,65 @@
             return indices.map((index) => imageUrls[index] || noCellPlaceholder);
         }
 
+        function defaultStatVisibility() {
+            return {
+                puncta_distance: true,
+                red_green_intensity: true,
+                nuclear_cell_pair_intensity: true,
+                cen_dot: true,
+                biorientation: true,
+                legacy_blue_intensity: true,
+            };
+        }
+
+        function getStatVisibility(cellStats) {
+            const defaults = defaultStatVisibility();
+            const visibility = cellStats && typeof cellStats.stat_visibility === 'object'
+                ? cellStats.stat_visibility
+                : null;
+            return {
+                puncta_distance: visibility ? visibility.puncta_distance !== false : defaults.puncta_distance,
+                red_green_intensity: visibility ? visibility.red_green_intensity !== false : defaults.red_green_intensity,
+                nuclear_cell_pair_intensity: visibility ? visibility.nuclear_cell_pair_intensity !== false : defaults.nuclear_cell_pair_intensity,
+                cen_dot: visibility ? visibility.cen_dot !== false : defaults.cen_dot,
+                biorientation: visibility ? visibility.biorientation !== false : defaults.biorientation,
+                legacy_blue_intensity: visibility ? visibility.legacy_blue_intensity !== false : defaults.legacy_blue_intensity,
+            };
+        }
+
+        function getStatisticsVisibility(statistics) {
+            const firstStats = Object.values(statistics || {}).find((row) => row);
+            return getStatVisibility(firstStats || null);
+        }
+
+        function isTableFieldVisible(fieldName, visibility) {
+            for (const [key, fields] of Object.entries(statFieldGroups)) {
+                if (fields.includes(fieldName)) {
+                    return visibility[key] !== false;
+                }
+            }
+            return true;
+        }
+
+        function getVisibleTableFieldOrder(statistics) {
+            const visibility = getStatisticsVisibility(statistics);
+            return tableFieldOrder.filter((fieldName) => isTableFieldVisible(fieldName, visibility));
+        }
+
+        function applyMetricVisibility(visibility) {
+            document.querySelectorAll('[data-stat-section]').forEach((section) => {
+                const key = section.dataset.statSection;
+                if (key === 'cen_puncta') {
+                    section.hidden = visibility.puncta_distance === false && visibility.cen_dot === false;
+                    return;
+                }
+                section.hidden = visibility[key] === false;
+            });
+            document.querySelectorAll('[data-stat-row]').forEach((row) => {
+                row.hidden = visibility[row.dataset.statRow] === false;
+            });
+        }
+
         function getCellDisplayState(cellPairImages, statistics, { showContours = getContourToggleState(), cellNumber = currentCellNumber } = {}) {
             const safeCellPairImages = cellPairImages || {};
             const safeStatistics = statistics || {};
@@ -2634,10 +2732,12 @@
             const labels = getNuclearLabelPair(mode);
             const distanceLabel = cellStats ? (cellStats.puncta_distance_label || 'Distance Between Red Puncta') : 'Distance Between Red Puncta';
             const lineIntensityLabel = cellStats ? (cellStats.puncta_line_intensity_label || 'Green Intensity Over Red Line') : 'Green Intensity Over Red Line';
+            const statVisibility = getStatVisibility(cellStats);
 
             return {
                 visibleImageUrls,
                 cellId: imageUrls ? cellNumber : (maxCells > 0 ? cellNumber : 0),
+                statVisibility,
                 metricValues: {
                     distance: formatFieldValue('puncta_distance', cellStats ? cellStats.puncta_distance : null, cellStats, scaleContext),
                     punctaLineIntensity: formatStatValue(cellStats ? cellStats.puncta_line_intensity : null),
@@ -2686,6 +2786,7 @@
             document.getElementById('lineIntensityLabel').textContent = state.labels.lineIntensityLabel;
             document.getElementById('nucleusIntensityLabel').textContent = state.labels.nucleusIntensityLabel;
             document.getElementById('cellularIntensityLabel').textContent = state.labels.cellularIntensityLabel;
+            applyMetricVisibility(state.statVisibility || defaultStatVisibility());
 
             const imageIds = ['cellImage1', 'cellImage2', 'cellImage3', 'cellImage4'];
             const imageUpdates = imageIds.map((id, index) =>
@@ -3228,7 +3329,8 @@
             });
 
             const headers = Array.from(document.querySelectorAll('#celltable thead th'));
-            tableFieldOrder.forEach((fieldName, index) => {
+            const visibleFieldOrder = getVisibleTableFieldOrder(fileData?.Statistics || {});
+            visibleFieldOrder.forEach((fieldName, index) => {
                 if (!Object.prototype.hasOwnProperty.call(spatialFieldKinds, fieldName) || !headers[index]) {
                     return;
                 }
@@ -3296,6 +3398,7 @@
             ]);
             const scaleContext = getScaleContext(fileData);
             updateSpatialUnitControls(fileData);
+            const visibleFieldOrder = getVisibleTableFieldOrder(statistics);
 
             const ids = Object.keys(statistics || {})
                 .map((k) => Number(k))
@@ -3306,7 +3409,7 @@
             for (const id of ids) {
                 const rowStats = statistics[String(id)] || null;
                 const tr = document.createElement('tr');
-                for (const fieldName of tableFieldOrder) {
+                for (const fieldName of visibleFieldOrder) {
                     const td = document.createElement('td');
                     if (fieldName === 'cell_id') {
                         td.textContent = String(id);

--- a/cytocv/templates/form/experiment.html
+++ b/cytocv/templates/form/experiment.html
@@ -969,6 +969,19 @@
         .stats-toggle-row.is-off .legacy-pill {
             opacity: var(--settings-module-off-control-opacity);
         }
+        .stats-toggle-row.is-paused {
+            background-color: var(--settings-module-off-bg);
+            border-color: var(--settings-module-off-border);
+            filter: var(--settings-module-off-filter);
+        }
+        .stats-toggle-row.is-paused .stats-toggle-left {
+            opacity: var(--settings-module-off-text-opacity);
+        }
+        .stats-toggle-row.is-paused .switch,
+        .stats-toggle-row.is-paused .info-dot,
+        .stats-toggle-row.is-paused .legacy-pill {
+            opacity: var(--settings-module-off-control-opacity);
+        }
         .stats-toggle-left {
             display: flex;
             align-items: center;
@@ -1292,6 +1305,26 @@
             margin-top: 4px;
             pointer-events: auto;
             overflow: visible;
+        }
+        .signal-mode-paused-note {
+            margin: 0;
+            min-height: 14px;
+            color: #e5c558;
+            font-size: 11px;
+            line-height: 1.25;
+            opacity: 0;
+            transform: translateY(-5px);
+            transition: opacity 0.2s ease, transform 0.2s ease;
+        }
+        .signal-mode-paused-note.visible {
+            opacity: 1;
+            transform: translateY(0);
+        }
+        .signal-mode-paused-note.is-enabled {
+            color: #8fdc9c;
+        }
+        .signal-mode-paused-note.is-paused {
+            color: #e5c558;
         }
         .signal-mode-stack {
             display: grid;
@@ -2244,6 +2277,7 @@
     let signalQuantificationToggle = null;
     let signalQuantificationModeRow = null;
     let signalQuantificationModeSelect = null;
+    let signalModePausedNote = null;
     let signalPunctaPanel = null;
     let signalNuclearPanel = null;
     let punctaContourIntensityToggle = null;
@@ -2344,6 +2378,68 @@
         }
     }
 
+    function isNuclearSignalModeActive() {
+        return !!statsState.signalQuantificationEnabled
+            && normalizeSignalMode(statsState.signalQuantificationMode) === 'nuclear_cell_pair';
+    }
+
+    function isPluginPausedBySignalMode(pluginId) {
+        return isNuclearSignalModeActive() && pluginId !== 'NuclearCellPairIntensity';
+    }
+
+    function getEffectiveSelectedPlugins() {
+        if (isNuclearSignalModeActive()) {
+            return new Set(['NuclearCellPairIntensity']);
+        }
+        return new Set(statsState.selectedPlugins);
+    }
+
+    function buildSignalModeNotice(signalEnabled, signalMode) {
+        if (!signalEnabled) return null;
+        if (signalMode === 'nuclear_cell_pair') {
+            return {
+                state: 'paused',
+                text: 'All other stat modules disabled in Nuclear, Cell-Pair mode.',
+            };
+        }
+        const activeSecondaries = [
+            statsState.selectedPlugins.has('CENDot') ? 'Cen Dot' : null,
+            statsState.selectedPlugins.has('Biorientation') ? 'Biorientation' : null,
+        ].filter(Boolean);
+        if (!activeSecondaries.length) return null;
+        return {
+            state: 'enabled',
+            text: activeSecondaries.length === 2
+                ? `${activeSecondaries[0]} and ${activeSecondaries[1]} modules enabled.`
+                : `${activeSecondaries[0]} module enabled.`,
+        };
+    }
+
+    function syncSignalModeNotice(signalEnabled, signalMode) {
+        if (!signalModePausedNote) return;
+        const notice = buildSignalModeNotice(signalEnabled, signalMode);
+        const state = notice ? notice.state : '';
+        const text = notice ? notice.text : '';
+        const changed = signalModePausedNote.dataset.state !== state || signalModePausedNote.textContent !== text;
+        signalModePausedNote.classList.remove('is-enabled', 'is-paused');
+        if (!notice) {
+            signalModePausedNote.classList.remove('visible');
+            signalModePausedNote.setAttribute('aria-hidden', 'true');
+            signalModePausedNote.dataset.state = '';
+            signalModePausedNote.textContent = '';
+            return;
+        }
+        signalModePausedNote.textContent = text;
+        signalModePausedNote.dataset.state = state;
+        signalModePausedNote.classList.add(`is-${state}`);
+        signalModePausedNote.setAttribute('aria-hidden', 'false');
+        if (changed) {
+            signalModePausedNote.classList.remove('visible');
+            void signalModePausedNote.offsetWidth;
+        }
+        signalModePausedNote.classList.add('visible');
+    }
+
     const advancedInfoTextById = {
         legacyPluginInfoDot: buildInfoSections([
             'Shows legacy Blue-channel statistics in the plugin list. Turn this on only when you need older Blue-nucleus or Red-in-Blue outputs; modern Red/Green modules stay available either way.',
@@ -2401,7 +2497,7 @@
 
     function selectedPluginLabelsRequiringChannel(channel) {
         const labels = [];
-        statsState.selectedPlugins.forEach((pluginId) => {
+        getEffectiveSelectedPlugins().forEach((pluginId) => {
             const plugin = pluginMap.get(pluginId);
             if (!plugin || !Array.isArray(plugin.required_channels)) return;
             if (plugin.required_channels.includes(channel)) {
@@ -3594,6 +3690,10 @@
         );
         modeTop.appendChild(signalQuantificationModeSelect.root);
         signalQuantificationModeRow.appendChild(modeTop);
+        signalModePausedNote = document.createElement('p');
+        signalModePausedNote.className = 'signal-mode-paused-note';
+        signalModePausedNote.setAttribute('aria-hidden', 'true');
+        signalQuantificationModeRow.appendChild(signalModePausedNote);
         row.appendChild(signalQuantificationModeRow);
 
         const signalPanelStack = document.createElement('div');
@@ -3762,6 +3862,7 @@
         signalQuantificationToggle = null;
         signalQuantificationModeRow = null;
         signalQuantificationModeSelect = null;
+        signalModePausedNote = null;
         signalPunctaPanel = null;
         signalNuclearPanel = null;
         punctaContourIntensityToggle = null;
@@ -4672,7 +4773,7 @@
 
     function getStatsRequiredChannels() {
         const required = new Set(alwaysRequiredChannels);
-        statsState.selectedPlugins.forEach((pluginId) => {
+        getEffectiveSelectedPlugins().forEach((pluginId) => {
             const plugin = pluginMap.get(pluginId);
             if (!plugin || !Array.isArray(plugin.required_channels)) return;
             plugin.required_channels.forEach((channel) => required.add(channel));
@@ -4682,7 +4783,7 @@
 
     function isChannelUsed(channel) {
         var used = statsState.manualRequiredChannels.has(channel);
-        statsState.selectedPlugins.forEach((pluginId) => {
+        getEffectiveSelectedPlugins().forEach((pluginId) => {
             const plugin = pluginMap.get(pluginId);
             if (!plugin || !Array.isArray(plugin.required_channels)) return false;
             plugin.required_channels.forEach((required_channel) => {
@@ -4693,7 +4794,7 @@
     }
 
     function selectedStatsRequireChannel(channel) {
-        for (const pluginId of statsState.selectedPlugins) {
+        for (const pluginId of getEffectiveSelectedPlugins()) {
             const plugin = pluginMap.get(pluginId);
             if (plugin && Array.isArray(plugin.required_channels) && plugin.required_channels.includes(channel)) {
                 return true;
@@ -4726,9 +4827,15 @@
         const moduleRow = document.getElementById('moduleToggleRow');
 
         statToggleElements.forEach((toggle, pluginId) => {
-            toggle.checked = statsState.selectedPlugins.has(pluginId);
-            toggle.disabled = isPluginRequiredBySelection(pluginId);
-            setOffVisualState(toggle.closest('.stats-toggle-row'), !toggle.checked);
+            const row = toggle.closest('.stats-toggle-row');
+            const paused = isPluginPausedBySignalMode(pluginId);
+            toggle.checked = statsState.selectedPlugins.has(pluginId) && !paused;
+            toggle.disabled = isPluginRequiredBySelection(pluginId) || paused;
+            if (row) {
+                row.classList.toggle('is-paused', paused);
+                row.setAttribute('aria-disabled', paused ? 'true' : 'false');
+            }
+            setOffVisualState(row, !toggle.checked);
         });
 
         const signalEnabled = !!statsState.signalQuantificationEnabled;
@@ -4743,6 +4850,7 @@
         if (signalQuantificationModeRow) {
             signalQuantificationModeRow.classList.toggle('visible', signalEnabled);
         }
+        syncSignalModeNotice(signalEnabled, signalMode);
         if (signalPunctaPanel) {
             signalPunctaPanel.classList.toggle('visible', signalEnabled && signalMode === 'puncta_distance');
         }
@@ -4777,10 +4885,16 @@
             cenDotProximityRadiusInput.value = formatNumericInputValue(statsState.cenDotProximityRadius);
         }
         if (cenDotDistanceRow) {
-            cenDotDistanceRow.classList.toggle('visible', statsState.selectedPlugins.has('CENDot'));
+            cenDotDistanceRow.classList.toggle(
+                'visible',
+                statsState.selectedPlugins.has('CENDot') && !isPluginPausedBySignalMode('CENDot')
+            );
         }
         if (biorientationRow) {
-            biorientationRow.classList.toggle('visible', statsState.selectedPlugins.has('Biorientation'));
+            biorientationRow.classList.toggle(
+                'visible',
+                statsState.selectedPlugins.has('Biorientation') && !isPluginPausedBySignalMode('Biorientation')
+            );
         }
         if (biorientationRedMinDistanceInput) {
             biorientationRedMinDistanceInput.value = formatNumericInputValue(statsState.biorientationRedMinDistance);
@@ -6373,7 +6487,7 @@
             prepData.append('enforce_layer_count', layerEnabled ? '1' : '0');
             prepData.append('enforce_wavelengths', wavelengthEnabled ? '1' : '0');
             extraRequiredChannels.forEach((channel) => prepData.append('extra_required_channels', channel));
-            [...statsState.selectedPlugins].forEach((pluginId) => prepData.append('selected_analysis', pluginId));
+            [...getEffectiveSelectedPlugins()].forEach((pluginId) => prepData.append('selected_analysis', pluginId));
             prepData.append('signalQuantificationEnabled', String(statsState.signalQuantificationEnabled));
             prepData.append('signalQuantificationMode', normalizeSignalMode(statsState.signalQuantificationMode));
             prepData.append('punctaContourIntensityEnabled', String(statsState.punctaContourIntensityEnabled));

--- a/cytocv/templates/form/experiment.html
+++ b/cytocv/templates/form/experiment.html
@@ -1293,6 +1293,67 @@
             pointer-events: auto;
             overflow: visible;
         }
+        .signal-mode-stack {
+            display: grid;
+            grid-template-columns: 1fr;
+            flex: 1 1 100%;
+            width: 100%;
+            margin-top: 10px;
+            margin-left: 10px;
+            padding-left: 10px;
+            border-left: 2px solid rgba(255, 255, 255, 0.14);
+        }
+        .signal-mode-stack:not(:has(.signal-mode-panel.visible)) {
+            display: none;
+        }
+        .signal-mode-panel {
+            grid-column: 1;
+            grid-row: 1;
+            min-height: 92px;
+            visibility: hidden;
+            opacity: 0;
+            pointer-events: none;
+        }
+        .signal-mode-panel.visible {
+            visibility: visible;
+            opacity: 1;
+            pointer-events: auto;
+            animation: measurementTextSlideFadeIn 0.24s cubic-bezier(0.22, 0.61, 0.36, 1);
+        }
+        .signal-mode-panel .stats-distance-inline,
+        .signal-mode-panel .nuclear-mode-inline {
+            opacity: 1;
+            max-height: none;
+            transform: none;
+            margin-top: 4px;
+            pointer-events: auto;
+            overflow: visible;
+            transition: none;
+        }
+        .stats-inline-toggle {
+            flex: 1 1 100%;
+            width: 100%;
+            margin-top: 4px;
+            padding: 8px 10px;
+        }
+        .signal-mode-panel .stats-inline-toggle {
+            padding: 0;
+            border: none;
+            border-radius: 0;
+            background: transparent;
+            filter: none;
+            margin-top: 6px;
+        }
+        .signal-mode-panel .stats-inline-toggle.is-off:not(.locked) {
+            background: transparent;
+            border: none;
+            filter: none;
+        }
+        .signal-mode-panel .stats-inline-toggle .toggle-label {
+            font-size: 11px;
+            color: #cfcfcf;
+            line-height: 1.2;
+        }
         .nuclear-mode-inline.mode-menu-open {
             position: relative;
             z-index: 10;
@@ -1546,6 +1607,11 @@
             flex-direction: column;
             gap: 2px;
         }
+        .toggle-help-text {
+            font-size: 11px;
+            line-height: 1.25;
+            color: #b8b8b8;
+        }
         .toggle-label-row {
             display: inline-flex;
             align-items: center;
@@ -1732,24 +1798,6 @@
                     <div class="stats-divider"></div>
                     <div class="stats-view-title">Dot Detection</div>
                     <div class="stats-list dot-detection-list">
-                        <div class="toggle-row" id="alternateRedRow">
-                            <div class="toggle-text">
-                                <span class="toggle-label-row">
-                                    <span class="toggle-label">Enable Alternate Red Detection</span>
-                                    <button
-                                        type="button"
-                                        class="info-dot compact advanced-info-dot"
-                                        id="alternateRedInfoDot"
-                                        data-info-text="Uses alternate Red detection when the tool attempts to find a single contour around all speckles."
-                                        aria-label="Use Alternate Red Detection"
-                                    >i</button>
-                                </span>
-                            </div>
-                            <label class="switch">
-                                <input type="checkbox" id="alternateRedDetection">
-                                <span class="slider"></span>
-                            </label>
-                        </div>
                         <div class="toggle-row combo" id="greenDotSplitRow">
                             <div class="toggle-text">
                                 <span class="toggle-label-row">
@@ -2073,6 +2121,7 @@
     const channelInfo = statsPayload.channel_info || {};
     const channelLabels = statsPayload.channel_labels || {};
     const pluginMap = new Map(statsPlugins.map((plugin) => [plugin.id, plugin]));
+    const signalPrimaryPluginIds = new Set(['PunctaDistance', 'GreenRedIntensity', 'NuclearCellPairIntensity']);
 
     const selectionKey = 'cytocv.selected_analyses.v3';
     const initializedKey = 'cytocv.selected_analyses_initialized.v3';
@@ -2087,6 +2136,7 @@
     const greenDotSplitModeKey = 'cytocv.green_dot_split_mode.v1';
     const legacyBiorientationGreenSplitKey = 'cytocv.biorientation_green_split_enabled.v1';
     const advancedKey = 'cytocv.advanced_validation.v3';
+    const signalQuantificationKey = 'cytocv.signal_quantification.v1';
     const punctaModeKey = 'cytocv.puncta_line_mode.v1';
     const nuclearModeKey = 'cytocv.nuclear_cell_pair_mode.v3';
     const legacyLengthUnitKey = 'cytocv.stats_length_unit.v2';
@@ -2150,13 +2200,16 @@
         cenDotProximityRadius: 13,
         biorientationRedMinDistance: 0,
         biorientationRedMaxDistance: 37,
-        biorientationCollinearityThreshold: 66,
+        biorientationCollinearityThreshold: 3,
+        signalQuantificationEnabled: true,
+        signalQuantificationMode: 'puncta_distance',
+        punctaContourIntensityEnabled: true,
+        alternateNucleusDetectionEnabled: false,
         greenDotSplitEnabled: true,
         greenDotSplitMode: 'balanced',
         punctaLineMode: 'red_puncta',
         nuclearCellPairMode: 'green_nucleus',
         greenContourFilterEnabled: false,
-        alternateRedDetection: false,
         punctaLineWidthUnit: 'px',
         cenDotDistanceUnit: 'px',
         cenDotProximityRadiusUnit: 'px',
@@ -2188,9 +2241,19 @@
     let measurementScaleFallbackHint = null;
     let punctaLineModeRow = null;
     let punctaLineModeSelect = null;
+    let signalQuantificationToggle = null;
+    let signalQuantificationModeRow = null;
+    let signalQuantificationModeSelect = null;
+    let signalPunctaPanel = null;
+    let signalNuclearPanel = null;
+    let punctaContourIntensityToggle = null;
+    let punctaContourIntensityRow = null;
+    let alternateNucleusDetectionToggle = null;
+    let alternateNucleusDetectionRow = null;
     let nuclearModeSelect = null;
     let nuclearModeRow = null;
     let greenDotSplitModeSelect = null;
+    let selectionsInitializedBeforeLoad = false;
     let infoTooltipElement = null;
     let activeInfoAnchor = null;
 
@@ -2235,10 +2298,11 @@
         Biorientation: [
             'Minimum Red Puncta Distance: smallest allowed spacing between the two Red puncta for biorientation counts to run.',
             'Maximum Red Puncta Distance: largest allowed spacing between the two Red puncta for biorientation counts to run.',
-            'Collinearity Threshold: maximum allowed perpendicular offset from the Red-puncta line for a Green dot to count as colinear.',
+            'Collinearity Threshold: maximum allowed perpendicular offset (pixels) from the Red-puncta line for a Green dot to count as colinear.',
         ],
         NuclearCellPairIntensity: [
             'Nucleus Contour Source: chooses which channel supplies the nucleus contour. Green Nucleus measures Red signal; Red Nucleus measures Green signal.',
+            'Alternate Nucleus Detection: only affects Nuclear, Cell-Pair Intensity and uses the alternate contour detection path on the selected nucleus source channel.',
         ],
     };
 
@@ -2250,6 +2314,34 @@
             ...adjustmentLines,
             `Required channels: ${joinLabels(requiredLabels)}`,
         ]);
+    }
+
+    function normalizeSignalMode(value) {
+        return value === 'nuclear_cell_pair' ? 'nuclear_cell_pair' : 'puncta_distance';
+    }
+
+    function persistSignalQuantificationSettings() {
+        localStorage.setItem(signalQuantificationKey, JSON.stringify({
+            enabled: !!statsState.signalQuantificationEnabled,
+            mode: normalizeSignalMode(statsState.signalQuantificationMode),
+            punctaContourIntensityEnabled: !!statsState.punctaContourIntensityEnabled,
+            alternateNucleusDetectionEnabled: !!statsState.alternateNucleusDetectionEnabled,
+        }));
+    }
+
+    function syncSignalSelectedPlugins() {
+        signalPrimaryPluginIds.forEach((pluginId) => statsState.selectedPlugins.delete(pluginId));
+        if (!statsState.signalQuantificationEnabled) {
+            return;
+        }
+        if (normalizeSignalMode(statsState.signalQuantificationMode) === 'nuclear_cell_pair') {
+            statsState.selectedPlugins.add('NuclearCellPairIntensity');
+            return;
+        }
+        statsState.selectedPlugins.add('PunctaDistance');
+        if (statsState.punctaContourIntensityEnabled) {
+            statsState.selectedPlugins.add('GreenRedIntensity');
+        }
     }
 
     const advancedInfoTextById = {
@@ -2355,9 +2447,19 @@
             greenContourFilterEnabled: !!serverPreferenceDefaults.green_contour_filter_enabled,
             greenDotSplitEnabled: rawGreenDotSplitDefault !== false,
             greenDotSplitMode: normalizeGreenDotSplitMode(serverPreferenceDefaults.green_dot_split_mode),
-            alternateRedDetection: !!serverPreferenceDefaults.alternate_red_detection,
         };
         localStorage.setItem(advancedKey, JSON.stringify(advancedPayload));
+        localStorage.setItem(signalQuantificationKey, JSON.stringify({
+            enabled: serverPreferenceDefaults.signal_quantification_enabled !== false,
+            mode: serverPreferenceDefaults.signal_quantification_mode === 'nuclear_cell_pair'
+                ? 'nuclear_cell_pair'
+                : 'puncta_distance',
+            punctaContourIntensityEnabled: serverPreferenceDefaults.puncta_contour_intensity_enabled !== false,
+            alternateNucleusDetectionEnabled: !!(
+                serverPreferenceDefaults.alternate_nucleus_detection_enabled ||
+                serverPreferenceDefaults.alternate_red_detection
+            ),
+        }));
 
         const widthUnit = (serverPreferenceDefaults.puncta_line_width_unit === 'um') ? 'um' : 'px';
         const distanceUnit = (serverPreferenceDefaults.cen_dot_distance_unit === 'um') ? 'um' : 'px';
@@ -2383,7 +2485,7 @@
         localStorage.setItem(proximityRadiusKey, Number.isFinite(proximityRadius) ? String(proximityRadius) : '13');
         localStorage.setItem(biorientationRedMinDistanceKey, Number.isFinite(biorientationMinDistance) ? String(biorientationMinDistance) : '0');
         localStorage.setItem(biorientationRedMaxDistanceKey, Number.isFinite(biorientationMaxDistance) ? String(biorientationMaxDistance) : '37');
-        localStorage.setItem(biorientationThresholdKey, Number.isFinite(threshold) ? String(Math.max(0, Math.round(threshold))) : '66');
+        localStorage.setItem(biorientationThresholdKey, Number.isFinite(threshold) ? String(Math.max(0, Math.round(threshold))) : '3');
         localStorage.setItem(greenDotSplitKey, String(rawGreenDotSplitDefault !== false));
         localStorage.setItem(
             micronsPerPixelKey,
@@ -3378,6 +3480,7 @@
         renderRequiredChannels();
         loadStoredSelections();
         loadStoredAdvancedSettings();
+        loadStoredSignalQuantificationSettings();
         loadStoredLengthUnits();
         loadStoredMicronsPerPixel();
         loadStoredUseMetadataScale();
@@ -3427,6 +3530,217 @@
         });
     }
 
+    function renderSignalQuantificationModule(list) {
+        const row = document.createElement('div');
+        row.className = 'stats-toggle-row signal-quantification-row';
+
+        const left = document.createElement('div');
+        left.className = 'stats-toggle-left';
+        const titleWrap = document.createElement('span');
+        titleWrap.className = 'stats-toggle-title-wrap';
+        const title = document.createElement('span');
+        title.className = 'stats-toggle-title';
+        title.textContent = 'Signal Quantification';
+        titleWrap.appendChild(title);
+        left.appendChild(titleWrap);
+        left.appendChild(buildInfoDot(buildInfoSections([
+            'Choose one primary signal workflow for this experiment.',
+            'Puncta Distance can also calculate Red/Green contour intensities. Nuclear, Cell-Pair Intensity measures the opposite channel inside the selected nucleus contour and full cell-pair mask.',
+            'Required channels: Red and Green.',
+        ])));
+        row.appendChild(left);
+
+        const right = document.createElement('div');
+        right.className = 'stats-toggle-right';
+        const switchLabel = document.createElement('label');
+        switchLabel.className = 'switch';
+        signalQuantificationToggle = document.createElement('input');
+        signalQuantificationToggle.type = 'checkbox';
+        signalQuantificationToggle.checked = !!statsState.signalQuantificationEnabled;
+        signalQuantificationToggle.addEventListener('change', () => {
+            statsState.signalQuantificationEnabled = signalQuantificationToggle.checked;
+            syncSignalSelectedPlugins();
+            persistSignalQuantificationSettings();
+            persistSelectedPlugins();
+            syncStatsUI();
+        });
+        const slider = document.createElement('span');
+        slider.className = 'slider';
+        switchLabel.appendChild(signalQuantificationToggle);
+        switchLabel.appendChild(slider);
+        right.appendChild(switchLabel);
+        row.appendChild(right);
+
+        signalQuantificationModeRow = document.createElement('div');
+        signalQuantificationModeRow.className = 'nuclear-mode-inline';
+        const modeTop = document.createElement('div');
+        modeTop.className = 'nuclear-mode-row';
+        const modeLabel = document.createElement('label');
+        modeLabel.textContent = 'Primary Mode:';
+        modeTop.appendChild(modeLabel);
+        signalQuantificationModeSelect = buildCustomModeSelect(
+            [
+                { value: 'puncta_distance', text: 'Puncta Distance' },
+                { value: 'nuclear_cell_pair', text: 'Nuclear, Cell-Pair Intensity' },
+            ],
+            normalizeSignalMode(statsState.signalQuantificationMode),
+            (nextMode) => {
+                statsState.signalQuantificationMode = normalizeSignalMode(nextMode);
+                syncSignalSelectedPlugins();
+                persistSignalQuantificationSettings();
+                persistSelectedPlugins();
+                syncStatsUI();
+            },
+        );
+        modeTop.appendChild(signalQuantificationModeSelect.root);
+        signalQuantificationModeRow.appendChild(modeTop);
+        row.appendChild(signalQuantificationModeRow);
+
+        const signalPanelStack = document.createElement('div');
+        signalPanelStack.className = 'signal-mode-stack';
+
+        signalPunctaPanel = document.createElement('div');
+        signalPunctaPanel.className = 'signal-mode-panel';
+
+        const punctaModeRow = document.createElement('div');
+        punctaModeRow.className = 'nuclear-mode-inline';
+        const punctaModeTop = document.createElement('div');
+        punctaModeTop.className = 'nuclear-mode-row';
+        const punctaModeLabel = document.createElement('label');
+        punctaModeLabel.textContent = 'Puncta Source:';
+        punctaModeTop.appendChild(punctaModeLabel);
+        punctaLineModeSelect = buildCustomModeSelect(
+            [
+                { value: 'red_puncta', text: 'Red Puncta (Measure Green)' },
+                { value: 'green_puncta', text: 'Green Puncta (Measure Red)' },
+            ],
+            statsState.punctaLineMode === 'green_puncta' ? 'green_puncta' : 'red_puncta',
+            (nextMode) => {
+                statsState.punctaLineMode = nextMode;
+                localStorage.setItem(punctaModeKey, nextMode);
+            },
+        );
+        punctaModeTop.appendChild(punctaLineModeSelect.root);
+        punctaModeRow.appendChild(punctaModeTop);
+        signalPunctaPanel.appendChild(punctaModeRow);
+        punctaLineModeRow = punctaModeRow;
+
+        const widthRow = document.createElement('div');
+        widthRow.className = 'stats-distance-inline';
+        const widthLine = document.createElement('div');
+        widthLine.className = 'stats-distance-line';
+        const widthLabel = document.createElement('label');
+        widthLabel.textContent = 'Puncta Line Width:';
+        widthLine.appendChild(widthLabel);
+        const widthGroup = buildLengthInputGroup({
+            field: 'punctaLineWidth',
+            inputId: 'punctaLineWidthInput',
+            minValue: 1,
+            defaultValue: 1,
+            onChange: () => {
+                const fallback = defaultWidthForUnit(statsState.punctaLineWidthUnit);
+                const minimum = statsState.punctaLineWidthUnit === 'um' ? 0.01 : 1;
+                statsState.punctaLineWidth = parseLengthValue(widthGroup.input.value, statsState.punctaLineWidthUnit, fallback, minimum);
+                widthGroup.input.value = formatNumericInputValue(statsState.punctaLineWidth);
+                localStorage.setItem(widthKey, String(statsState.punctaLineWidth));
+                updateMeasurementScaleHints();
+            },
+        });
+        widthLine.appendChild(widthGroup.controls);
+        widthRow.appendChild(widthLine);
+        signalPunctaPanel.appendChild(widthRow);
+        punctaLineWidthRow = widthRow;
+        punctaLineWidthInput = widthGroup.input;
+
+        punctaContourIntensityRow = document.createElement('div');
+        punctaContourIntensityRow.className = 'toggle-row stats-inline-toggle';
+        const contourText = document.createElement('div');
+        contourText.className = 'toggle-text';
+        const contourLabel = document.createElement('span');
+        contourLabel.className = 'toggle-label';
+        contourLabel.textContent = 'Red/Green Contour Intensities';
+        contourText.appendChild(contourLabel);
+        punctaContourIntensityRow.appendChild(contourText);
+        const contourSwitch = document.createElement('label');
+        contourSwitch.className = 'switch';
+        punctaContourIntensityToggle = document.createElement('input');
+        punctaContourIntensityToggle.type = 'checkbox';
+        punctaContourIntensityToggle.checked = !!statsState.punctaContourIntensityEnabled;
+        punctaContourIntensityToggle.addEventListener('change', () => {
+            statsState.punctaContourIntensityEnabled = punctaContourIntensityToggle.checked;
+            syncSignalSelectedPlugins();
+            persistSignalQuantificationSettings();
+            persistSelectedPlugins();
+            syncStatsUI();
+        });
+        const contourSlider = document.createElement('span');
+        contourSlider.className = 'slider';
+        contourSwitch.appendChild(punctaContourIntensityToggle);
+        contourSwitch.appendChild(contourSlider);
+        punctaContourIntensityRow.appendChild(contourSwitch);
+        signalPunctaPanel.appendChild(punctaContourIntensityRow);
+        signalPanelStack.appendChild(signalPunctaPanel);
+
+        signalNuclearPanel = document.createElement('div');
+        signalNuclearPanel.className = 'signal-mode-panel';
+        const nuclearRow = document.createElement('div');
+        nuclearRow.className = 'nuclear-mode-inline';
+        const nuclearTop = document.createElement('div');
+        nuclearTop.className = 'nuclear-mode-row';
+        const nuclearLabel = document.createElement('label');
+        nuclearLabel.textContent = 'Nucleus Contour Source:';
+        nuclearTop.appendChild(nuclearLabel);
+        nuclearModeSelect = buildCustomModeSelect(
+            [
+                { value: 'green_nucleus', text: 'Green Nucleus (Measure Red)' },
+                { value: 'red_nucleus', text: 'Red Nucleus (Measure Green)' },
+            ],
+            statsState.nuclearCellPairMode === 'red_nucleus' ? 'red_nucleus' : 'green_nucleus',
+            (nextMode) => {
+                statsState.nuclearCellPairMode = nextMode;
+                localStorage.setItem(nuclearModeKey, nextMode);
+            },
+        );
+        nuclearTop.appendChild(nuclearModeSelect.root);
+        nuclearRow.appendChild(nuclearTop);
+        signalNuclearPanel.appendChild(nuclearRow);
+        nuclearModeRow = nuclearRow;
+
+        alternateNucleusDetectionRow = document.createElement('div');
+        alternateNucleusDetectionRow.className = 'toggle-row stats-inline-toggle';
+        const alternateText = document.createElement('div');
+        alternateText.className = 'toggle-text';
+        const alternateLabel = document.createElement('span');
+        alternateLabel.className = 'toggle-label';
+        alternateLabel.textContent = 'Alternate Nucleus Detection';
+        alternateText.appendChild(alternateLabel);
+        const alternateHelp = document.createElement('span');
+        alternateHelp.className = 'toggle-help-text';
+        alternateHelp.textContent = 'Only affects Nuclear, Cell-Pair Intensity and uses the alternate contour detection path on the selected nucleus source channel only.';
+        alternateText.appendChild(alternateHelp);
+        alternateNucleusDetectionRow.appendChild(alternateText);
+        const alternateSwitch = document.createElement('label');
+        alternateSwitch.className = 'switch';
+        alternateNucleusDetectionToggle = document.createElement('input');
+        alternateNucleusDetectionToggle.type = 'checkbox';
+        alternateNucleusDetectionToggle.checked = !!statsState.alternateNucleusDetectionEnabled;
+        alternateNucleusDetectionToggle.addEventListener('change', () => {
+            statsState.alternateNucleusDetectionEnabled = alternateNucleusDetectionToggle.checked;
+            persistSignalQuantificationSettings();
+            syncStatsUI();
+        });
+        const alternateSlider = document.createElement('span');
+        alternateSlider.className = 'slider';
+        alternateSwitch.appendChild(alternateNucleusDetectionToggle);
+        alternateSwitch.appendChild(alternateSlider);
+        alternateNucleusDetectionRow.appendChild(alternateSwitch);
+        signalNuclearPanel.appendChild(alternateNucleusDetectionRow);
+        signalPanelStack.appendChild(signalNuclearPanel);
+        row.appendChild(signalPanelStack);
+
+        list.appendChild(row);
+    }
+
     function renderStatsToggles() {
         const list = document.getElementById('statsList');
         if (!list) return;
@@ -3445,11 +3759,22 @@
         micronsPerPixelInput = null;
         punctaLineModeRow = null;
         punctaLineModeSelect = null;
+        signalQuantificationToggle = null;
+        signalQuantificationModeRow = null;
+        signalQuantificationModeSelect = null;
+        signalPunctaPanel = null;
+        signalNuclearPanel = null;
+        punctaContourIntensityToggle = null;
+        punctaContourIntensityRow = null;
+        alternateNucleusDetectionToggle = null;
+        alternateNucleusDetectionRow = null;
         nuclearModeSelect = null;
         nuclearModeRow = null;
+        syncSignalSelectedPlugins();
+        renderSignalQuantificationModule(list);
 
         const visiblePlugins = statsPlugins.filter(
-            (plugin) => statsState.showLegacyPlugins || !plugin.is_legacy
+            (plugin) => !signalPrimaryPluginIds.has(plugin.id) && (statsState.showLegacyPlugins || !plugin.is_legacy)
         );
 
         visiblePlugins.forEach((plugin) => {
@@ -3697,10 +4022,10 @@
                 thresholdInput.type = 'number';
                 thresholdInput.id = 'biorientationCollinearityThresholdInput';
                 thresholdInput.min = '0';
-                thresholdInput.value = '66';
+                thresholdInput.value = '3';
                 thresholdInput.addEventListener('change', () => {
                     const parsed = parseInt(thresholdInput.value, 10);
-                    statsState.biorientationCollinearityThreshold = Number.isFinite(parsed) && parsed >= 0 ? parsed : 66;
+                    statsState.biorientationCollinearityThreshold = Number.isFinite(parsed) && parsed >= 0 ? parsed : 3;
                     thresholdInput.value = String(statsState.biorientationCollinearityThreshold);
                     localStorage.setItem(biorientationThresholdKey, String(statsState.biorientationCollinearityThreshold));
                 });
@@ -4032,7 +4357,6 @@
         const greenContourFilterEnabled = document.getElementById('greenContourFilterEnabled');
         const greenDotSplitEnabled = document.getElementById('greenDotSplitEnabled');
         const greenDotSplitModeMount = document.getElementById('greenDotSplitModeMount');
-        const alternateRedDetection = document.getElementById('alternateRedDetection');
         const moduleToggle = document.getElementById('cytocvAnalysisEnabled');
         const layerToggle = document.getElementById('enforceLayerCount');
         const wavelengthToggle = document.getElementById('enforceWavelengths');
@@ -4065,13 +4389,6 @@
                 },
             );
             greenDotSplitModeMount.appendChild(greenDotSplitModeSelect.root);
-        }
-        if (alternateRedDetection) {
-            alternateRedDetection.addEventListener('change', () => {
-                statsState.alternateRedDetection = alternateRedDetection.checked;
-                persistAdvancedSettings();
-                syncStatsUI();
-            });
         }
         if (moduleToggle) {
             moduleToggle.addEventListener('change', () => {
@@ -4114,6 +4431,7 @@
 
     function loadStoredSelections() {
         const initialized = localStorage.getItem(initializedKey) === '1';
+        selectionsInitializedBeforeLoad = initialized;
         let stored = [];
         try {
             stored = JSON.parse(localStorage.getItem(selectionKey) || '[]');
@@ -4125,7 +4443,7 @@
         }
 
         if (!initialized) {
-            // First-run default: no statistics selected.
+            // First-run plugin defaults are applied by the Signal Quantification state.
             persistSelectedPlugins();
         } else {
             stored.forEach((pluginId) => {
@@ -4160,7 +4478,6 @@
         statsState.greenDotSplitMode = normalizeGreenDotSplitMode(
             stored.greenDotSplitMode || localStorage.getItem(greenDotSplitModeKey)
         );
-        statsState.alternateRedDetection = typeof stored.alternateRedDetection === 'boolean' ? stored.alternateRedDetection : false;
         statsState.moduleEnabled = typeof stored.moduleEnabled === 'boolean' ? stored.moduleEnabled : false;
         statsState.enforceLayerCount = typeof stored.enforceLayerCount === 'boolean' ? stored.enforceLayerCount : false;
         statsState.enforceAllWavelengths = typeof stored.enforceAllWavelengths === 'boolean' ? stored.enforceAllWavelengths : false;
@@ -4170,6 +4487,42 @@
                 ? stored.manualRequiredChannels.filter((channel) => channelOrder.includes(channel))
                 : []
         );
+    }
+
+    function loadStoredSignalQuantificationSettings() {
+        let stored = {};
+        try {
+            stored = JSON.parse(localStorage.getItem(signalQuantificationKey) || '{}');
+        } catch (err) {
+            stored = {};
+        }
+        const hasPrimary = [...statsState.selectedPlugins].some((pluginId) => signalPrimaryPluginIds.has(pluginId));
+        statsState.signalQuantificationEnabled = typeof stored.enabled === 'boolean'
+            ? stored.enabled
+            : (selectionsInitializedBeforeLoad ? hasPrimary : true);
+        if (typeof stored.mode === 'string') {
+            statsState.signalQuantificationMode = normalizeSignalMode(stored.mode);
+        } else if (statsState.selectedPlugins.has('NuclearCellPairIntensity') && !statsState.selectedPlugins.has('PunctaDistance')) {
+            statsState.signalQuantificationMode = 'nuclear_cell_pair';
+        } else {
+            statsState.signalQuantificationMode = 'puncta_distance';
+        }
+        statsState.punctaContourIntensityEnabled = typeof stored.punctaContourIntensityEnabled === 'boolean'
+            ? stored.punctaContourIntensityEnabled
+            : statsState.selectedPlugins.has('GreenRedIntensity');
+        const legacyAlternateRedDetection = typeof stored.alternateRedDetection === 'boolean'
+            ? stored.alternateRedDetection
+            : null;
+        statsState.alternateNucleusDetectionEnabled = typeof stored.alternateNucleusDetectionEnabled === 'boolean'
+            ? stored.alternateNucleusDetectionEnabled
+            : !!legacyAlternateRedDetection;
+        if (!selectionsInitializedBeforeLoad) {
+            statsState.selectedPlugins.add('CENDot');
+            statsState.selectedPlugins.add('Biorientation');
+        }
+        syncSignalSelectedPlugins();
+        persistSignalQuantificationSettings();
+        persistSelectedPlugins();
     }
 
     function loadStoredLengthUnits() {
@@ -4235,8 +4588,8 @@
             0
         );
         const raw = localStorage.getItem(biorientationThresholdKey) || localStorage.getItem(oldThresholdKey);
-        const parsed = parseInt(raw || '66', 10);
-        statsState.biorientationCollinearityThreshold = Number.isFinite(parsed) && parsed >= 0 ? parsed : 66;
+        const parsed = parseInt(raw || '3', 10);
+        statsState.biorientationCollinearityThreshold = Number.isFinite(parsed) && parsed >= 0 ? parsed : 3;
     }
 
     function loadStoredPunctaMode() {
@@ -4264,7 +4617,6 @@
             greenContourFilterEnabled: !!statsState.greenContourFilterEnabled,
             greenDotSplitEnabled: !!statsState.greenDotSplitEnabled,
             greenDotSplitMode: normalizeGreenDotSplitMode(statsState.greenDotSplitMode),
-            alternateRedDetection: !!statsState.alternateRedDetection,
         }));
         localStorage.setItem(greenDotSplitKey, String(statsState.greenDotSplitEnabled));
         localStorage.setItem(greenDotSplitModeKey, normalizeGreenDotSplitMode(statsState.greenDotSplitMode));
@@ -4356,6 +4708,7 @@
     }
 
     function syncStatsUI() {
+        syncSignalSelectedPlugins();
         const statsRequired = getStatsRequiredChannels();
         const moduleToggle = document.getElementById('cytocvAnalysisEnabled');
         const layerToggle = document.getElementById('enforceLayerCount');
@@ -4368,10 +4721,8 @@
         const greenContourFilterEnabled = document.getElementById('greenContourFilterEnabled');
         const greenDotSplitEnabled = document.getElementById('greenDotSplitEnabled');
         const greenDotSplitModeRow = document.getElementById('greenDotSplitModeRow');
-        const alternateRedDetection = document.getElementById('alternateRedDetection');
         const greenFilterRow = document.getElementById('greenFilterRow');
         const greenDotSplitRow = document.getElementById('greenDotSplitRow');
-        const alternateRedRow = document.getElementById('alternateRedRow');
         const moduleRow = document.getElementById('moduleToggleRow');
 
         statToggleElements.forEach((toggle, pluginId) => {
@@ -4379,6 +4730,31 @@
             toggle.disabled = isPluginRequiredBySelection(pluginId);
             setOffVisualState(toggle.closest('.stats-toggle-row'), !toggle.checked);
         });
+
+        const signalEnabled = !!statsState.signalQuantificationEnabled;
+        const signalMode = normalizeSignalMode(statsState.signalQuantificationMode);
+        if (signalQuantificationToggle) {
+            signalQuantificationToggle.checked = signalEnabled;
+            setOffVisualState(signalQuantificationToggle.closest('.stats-toggle-row'), !signalEnabled);
+        }
+        if (signalQuantificationModeSelect) {
+            signalQuantificationModeSelect.value = signalMode;
+        }
+        if (signalQuantificationModeRow) {
+            signalQuantificationModeRow.classList.toggle('visible', signalEnabled);
+        }
+        if (signalPunctaPanel) {
+            signalPunctaPanel.classList.toggle('visible', signalEnabled && signalMode === 'puncta_distance');
+        }
+        if (signalNuclearPanel) {
+            signalNuclearPanel.classList.toggle('visible', signalEnabled && signalMode === 'nuclear_cell_pair');
+        }
+        if (punctaContourIntensityToggle) {
+            punctaContourIntensityToggle.checked = !!statsState.punctaContourIntensityEnabled;
+        }
+        if (alternateNucleusDetectionToggle) {
+            alternateNucleusDetectionToggle.checked = !!statsState.alternateNucleusDetectionEnabled;
+        }
 
         syncLengthControls();
 
@@ -4458,20 +4834,6 @@
         if (greenDotSplitModeRow) {
             greenDotSplitModeRow.classList.toggle('visible', !!greenDotSplitEnabled && !greenDotSplitEnabled.disabled && greenDotSplitEnabled.checked);
         }
-        if (alternateRedDetection) {
-            alternateRedDetection.checked = !!statsState.alternateRedDetection;
-            const redUsed = isChannelUsed('channel_red');
-            alternateRedDetection.disabled = !redUsed;
-            if (redUsed) {
-                alternateRedRow.classList.remove('disabled');
-            } else {
-                alternateRedRow.classList.add('disabled');
-                alternateRedDetection.checked = false;
-                statsState.alternateRedDetection = alternateRedDetection.checked;
-            }
-            setOffVisualState(alternateRedRow, !alternateRedDetection.checked);
-        }
-
         if (moduleToggle) moduleToggle.checked = !!statsState.moduleEnabled;
         if (layerToggle) layerToggle.checked = !!statsState.enforceLayerCount;
         if (wavelengthToggle) wavelengthToggle.checked = !!statsState.enforceAllWavelengths;
@@ -4656,7 +5018,7 @@
         }
         if (biorientationCollinearityThresholdInput) {
             const parsed = parseInt(biorientationCollinearityThresholdInput.value, 10);
-            statsState.biorientationCollinearityThreshold = Number.isFinite(parsed) && parsed >= 0 ? parsed : 66;
+            statsState.biorientationCollinearityThreshold = Number.isFinite(parsed) && parsed >= 0 ? parsed : 3;
             biorientationCollinearityThresholdInput.value = String(statsState.biorientationCollinearityThreshold);
             localStorage.setItem(
                 biorientationThresholdKey,
@@ -4669,6 +5031,20 @@
                 : 'red_puncta';
             localStorage.setItem(punctaModeKey, statsState.punctaLineMode);
         }
+        if (signalQuantificationToggle) {
+            statsState.signalQuantificationEnabled = !!signalQuantificationToggle.checked;
+        }
+        if (signalQuantificationModeSelect) {
+            statsState.signalQuantificationMode = normalizeSignalMode(signalQuantificationModeSelect.value);
+        }
+        if (punctaContourIntensityToggle) {
+            statsState.punctaContourIntensityEnabled = !!punctaContourIntensityToggle.checked;
+        }
+        if (alternateNucleusDetectionToggle) {
+            statsState.alternateNucleusDetectionEnabled = !!alternateNucleusDetectionToggle.checked;
+        }
+        syncSignalSelectedPlugins();
+        persistSignalQuantificationSettings();
         if (nuclearModeSelect) {
             statsState.nuclearCellPairMode = nuclearModeSelect.value === 'red_nucleus'
                 ? 'red_nucleus'
@@ -4734,6 +5110,10 @@
 
         const captureStatsSnapshot = () => ({
             selectedPlugins: [...statsState.selectedPlugins].sort(),
+            signalQuantificationEnabled: !!statsState.signalQuantificationEnabled,
+            signalQuantificationMode: normalizeSignalMode(statsState.signalQuantificationMode),
+            punctaContourIntensityEnabled: !!statsState.punctaContourIntensityEnabled,
+            alternateNucleusDetectionEnabled: !!statsState.alternateNucleusDetectionEnabled,
             moduleEnabled: !!statsState.moduleEnabled,
             enforceLayerCount: !!statsState.enforceLayerCount,
             enforceAllWavelengths: !!statsState.enforceAllWavelengths,
@@ -4744,13 +5124,12 @@
             cenDotProximityRadius: Number.isFinite(Number(statsState.cenDotProximityRadius)) ? Number(statsState.cenDotProximityRadius) : 13,
             biorientationRedMinDistance: Number.isFinite(Number(statsState.biorientationRedMinDistance)) ? Number(statsState.biorientationRedMinDistance) : 0,
             biorientationRedMaxDistance: Number.isFinite(Number(statsState.biorientationRedMaxDistance)) ? Number(statsState.biorientationRedMaxDistance) : 37,
-            biorientationCollinearityThreshold: Number.isFinite(Number(statsState.biorientationCollinearityThreshold)) ? Number(statsState.biorientationCollinearityThreshold) : 66,
+            biorientationCollinearityThreshold: Number.isFinite(Number(statsState.biorientationCollinearityThreshold)) ? Number(statsState.biorientationCollinearityThreshold) : 3,
             punctaLineMode: statsState.punctaLineMode === 'green_puncta' ? 'green_puncta' : 'red_puncta',
             nuclearCellPairMode: statsState.nuclearCellPairMode === 'red_nucleus' ? 'red_nucleus' : 'green_nucleus',
             greenContourFilterEnabled: !!statsState.greenContourFilterEnabled,
             greenDotSplitEnabled: !!statsState.greenDotSplitEnabled,
             greenDotSplitMode: normalizeGreenDotSplitMode(statsState.greenDotSplitMode),
-            alternateRedDetection: !!statsState.alternateRedDetection,
             punctaLineWidthUnit: normalizeLengthUnit(statsState.punctaLineWidthUnit),
             cenDotDistanceUnit: normalizeLengthUnit(statsState.cenDotDistanceUnit),
             cenDotProximityRadiusUnit: normalizeLengthUnit(statsState.cenDotProximityRadiusUnit),
@@ -4808,14 +5187,20 @@
                 defaultBiorientationMaxDistanceForUnit(statsState.biorientationRedMaxDistanceUnit),
                 0
             );
-            const parsedThreshold = parseInt(String(snapshot.biorientationCollinearityThreshold ?? 66), 10);
-            statsState.biorientationCollinearityThreshold = Number.isFinite(parsedThreshold) && parsedThreshold >= 0 ? parsedThreshold : 66;
+            const parsedThreshold = parseInt(String(snapshot.biorientationCollinearityThreshold ?? 3), 10);
+            statsState.biorientationCollinearityThreshold = Number.isFinite(parsedThreshold) && parsedThreshold >= 0 ? parsedThreshold : 3;
             statsState.punctaLineMode = snapshot.punctaLineMode === 'green_puncta' ? 'green_puncta' : 'red_puncta';
             statsState.nuclearCellPairMode = snapshot.nuclearCellPairMode === 'red_nucleus' ? 'red_nucleus' : 'green_nucleus';
-            statsState.greenContourFilterEnabled = !!snapshot.greenContourFilterEnabled;
-            statsState.greenDotSplitEnabled = snapshot.greenDotSplitEnabled !== false;
-            statsState.greenDotSplitMode = normalizeGreenDotSplitMode(snapshot.greenDotSplitMode);
-            statsState.alternateRedDetection = !!snapshot.alternateRedDetection;
+            statsState.signalQuantificationEnabled = snapshot.signalQuantificationEnabled !== false;
+            statsState.signalQuantificationMode = normalizeSignalMode(snapshot.signalQuantificationMode);
+            statsState.punctaContourIntensityEnabled = snapshot.punctaContourIntensityEnabled !== false;
+        statsState.alternateNucleusDetectionEnabled = !!(
+            snapshot.alternateNucleusDetectionEnabled || snapshot.alternateRedDetection
+        );
+        statsState.greenContourFilterEnabled = !!snapshot.greenContourFilterEnabled;
+        statsState.greenDotSplitEnabled = snapshot.greenDotSplitEnabled !== false;
+        statsState.greenDotSplitMode = normalizeGreenDotSplitMode(snapshot.greenDotSplitMode);
+        syncSignalSelectedPlugins();
             if (!statsState.showLegacyPlugins) {
                 statsPlugins.forEach((plugin) => {
                     if (plugin.is_legacy) {
@@ -4836,6 +5221,7 @@
             localStorage.setItem(greenDotSplitModeKey, normalizeGreenDotSplitMode(statsState.greenDotSplitMode));
             localStorage.setItem(punctaModeKey, statsState.punctaLineMode);
             localStorage.setItem(nuclearModeKey, statsState.nuclearCellPairMode);
+            persistSignalQuantificationSettings();
             persistLengthUnitSettings();
             syncStatsUI();
         };
@@ -4983,6 +5369,10 @@
             const snapshot = captureStatsSnapshot();
             return {
                 selected_plugins: snapshot.selectedPlugins,
+                signal_quantification_enabled: snapshot.signalQuantificationEnabled,
+                signal_quantification_mode: snapshot.signalQuantificationMode,
+                puncta_contour_intensity_enabled: snapshot.punctaContourIntensityEnabled,
+                alternate_nucleus_detection_enabled: snapshot.alternateNucleusDetectionEnabled,
                 module_enabled: snapshot.moduleEnabled,
                 enforce_layer_count: snapshot.enforceLayerCount,
                 enforce_wavelengths: snapshot.enforceAllWavelengths,
@@ -4991,7 +5381,7 @@
                 green_contour_filter_enabled: snapshot.greenContourFilterEnabled,
                 green_dot_split_enabled: snapshot.greenDotSplitEnabled,
                 green_dot_split_mode: snapshot.greenDotSplitMode,
-                alternate_red_detection: snapshot.alternateRedDetection,
+                alternate_red_detection: snapshot.alternateNucleusDetectionEnabled,
                 puncta_line_width: snapshot.punctaLineWidth,
                 puncta_line_width_unit: snapshot.punctaLineWidthUnit,
                 cen_dot_distance: snapshot.cenDotDistance,
@@ -5984,6 +6374,10 @@
             prepData.append('enforce_wavelengths', wavelengthEnabled ? '1' : '0');
             extraRequiredChannels.forEach((channel) => prepData.append('extra_required_channels', channel));
             [...statsState.selectedPlugins].forEach((pluginId) => prepData.append('selected_analysis', pluginId));
+            prepData.append('signalQuantificationEnabled', String(statsState.signalQuantificationEnabled));
+            prepData.append('signalQuantificationMode', normalizeSignalMode(statsState.signalQuantificationMode));
+            prepData.append('punctaContourIntensityEnabled', String(statsState.punctaContourIntensityEnabled));
+            prepData.append('alternateNucleusDetectionEnabled', String(statsState.alternateNucleusDetectionEnabled));
             prepData.append('stats_puncta_line_width_value', String(statsState.punctaLineWidth));
             prepData.append('stats_cen_dot_distance_value', String(statsState.cenDotDistance));
             prepData.append('stats_cen_dot_proximity_radius_value', String(statsState.cenDotProximityRadius));
@@ -6000,7 +6394,7 @@
             prepData.append('puncta_line_mode', statsState.punctaLineMode);
             prepData.append('nuclear_cell_pair_mode', statsState.nuclearCellPairMode);
             prepData.append('greenContourFilterEnabled', String(statsState.greenContourFilterEnabled));
-            prepData.append('alternateRedDetection', String(statsState.alternateRedDetection));
+            prepData.append('alternateRedDetection', String(statsState.alternateNucleusDetectionEnabled));
             const allUnitsMatch = statsState.punctaLineWidthUnit === statsState.cenDotDistanceUnit
                 && statsState.cenDotDistanceUnit === statsState.cenDotProximityRadiusUnit;
             const sharedLengthUnit = allUnitsMatch

--- a/cytocv/templates/workflow_defaults.html
+++ b/cytocv/templates/workflow_defaults.html
@@ -282,6 +282,20 @@ main.main > section.panel > form.panel > .card {
   opacity: var(--workflow-module-off-control-opacity);
 }
 
+.plugin.is-paused {
+  background: var(--workflow-module-off-bg);
+  border-color: var(--workflow-module-off-border);
+  filter: var(--workflow-module-off-filter);
+}
+
+.plugin.is-paused .plugin-main {
+  opacity: var(--workflow-module-off-text-opacity);
+}
+
+.plugin.is-paused > .sw {
+  opacity: var(--workflow-module-off-control-opacity);
+}
+
 .plugin-main {
   display: grid;
   gap: 4px;
@@ -352,6 +366,30 @@ main.main > section.panel > form.panel > .card {
   opacity: 1;
   pointer-events: auto;
   animation: signalModeChildFadeIn 0.24s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.signal-mode-paused-note {
+  margin: 2px 0 0;
+  min-height: 14px;
+  color: #e5c558;
+  font-size: 11px;
+  line-height: 1.25;
+  opacity: 0;
+  transform: translateY(-5px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.signal-mode-paused-note.is-active {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.signal-mode-paused-note.is-enabled {
+  color: #8fdc9c;
+}
+
+.signal-mode-paused-note.is-paused {
+  color: #e5c558;
 }
 
 @keyframes signalModeChildFadeIn {
@@ -1462,6 +1500,7 @@ main.main > section.panel > form.panel > .card {
                 <div class="plugin-measure-copy">
                   <label for="signal_quantification_mode">Primary Mode:</label>
                   <p class="module-help">Puncta Distance can also calculate Red/Green contour intensities. Nuclear, Cell-Pair Intensity measures the opposite channel inside the selected nucleus contour and full cell-pair mask.</p>
+                  <p class="signal-mode-paused-note" id="signalModePausedNote" aria-hidden="true"></p>
                 </div>
                 <div class="mode-select-group plugin-measure-right">
                   <select id="signal_quantification_mode" name="signal_quantification_mode"><option value="puncta_distance" {% if preferences.experiment_defaults.signal_quantification_mode != 'nuclear_cell_pair' %}selected{% endif %}>Puncta Distance</option><option value="nuclear_cell_pair" {% if preferences.experiment_defaults.signal_quantification_mode == 'nuclear_cell_pair' %}selected{% endif %}>Nuclear, Cell-Pair Intensity</option></select>

--- a/cytocv/templates/workflow_defaults.html
+++ b/cytocv/templates/workflow_defaults.html
@@ -329,6 +329,42 @@ main.main > section.panel > form.panel > .card {
   pointer-events: auto;
 }
 
+.signal-mode-stack {
+  display: grid;
+  grid-template-columns: 1fr;
+  margin-top: 10px;
+  margin-left: 10px;
+  padding-left: 10px;
+  border-left: 2px solid rgba(255, 255, 255, 0.18);
+}
+
+.signal-mode-panel {
+  grid-column: 1;
+  grid-row: 1;
+  min-height: 92px;
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.signal-mode-panel.is-active {
+  visibility: visible;
+  opacity: 1;
+  pointer-events: auto;
+  animation: signalModeChildFadeIn 0.24s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+@keyframes signalModeChildFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .plugin-measure-line {
   position: relative;
   display: grid;
@@ -1412,7 +1448,83 @@ main.main > section.panel > form.panel > .card {
           {% endfor %}
         </div></div>
         <div class="card" data-workflow-card="plugin-defaults"><p class="section-eyebrow card-title">Plugin Defaults</p><div class="plugins">
+          <div id="signalSelectedPlugins"></div>
+          <div class="plugin signal-quantification" id="signalQuantificationModule">
+            <div class="plugin-main">
+              <p><strong>Signal Quantification</strong></p>
+              <p class="desc">Choose one primary signal workflow for this experiment.</p>
+              <p class="reqtxt">Requires: Red, Green.</p>
+            </div>
+            <input type="hidden" name="signal_quantification_enabled" value="0">
+            <label class="sw"><input type="checkbox" id="signal_quantification_enabled" name="signal_quantification_enabled" value="1" {% if preferences.experiment_defaults.signal_quantification_enabled %}checked{% endif %}><span class="sl"></span></label>
+            <div class="plugin-inline{% if preferences.experiment_defaults.signal_quantification_enabled %} is-active{% endif %}" id="signalQuantificationInline" aria-hidden="{% if preferences.experiment_defaults.signal_quantification_enabled %}false{% else %}true{% endif %}">
+              <div class="plugin-measure-line">
+                <div class="plugin-measure-copy">
+                  <label for="signal_quantification_mode">Primary Mode:</label>
+                  <p class="module-help">Puncta Distance can also calculate Red/Green contour intensities. Nuclear, Cell-Pair Intensity measures the opposite channel inside the selected nucleus contour and full cell-pair mask.</p>
+                </div>
+                <div class="mode-select-group plugin-measure-right">
+                  <select id="signal_quantification_mode" name="signal_quantification_mode"><option value="puncta_distance" {% if preferences.experiment_defaults.signal_quantification_mode != 'nuclear_cell_pair' %}selected{% endif %}>Puncta Distance</option><option value="nuclear_cell_pair" {% if preferences.experiment_defaults.signal_quantification_mode == 'nuclear_cell_pair' %}selected{% endif %}>Nuclear, Cell-Pair Intensity</option></select>
+                </div>
+              </div>
+              <div class="signal-mode-stack">
+              <div class="signal-mode-panel" id="signalPunctaPanel" data-signal-mode-panel="puncta_distance">
+                <div class="plugin-measure-line">
+                  <div class="plugin-measure-copy">
+                    <label for="puncta_line_mode">Puncta Source:</label>
+                    <p class="module-help">Chooses which channel supplies the two dots that define the line. Red Puncta measures Green along the Red-dot line; Green Puncta measures Red along the Green-dot line.</p>
+                  </div>
+                  <div class="mode-select-group plugin-measure-right">
+                    <select id="puncta_line_mode" name="puncta_line_mode"><option value="red_puncta" {% if preferences.experiment_defaults.puncta_line_mode == 'red_puncta' %}selected{% endif %}>Red Puncta (Measure Green)</option><option value="green_puncta" {% if preferences.experiment_defaults.puncta_line_mode == 'green_puncta' %}selected{% endif %}>Green Puncta (Measure Red)</option></select>
+                  </div>
+                </div>
+                <div class="plugin-measure-line">
+                  <div class="plugin-measure-copy">
+                    <label for="puncta_line_width">Puncta Line Width:</label>
+                    <p class="module-help">Sets the thickness of the line mask used for the intensity sum. Values can be saved in px or um.</p>
+                  </div>
+                  <div class="length-input-group plugin-measure-right">
+                    <input type="number" step="0.01" min="0" id="puncta_line_width" name="puncta_line_width" value="{{ preferences.experiment_defaults.puncta_line_width }}">
+                    <select id="puncta_line_width_unit" name="puncta_line_width_unit"><option value="px" {% if preferences.experiment_defaults.puncta_line_width_unit == 'px' %}selected{% endif %}>px</option><option value="um" {% if preferences.experiment_defaults.puncta_line_width_unit == 'um' %}selected{% endif %}>&micro;m</option></select>
+                  </div>
+                </div>
+                <div class="plugin-measure-line">
+                  <div class="plugin-measure-copy">
+                    <label for="puncta_contour_intensity_enabled">Red/Green Contour Intensities:</label>
+                    <p class="module-help">Calculates raw Red/Green sums in Red and Green contour masks plus the Measurement/Contour ratios for the selected puncta source.</p>
+                  </div>
+                  <div class="plugin-measure-right compact-control">
+                    <input type="hidden" name="puncta_contour_intensity_enabled" value="0">
+                    <label class="sw"><input type="checkbox" id="puncta_contour_intensity_enabled" name="puncta_contour_intensity_enabled" value="1" {% if preferences.experiment_defaults.puncta_contour_intensity_enabled %}checked{% endif %}><span class="sl"></span></label>
+                  </div>
+                </div>
+              </div>
+              <div class="signal-mode-panel" id="signalNuclearPanel" data-signal-mode-panel="nuclear_cell_pair">
+                <div class="plugin-measure-line">
+                  <div class="plugin-measure-copy">
+                    <label for="nuclear_cell_pair_mode">Nucleus Contour Source:</label>
+                    <p class="module-help">Chooses which channel supplies the nucleus contour. Green Nucleus measures Red signal; Red Nucleus measures Green signal.</p>
+                  </div>
+                  <div class="mode-select-group plugin-measure-right">
+                    <select id="nuclear_cell_pair_mode" name="nuclear_cell_pair_mode"><option value="green_nucleus" {% if preferences.experiment_defaults.nuclear_cell_pair_mode == 'green_nucleus' %}selected{% endif %}>Green Nucleus (Measure Red)</option><option value="red_nucleus" {% if preferences.experiment_defaults.nuclear_cell_pair_mode == 'red_nucleus' %}selected{% endif %}>Red Nucleus (Measure Green)</option></select>
+                  </div>
+                </div>
+                  <div class="plugin-measure-line">
+                    <div class="plugin-measure-copy">
+                      <label for="alternate_nucleus_detection_enabled">Alternate Nucleus Detection:</label>
+                      <p class="module-help">Only affects Nuclear, Cell-Pair Intensity. Uses the alternate contour detection path on the selected nucleus source channel only.</p>
+                    </div>
+                  <div class="plugin-measure-right compact-control">
+                    <input type="hidden" name="alternate_nucleus_detection_enabled" value="0">
+                    <label class="sw"><input type="checkbox" id="alternate_nucleus_detection_enabled" name="alternate_nucleus_detection_enabled" value="1" {% if preferences.experiment_defaults.alternate_nucleus_detection_enabled %}checked{% endif %}><span class="sl"></span></label>
+                  </div>
+                </div>
+              </div>
+              </div>
+            </div>
+          </div>
           {% for plugin in plugins %}
+          {% if plugin.id != 'PunctaDistance' and plugin.id != 'GreenRedIntensity' and plugin.id != 'NuclearCellPairIntensity' %}
           <div class="plugin">
             <div class="plugin-main">
               <p><strong>{{ plugin.label }}</strong>{% if plugin.is_legacy %}<span class="legacy">Legacy</span>{% endif %}</p>
@@ -1490,7 +1602,7 @@ main.main > section.panel > form.panel > .card {
                 <div class="plugin-measure-line">
                   <div class="plugin-measure-copy">
                     <label for="biorientation_collinearity_threshold">Collinearity Threshold:</label>
-                    <p class="module-help">Maximum allowed perpendicular offset from the Red-puncta line for a Green dot to count as colinear.</p>
+                    <p class="module-help">Maximum allowed perpendicular offset (pixels) from the Red-puncta line for a Green dot to count as colinear.</p>
                   </div>
                   <div class="boxed-number-group plugin-measure-right compact-control">
                     <input type="number" min="0" id="biorientation_collinearity_threshold" name="biorientation_collinearity_threshold" value="{{ preferences.experiment_defaults.biorientation_collinearity_threshold }}">
@@ -1511,21 +1623,11 @@ main.main > section.panel > form.panel > .card {
               </div>
             {% endif %}
           </div>
+          {% endif %}
           {% endfor %}
         </div></div>
         <div class="card" data-workflow-card="dot-detection">
           <p class="section-eyebrow card-title">Dot Detection</p>
-          <div class="row">
-            <div class="row-copy">
-              <span class="row-label-line">
-                <label for="alternate_red_detection">Enable Alternate Red Detection</label>
-              </span>
-              <p class="module-help">Utilize an alternate Red detection mode where the tool attempts to find a single contour to surround all speckles.</p>
-              <p class="reqtxt">Requires: Red.</p>
-            </div>
-            <input type="hidden" name="alternate_red_detection" value="0">
-            <label class="sw"><input type="checkbox" id="alternate_red_detection" name="alternate_red_detection" value="1" {% if preferences.experiment_defaults.alternate_red_detection %}checked{% endif %}><span class="sl"></span></label>
-          </div>
           <div class="row combo" id="greenDotSplitRow">
             <div class="row-line">
               <div class="row-copy">


### PR DESCRIPTION
This pull request introduces significant improvements and refactoring to the user preferences and signal quantification logic, particularly around experiment defaults, plugin selection, and the handling of biorientation collinearity thresholds. The changes ensure more consistent handling of signal quantification settings across the codebase, centralize default values, and improve the normalization and updating of user preferences. The biorientation collinearity threshold is now consistently sourced from a single default value, and the logic for determining selected plugins and related signal quantification options has been unified and made more robust.

**Signal Quantification & Plugin Selection Improvements**
- Centralized signal quantification options (`signal_quantification_enabled`, `signal_quantification_mode`, `puncta_contour_intensity_enabled`, `alternate_nucleus_detection_enabled`) into experiment defaults, and refactored normalization and update logic to use `resolve_signal_quantification_selection`. This ensures consistent plugin selection and option handling across user preference updates, popup payloads, and profile views. [[1]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379L38-R51) [[2]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379R244-R253) [[3]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379R388-R413) [[4]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379R453-R456) [[5]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379R608-R646) [[6]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379R666-R673) [[7]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR1178-R1234) [[8]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR1285-R1319) [[9]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL1290-R1378) [[10]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL1310-R1398)

- Updated UI and backend to reflect effective selected plugins and their dependencies, using the resolved signal quantification configuration for both display and validation. [[1]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL1290-R1378) [[2]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL1310-R1398)

**Biorientation Collinearity Threshold Consistency**
- Replaced hardcoded biorientation collinearity threshold values with the centralized `DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX` constant in preferences, views, and analysis logic, ensuring consistent defaulting and easier future updates. [[1]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379L55-R62) [[2]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379L333-R350) [[3]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL201-R208) [[4]](diffhunk://#diff-186e3c1b7ad6393058edb4b79276cebc727fbd4065591d4a706f628fa0313a63R4-R6) [[5]](diffhunk://#diff-186e3c1b7ad6393058edb4b79276cebc727fbd4065591d4a706f628fa0313a63L71-R78)

**Biorientation Collinearity Calculation Refactor**
- Refactored the `_is_collinear` method in biorientation analysis to use an explicit pixel threshold for off-axis distance instead of a fixed epsilon, improving clarity and correctness in collinearity checks.

**Imports and Dependency Updates**
- Updated imports throughout the codebase to use new centralized constants and utility functions for signal quantification and biorientation configuration. [[1]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379R10-R25) [[2]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR51-R53) [[3]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR63-R66) [[4]](diffhunk://#diff-0c861ad0138f6c820b2e820502b3d32b441a5805272a41eb15d3bcb84918ceaaL9-R12)