### PR TITLE
Enhance statistics export flows with combined downloads and UI updates

### DIFF
--- a/cytocv/accounts/preferences.py
+++ b/cytocv/accounts/preferences.py
@@ -61,9 +61,9 @@ DEFAULT_USER_PREFERENCES: dict[str, Any] = {
         "biorientation_red_max_distance": 37,
         "biorientation_collinearity_threshold": DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
         "green_dot_split_enabled": True,
-        "green_dot_split_mode": "balanced",
+        "green_dot_split_mode": "aggressive",
         "red_dot_split_enabled": True,
-        "red_dot_split_mode": "balanced",
+        "red_dot_split_mode": "aggressive",
         "puncta_line_mode": DEFAULT_PUNCTA_LINE_MODE,
         "nuclear_cell_pair_mode": "green_nucleus",
         "green_contour_filter_enabled": False,
@@ -635,7 +635,7 @@ def build_experiment_defaults_from_popup_payload(
         allowed={"balanced", "aggressive"},
     )
     red_dot_split_mode = _strict_mode(
-        raw_payload.get("red_dot_split_mode", current.get("red_dot_split_mode", "balanced")),
+        raw_payload.get("red_dot_split_mode", current.get("red_dot_split_mode", "aggressive")),
         field="red_dot_split_mode",
         allowed={"balanced", "aggressive"},
     )

--- a/cytocv/accounts/views/profile.py
+++ b/cytocv/accounts/views/profile.py
@@ -60,7 +60,6 @@ from core.services.combined_stat_export import (
 )
 from core.services.export_filenames import (
     build_statistics_export_filename,
-    export_scope_for_selection,
 )
 from core.services.main_image_urls import build_main_image_paths
 from core.services.overlay_rendering import build_overlay_image_url, overlay_image_available
@@ -79,6 +78,7 @@ from core.services.signal_quantification import (
 from core.services.stat_export_selection import (
     ExportColumnSelectionError,
     export_exclude_columns,
+    export_metric_scope,
     export_selection_config,
 )
 from core.scale import (
@@ -992,10 +992,16 @@ def dashboard_view(request: HttpRequest) -> HttpResponse:
     export_uuid = str(request.GET.get("file_uuid") or "").strip()
     export_unit = normalize_spatial_stats_unit(request.GET.get("_unit"), default="px")
     if TableExport.is_valid_format(export_format) and export_uuid:
+        raw_columns = request.GET.getlist("_columns")
+        columns_present = "_columns" in request.GET
         try:
             exclude_columns = export_exclude_columns(
-                request.GET.getlist("_columns"),
-                columns_present="_columns" in request.GET,
+                raw_columns,
+                columns_present=columns_present,
+            )
+            metric_scope = export_metric_scope(
+                raw_columns,
+                columns_present=columns_present,
             )
         except ExportColumnSelectionError as exc:
             return HttpResponse(str(exc), status=400)
@@ -1004,12 +1010,8 @@ def dashboard_view(request: HttpRequest) -> HttpResponse:
             export_uuid,
             spatial_stats_unit=export_unit,
         )
-        available_export_uuids = _dashboard_available_export_uuid_set(request.user)
         download_name = build_statistics_export_filename(
-            scope=export_scope_for_selection(
-                selected_count=1,
-                available_count=len(available_export_uuids),
-            ),
+            scope=metric_scope,
             file_count=1,
             export_format=export_format,
         )
@@ -1086,7 +1088,6 @@ def dashboard_bulk_export_view(request: HttpRequest) -> HttpResponse:
             status=400,
         )
 
-    available_export_uuids = _dashboard_available_export_uuid_set(request.user)
     uploaded_map = {
         str(item.uuid): item
         for item in UploadedImage.objects.filter(
@@ -1130,10 +1131,6 @@ def dashboard_bulk_export_view(request: HttpRequest) -> HttpResponse:
             raw_columns=payload.get("_columns"),
             spatial_stats_unit=str(payload.get("_unit") or "px"),
             default_manual_scale=default_manual_scale,
-            export_scope=export_scope_for_selection(
-                selected_count=len(sources),
-                available_count=len(available_export_uuids),
-            ),
         )
     except (CombinedStatisticsExportError, ExportColumnSelectionError) as exc:
         return JsonResponse({"error": str(exc)}, status=400)

--- a/cytocv/accounts/views/profile.py
+++ b/cytocv/accounts/views/profile.py
@@ -53,6 +53,15 @@ from core.services.biorientation_config import (
     DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
 )
 from core.services.cell_statistics_payload import serialize_cell_statistics_payload
+from core.services.combined_stat_export import (
+    CombinedStatisticsExportError,
+    StatisticsExportFile,
+    build_combined_statistics_export_response,
+)
+from core.services.export_filenames import (
+    build_statistics_export_filename,
+    export_scope_for_selection,
+)
 from core.services.main_image_urls import build_main_image_paths
 from core.services.overlay_rendering import build_overlay_image_url, overlay_image_available
 from core.services.puncta_line_mode import (
@@ -144,17 +153,6 @@ def _normalize_nuclear_mode(value: Any, default: str = "green_nucleus") -> str:
 
 def _normalize_puncta_mode(value: Any, default: str = DEFAULT_PUNCTA_LINE_MODE) -> str:
     return normalize_puncta_line_mode(value, default=default)
-
-
-def _build_export_download_name(raw_name: Any, export_format: str, fallback: str) -> str:
-    stem = Path(str(raw_name or "").strip()).stem
-    if not stem:
-        stem = fallback
-    # Keep the source name recognizable while avoiding header-breaking characters.
-    stem = re.sub(r"[\\/\r\n\t]+", "_", stem).strip()
-    if not stem:
-        stem = fallback
-    return f"{stem}.{export_format}"
 
 
 def _preferences_redirect(request: HttpRequest, section: str) -> HttpResponse:
@@ -515,6 +513,24 @@ def _build_cell_table_for_uuid(
         spatial_stats_unit=spatial_stats_unit,
         scale_context=scale_context,
     )
+
+
+def _dashboard_available_export_uuid_set(user: Any) -> set[str]:
+    """Return saved dashboard files that can participate in statistics export."""
+
+    segmented_uuids = {
+        str(value)
+        for value in SegmentedImage.objects.filter(user=user).values_list("UUID", flat=True)
+    }
+    if not segmented_uuids:
+        return set()
+    return {
+        str(value)
+        for value in UploadedImage.objects.filter(
+            user=user,
+            uuid__in=segmented_uuids,
+        ).values_list("uuid", flat=True)
+    }
 
 
 def _resolve_nuclear_cell_pair_mode(stats_iterable: Any) -> str | None:
@@ -988,15 +1004,14 @@ def dashboard_view(request: HttpRequest) -> HttpResponse:
             export_uuid,
             spatial_stats_unit=export_unit,
         )
-        uploaded_name = (
-            UploadedImage.objects.filter(user=request.user, uuid=export_uuid)
-            .values_list("name", flat=True)
-            .first()
-        )
-        download_name = _build_export_download_name(
-            uploaded_name,
-            export_format,
-            fallback=f"dashboard-{export_uuid}",
+        available_export_uuids = _dashboard_available_export_uuid_set(request.user)
+        download_name = build_statistics_export_filename(
+            scope=export_scope_for_selection(
+                selected_count=1,
+                available_count=len(available_export_uuids),
+            ),
+            file_count=1,
+            export_format=export_format,
         )
         exporter = TableExport(
             export_format,
@@ -1051,6 +1066,77 @@ def dashboard_bulk_delete_view(request: HttpRequest) -> HttpResponse:
             "storage_percentage": round(context["storage_percentage"], 2),
         }
     )
+
+
+@login_required
+@require_POST
+def dashboard_bulk_export_view(request: HttpRequest) -> HttpResponse:
+    try:
+        payload = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return JsonResponse(
+            {"error": "Your request could not be processed. Please try again."},
+            status=400,
+        )
+
+    requested_uuids = _normalize_uuid_list(payload.get("uuids", []))
+    if not requested_uuids:
+        return JsonResponse(
+            {"error": "Select at least one saved file to continue."},
+            status=400,
+        )
+
+    available_export_uuids = _dashboard_available_export_uuid_set(request.user)
+    uploaded_map = {
+        str(item.uuid): item
+        for item in UploadedImage.objects.filter(
+            user=request.user,
+            uuid__in=requested_uuids,
+        )
+    }
+    segmented_map = {
+        str(item.UUID): item
+        for item in SegmentedImage.objects.filter(
+            user=request.user,
+            UUID__in=requested_uuids,
+        )
+    }
+    if (
+        len(uploaded_map) != len(set(requested_uuids))
+        or len(segmented_map) != len(set(requested_uuids))
+    ):
+        return JsonResponse(
+            {"error": "One or more selected files are no longer available. Refresh and try again."},
+            status=403,
+        )
+
+    preferences = get_user_preferences(request.user)
+    default_manual_scale = (
+        preferences.get("experiment_defaults", {}).get("microns_per_pixel", 0.1)
+    )
+    sources = [
+        StatisticsExportFile(
+            uuid=uuid,
+            file_name=uploaded_map[uuid].name,
+            segmented_image=segmented_map[uuid],
+            scale_info=uploaded_map[uuid].scale_info,
+        )
+        for uuid in requested_uuids
+    ]
+    try:
+        return build_combined_statistics_export_response(
+            sources,
+            export_format=str(payload.get("_export") or ""),
+            raw_columns=payload.get("_columns"),
+            spatial_stats_unit=str(payload.get("_unit") or "px"),
+            default_manual_scale=default_manual_scale,
+            export_scope=export_scope_for_selection(
+                selected_count=len(sources),
+                available_count=len(available_export_uuids),
+            ),
+        )
+    except (CombinedStatisticsExportError, ExportColumnSelectionError) as exc:
+        return JsonResponse({"error": str(exc)}, status=400)
 
 
 @login_required

--- a/cytocv/core/services/combined_stat_export.py
+++ b/cytocv/core/services/combined_stat_export.py
@@ -18,6 +18,7 @@ from core.scale import (
 from core.services.stat_export_selection import (
     export_exclude_columns,
     export_included_columns,
+    export_metric_scope,
 )
 from core.services.export_filenames import build_statistics_export_filename
 from core.tables import CellTable
@@ -111,7 +112,6 @@ def build_combined_statistics_export_response(
     raw_columns: Any,
     spatial_stats_unit: str,
     default_manual_scale: float,
-    export_scope: str = "selected",
 ) -> HttpResponse:
     """Return one CSV/XLSX attachment for the selected files."""
 
@@ -150,7 +150,7 @@ def build_combined_statistics_export_response(
         )
 
     filename = build_statistics_export_filename(
-        scope=export_scope,
+        scope=export_metric_scope(raw_columns, columns_present=True),
         file_count=len(sources),
         export_format=export_format,
     )

--- a/cytocv/core/services/combined_stat_export.py
+++ b/cytocv/core/services/combined_stat_export.py
@@ -139,8 +139,9 @@ def build_combined_statistics_export_response(
             spatial_stats_unit=unit,
             default_manual_scale=default_manual_scale,
         )
-        for row in rows:
-            dataset.append([source.file_name, *row])
+        for row_index, row in enumerate(rows):
+            file_name_cell = source.file_name if row_index == 0 else ""
+            dataset.append([file_name_cell, *row])
             row_count += 1
 
     if row_count == 0:

--- a/cytocv/core/services/combined_stat_export.py
+++ b/cytocv/core/services/combined_stat_export.py
@@ -1,0 +1,159 @@
+"""Build combined statistics exports for multiple files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from django.http import HttpResponse
+from django_tables2.export.export import TableExport
+from tablib import Dataset
+
+from core.models import CellStatistics
+from core.scale import (
+    format_spatial_stat_header,
+    get_scale_context_payload,
+    normalize_spatial_stats_unit,
+)
+from core.services.stat_export_selection import (
+    export_exclude_columns,
+    export_included_columns,
+)
+from core.services.export_filenames import build_statistics_export_filename
+from core.tables import CellTable
+
+
+EXPORT_FORMATS = {"csv", "xlsx"}
+
+
+class CombinedStatisticsExportError(ValueError):
+    """Raised when a combined export request cannot produce a file."""
+
+
+@dataclass(frozen=True)
+class StatisticsExportFile:
+    """Source metadata needed to export one selected file."""
+
+    uuid: str
+    file_name: str
+    segmented_image: Any
+    scale_info: Any = None
+
+
+def _generic_headers_for_fields(
+    field_names: tuple[str, ...],
+    *,
+    spatial_stats_unit: str,
+) -> list[str]:
+    table = CellTable(
+        [],
+        intensity_mode=None,
+        puncta_line_mode=None,
+        spatial_stats_unit=spatial_stats_unit,
+        scale_context=None,
+    )
+    labels = {
+        field_name: str(table.columns[field_name].column.verbose_name)
+        for field_name in field_names
+        if field_name in table.columns
+    }
+
+    labels.update(
+        {
+            "cell_id": "Cell ID",
+            "puncta_distance": format_spatial_stat_header(
+                "Puncta Distance",
+                spatial_kind="distance",
+                unit=spatial_stats_unit,
+            ),
+            "puncta_line_intensity": "Puncta Line Intensity",
+            "green_red_intensity_1": "Measurement/Contour Ratio 1",
+            "green_red_intensity_2": "Measurement/Contour Ratio 2",
+            "green_red_intensity_3": "Measurement/Contour Ratio 3",
+            "cell_pair_intensity_sum": "Measured Cell-Pair Intensity",
+            "nucleus_intensity_sum": "Measured Nuclear Intensity",
+        }
+    )
+    return [labels.get(field_name, field_name.replace("_", " ").title()) for field_name in field_names]
+
+
+def _table_rows_for_file(
+    source: StatisticsExportFile,
+    *,
+    exclude_columns: tuple[str, ...],
+    spatial_stats_unit: str,
+    default_manual_scale: float,
+) -> list[list[Any]]:
+    stats_qs = CellStatistics.objects.filter(
+        segmented_image=source.segmented_image,
+    ).order_by("cell_id")
+    if not stats_qs.exists():
+        return []
+
+    table = CellTable(
+        stats_qs,
+        intensity_mode=None,
+        puncta_line_mode=None,
+        spatial_stats_unit=spatial_stats_unit,
+        scale_context=get_scale_context_payload(
+            source.scale_info,
+            manual_default=default_manual_scale,
+        ),
+    )
+    rows = list(table.as_values(exclude_columns=exclude_columns))
+    return [list(row) for row in rows[1:]]
+
+
+def build_combined_statistics_export_response(
+    sources: list[StatisticsExportFile],
+    *,
+    export_format: str,
+    raw_columns: Any,
+    spatial_stats_unit: str,
+    default_manual_scale: float,
+    export_scope: str = "selected",
+) -> HttpResponse:
+    """Return one CSV/XLSX attachment for the selected files."""
+
+    if export_format not in EXPORT_FORMATS:
+        raise CombinedStatisticsExportError("Choose CSV or Excel for this download.")
+    if not sources:
+        raise CombinedStatisticsExportError("Select at least one file to download.")
+
+    unit = normalize_spatial_stats_unit(spatial_stats_unit, default="px")
+    included_columns = export_included_columns(raw_columns, columns_present=True)
+    if included_columns is None:
+        raise CombinedStatisticsExportError("Select at least one statistic to export.")
+    exclude_columns = export_exclude_columns(raw_columns, columns_present=True) or ()
+
+    dataset = Dataset()
+    dataset.headers = [
+        "File Name",
+        *_generic_headers_for_fields(included_columns, spatial_stats_unit=unit),
+    ]
+    row_count = 0
+    for source in sources:
+        rows = _table_rows_for_file(
+            source,
+            exclude_columns=exclude_columns,
+            spatial_stats_unit=unit,
+            default_manual_scale=default_manual_scale,
+        )
+        for row in rows:
+            dataset.append([source.file_name, *row])
+            row_count += 1
+
+    if row_count == 0:
+        raise CombinedStatisticsExportError(
+            "Selected files do not have statistics available to download."
+        )
+
+    filename = build_statistics_export_filename(
+        scope=export_scope,
+        file_count=len(sources),
+        export_format=export_format,
+    )
+    response = HttpResponse(content_type=TableExport.FORMATS[export_format])
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    response.write(dataset.export(export_format))
+    return response

--- a/cytocv/core/services/dot_split.py
+++ b/cytocv/core/services/dot_split.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-DEFAULT_DOT_SPLIT_MODE = "balanced"
+DEFAULT_DOT_SPLIT_MODE = "aggressive"
 VALID_DOT_SPLIT_MODES = frozenset({"balanced", "aggressive"})
 
 

--- a/cytocv/core/services/export_filenames.py
+++ b/cytocv/core/services/export_filenames.py
@@ -1,0 +1,57 @@
+"""Reusable download filenames for exported statistics."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from django.utils import timezone
+
+
+EXPORT_SCOPE_ALL = "all"
+EXPORT_SCOPE_SELECTED = "selected"
+EXPORT_SCOPES = {EXPORT_SCOPE_ALL, EXPORT_SCOPE_SELECTED}
+EXPORT_FORMAT_EXTENSIONS = {"csv": "csv", "xlsx": "xlsx"}
+
+
+def export_scope_for_selection(*, selected_count: int, available_count: int) -> str:
+    """Return whether an export covers all available files or a selected subset."""
+
+    try:
+        selected = int(selected_count)
+        available = int(available_count)
+    except (TypeError, ValueError):
+        return EXPORT_SCOPE_SELECTED
+    if available > 0 and selected == available:
+        return EXPORT_SCOPE_ALL
+    return EXPORT_SCOPE_SELECTED
+
+
+def build_statistics_export_filename(
+    *,
+    scope: str,
+    file_count: int,
+    export_format: str,
+    exported_at: datetime | None = None,
+) -> str:
+    """Build a stable, readable statistics export attachment filename."""
+
+    normalized_scope = str(scope or "").strip().lower()
+    if normalized_scope not in EXPORT_SCOPES:
+        normalized_scope = EXPORT_SCOPE_SELECTED
+
+    extension = EXPORT_FORMAT_EXTENSIONS.get(str(export_format or "").strip().lower())
+    if extension is None:
+        extension = "csv"
+
+    try:
+        normalized_file_count = max(int(file_count), 0)
+    except (TypeError, ValueError):
+        normalized_file_count = 0
+
+    timestamp = timezone.localtime(exported_at or timezone.now()).strftime(
+        "%Y-%m-%d_%H%M"
+    )
+    return (
+        f"cytocv_{normalized_scope}_cell-metrics_"
+        f"{normalized_file_count}files_{timestamp}.{extension}"
+    )

--- a/cytocv/core/services/export_filenames.py
+++ b/cytocv/core/services/export_filenames.py
@@ -13,19 +13,6 @@ EXPORT_SCOPES = {EXPORT_SCOPE_ALL, EXPORT_SCOPE_SELECTED}
 EXPORT_FORMAT_EXTENSIONS = {"csv": "csv", "xlsx": "xlsx"}
 
 
-def export_scope_for_selection(*, selected_count: int, available_count: int) -> str:
-    """Return whether an export covers all available files or a selected subset."""
-
-    try:
-        selected = int(selected_count)
-        available = int(available_count)
-    except (TypeError, ValueError):
-        return EXPORT_SCOPE_SELECTED
-    if available > 0 and selected == available:
-        return EXPORT_SCOPE_ALL
-    return EXPORT_SCOPE_SELECTED
-
-
 def build_statistics_export_filename(
     *,
     scope: str,

--- a/cytocv/core/services/stat_export_selection.py
+++ b/cytocv/core/services/stat_export_selection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
+from core.services.export_filenames import EXPORT_SCOPE_ALL, EXPORT_SCOPE_SELECTED
 from core.services.stat_applicability import STAT_FIELD_GROUPS
 from core.tables import CellTable
 
@@ -184,3 +185,14 @@ def export_exclude_columns(
         for field_name in USER_SELECTABLE_TABLE_FIELDS
         if field_name not in selected_fields
     )
+
+
+def export_metric_scope(raw_columns: Any, *, columns_present: bool) -> str:
+    """Return whether all user-selectable metric columns are included."""
+
+    if not columns_present:
+        return EXPORT_SCOPE_ALL
+    selected_fields = set(normalize_export_columns(raw_columns))
+    if selected_fields == USER_SELECTABLE_TABLE_FIELD_SET:
+        return EXPORT_SCOPE_ALL
+    return EXPORT_SCOPE_SELECTED

--- a/cytocv/core/services/stat_export_selection.py
+++ b/cytocv/core/services/stat_export_selection.py
@@ -51,6 +51,18 @@ USER_SELECTABLE_TABLE_FIELDS = _user_selectable_table_fields()
 USER_SELECTABLE_TABLE_FIELD_SET = set(USER_SELECTABLE_TABLE_FIELDS)
 
 
+def export_included_columns(
+    raw_columns: Any,
+    *,
+    columns_present: bool,
+) -> tuple[str, ...] | None:
+    """Return included table fields, including always-included identity columns."""
+
+    if not columns_present:
+        return None
+    return (*ALWAYS_INCLUDED_EXPORT_COLUMNS, *normalize_export_columns(raw_columns))
+
+
 def _client_id_for_table_field(table_field: str) -> str:
     return TABLE_FIELD_CLIENT_IDS.get(table_field, table_field)
 

--- a/cytocv/core/static/js/export_selection_modal.js
+++ b/cytocv/core/static/js/export_selection_modal.js
@@ -1,6 +1,19 @@
 (function () {
   'use strict';
 
+  const MODAL_ENTER_MS = 170;
+  const MODAL_EXIT_MS = 120;
+  const VIEW_ENTER_MS = 150;
+  const VIEW_EXIT_MS = 120;
+  const SELECTED_COUNT_COLOR = '#61d394';
+  const EMPTY_COUNT_COLOR = '#f0c95a';
+  const VIEW_ANIM_CLASSES = [
+    'anim-enter-forward',
+    'anim-enter-backward',
+    'anim-exit-forward',
+    'anim-exit-backward',
+  ];
+
   function parseConfig(scriptId) {
     const node = document.getElementById(scriptId || 'exportSelectionConfig');
     if (!node) return null;
@@ -30,13 +43,10 @@
     return format === 'xlsx' ? 'xlsx' : 'csv';
   }
 
-  function formatLabel(format) {
-    return normalizeFormat(format) === 'xlsx' ? 'Excel' : 'CSV';
-  }
-
-  function getHeaderLabels(items) {
-    const headers = Array.from(document.querySelectorAll('#celltable thead th'));
+  function getHeaderLabels(items, useCurrentTable) {
     const labels = new Map();
+    if (!useCurrentTable) return labels;
+    const headers = Array.from(document.querySelectorAll('#celltable thead th'));
     if (headers.length < 2) return labels;
     items.forEach((item, index) => {
       const header = headers[index + 1];
@@ -46,8 +56,35 @@
     return labels;
   }
 
-  const MODAL_ENTER_MS = 170;
-  const MODAL_EXIT_MS = 120;
+  function getCookie(name) {
+    let value = null;
+    document.cookie.split(';').forEach((cookie) => {
+      const item = cookie.trim();
+      if (item.startsWith(`${name}=`)) {
+        value = decodeURIComponent(item.slice(name.length + 1));
+      }
+    });
+    return value;
+  }
+
+  function filenameFromDisposition(header, fallback) {
+    const value = String(header || '');
+    const utfMatch = value.match(/filename\*=UTF-8''([^;]+)/i);
+    if (utfMatch) return decodeURIComponent(utfMatch[1].replace(/"/g, ''));
+    const match = value.match(/filename="?([^";]+)"?/i);
+    return match ? match[1] : fallback;
+  }
+
+  function triggerBlobDownload(blob, filename) {
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.setTimeout(() => window.URL.revokeObjectURL(url), 500);
+  }
 
   function createModalVisibility(backdrop, panel) {
     const prefersReducedMotion = !!(
@@ -116,11 +153,21 @@
     const metadata = options.metadata || parseConfig(options.configScriptId);
     const backdrop = document.getElementById(options.modalId || 'exportSelectionBackdrop');
     const modalPanel = backdrop ? backdrop.querySelector('.export-selection-modal') : null;
-    const list = document.getElementById(options.listId || 'exportSelectionList');
+    const fileView = document.getElementById(options.fileViewId || 'exportFileSelectionView');
+    const statsView = document.getElementById(options.statsViewId || 'exportStatSelectionView');
+    const fileList = document.getElementById(options.fileListId || 'exportFileSelectionList');
+    const statList = document.getElementById(options.listId || 'exportSelectionList');
+    const fileCountEl = document.getElementById(options.fileCountId || 'exportFileSelectionCount');
+    const statCountEl = document.getElementById(options.countId || 'exportSelectionCount');
+    const titleEl = document.getElementById(options.titleId || 'exportSelectionTitle');
+    const messageEl = document.getElementById(options.messageId || 'exportSelectionMessage');
+    const fileMessageEl = document.getElementById(options.fileMessageId || 'exportFileSelectionMessage');
+    const backFileBtn = document.getElementById(options.backFileId || 'backExportFileSelectionBtn');
+    const continueFileBtn = document.getElementById(options.continueFileId || 'continueExportFileSelectionBtn');
     const cancelBtn = document.getElementById(options.cancelId || 'cancelExportSelectionBtn');
     const confirmBtn = document.getElementById(options.confirmId || 'confirmExportSelectionBtn');
-    const countEl = document.getElementById(options.countId || 'exportSelectionCount');
-    const messageEl = document.getElementById(options.messageId || 'exportSelectionMessage');
+    const chooseFilesBtn = document.getElementById(options.chooseFilesId || 'chooseExportFilesBtn');
+    const formatToggle = document.getElementById(options.formatToggleId || 'exportFormatToggle');
     const triggerFormats = options.triggerFormats || {};
     const items = metadata && Array.isArray(metadata.items) ? metadata.items : [];
     const groups = metadata && Array.isArray(metadata.groups) ? metadata.groups : [];
@@ -128,14 +175,29 @@
     const presetButtons = Array.from(
       backdrop ? backdrop.querySelectorAll('[data-export-selection-action]') : []
     );
+    const fileActionButtons = Array.from(
+      backdrop ? backdrop.querySelectorAll('[data-export-file-action]') : []
+    );
+    const formatButtons = Array.from(
+      backdrop ? backdrop.querySelectorAll('[data-export-format]') : []
+    );
 
-    if (!metadata || !backdrop || !list || !cancelBtn || !confirmBtn || !items.length) {
+    if (
+      !metadata || !backdrop || !fileView || !statsView || !fileList || !statList
+      || !backFileBtn || !continueFileBtn || !cancelBtn || !confirmBtn || !items.length
+    ) {
       return null;
     }
 
     const modalVisibility = createModalVisibility(backdrop, modalPanel);
     let activeFormat = 'csv';
+    let activeMode = 'single';
+    let activeView = 'stats';
     let activeFileContext = null;
+    let activeFileIds = new Set();
+    let statsCanBack = false;
+    let viewTimer = null;
+    let downloading = false;
 
     function fileContext() {
       if (typeof options.getCurrentFileContext === 'function') {
@@ -144,17 +206,84 @@
       return {};
     }
 
-    function isDefaultSelected(item, visibility) {
-      if (item.disabled) return true;
-      if (!visibility) return item.defaultSelected !== false;
-      if (!item.group) return item.defaultSelected !== false;
-      return visibility[item.group] !== false;
+    function selectableFiles() {
+      if (typeof options.getSelectableFiles !== 'function') return [];
+      return (options.getSelectableFiles() || [])
+        .map((file) => {
+          const id = String(file.id || file.uuid || file.fileUUID || '');
+          return {
+            id,
+            label: file.label || file.name || id,
+            fileData: file.fileData || null,
+          };
+        })
+        .filter((file) => file.id);
     }
 
-    function selectedIds() {
-      return Array.from(list.querySelectorAll('input[type="checkbox"]:checked'))
-        .map((input) => input.value)
-        .filter(Boolean);
+    function selectedFileIdsInOrder() {
+      const selected = activeFileIds;
+      return selectableFiles()
+        .filter((file) => selected.has(file.id))
+        .map((file) => file.id);
+    }
+
+    function selectedSidebarFileIds() {
+      if (typeof options.getSelectedFileIds !== 'function') return [];
+      const selected = new Set((options.getSelectedFileIds() || []).map((id) => String(id)));
+      return selectableFiles()
+        .filter((file) => selected.has(file.id))
+        .map((file) => file.id);
+    }
+
+    function selectedFileDataList() {
+      const selected = activeFileIds;
+      return selectableFiles()
+        .filter((file) => selected.has(file.id))
+        .map((file) => file.fileData)
+        .filter((fileData) => fileData && typeof fileData === 'object');
+    }
+
+    function clearViewTimer() {
+      if (viewTimer !== null) {
+        window.clearTimeout(viewTimer);
+        viewTimer = null;
+      }
+    }
+
+    function clearViewAnim(view) {
+      if (!view) return;
+      VIEW_ANIM_CLASSES.forEach((className) => view.classList.remove(className));
+    }
+
+    function switchView(target, animate, direction) {
+      const toView = target === 'files' ? fileView : statsView;
+      const fromView = target === 'files' ? statsView : fileView;
+      activeView = target;
+      clearViewTimer();
+      clearViewAnim(fileView);
+      clearViewAnim(statsView);
+
+      if (!animate || fromView.hidden) {
+        fromView.hidden = true;
+        toView.hidden = false;
+        return;
+      }
+
+      const suffix = direction === 'backward' ? 'backward' : 'forward';
+      fromView.hidden = false;
+      toView.hidden = true;
+      fromView.classList.add(`anim-exit-${suffix}`);
+      viewTimer = window.setTimeout(() => {
+        clearViewAnim(fromView);
+        fromView.hidden = true;
+        toView.hidden = false;
+        void toView.offsetWidth;
+        toView.classList.add(`anim-enter-${suffix}`);
+        viewTimer = window.setTimeout(() => {
+          clearViewAnim(toView);
+          viewTimer = null;
+        }, VIEW_ENTER_MS);
+      }, VIEW_EXIT_MS);
     }
 
     function sameMembers(left, right) {
@@ -163,8 +292,50 @@
       return left.every((value) => rightSet.has(value));
     }
 
+    function majorityVisibility() {
+      const totals = new Map();
+      const enabled = new Map();
+      selectedFileDataList().forEach((fileData) => {
+        const visibility = statVisibilityForFile(fileData);
+        if (!visibility) return;
+        groups.forEach((group) => {
+          if (!Object.prototype.hasOwnProperty.call(visibility, group.id)) return;
+          totals.set(group.id, (totals.get(group.id) || 0) + 1);
+          if (visibility[group.id] !== false) {
+            enabled.set(group.id, (enabled.get(group.id) || 0) + 1);
+          }
+        });
+      });
+      const result = {};
+      totals.forEach((total, groupId) => {
+        result[groupId] = (enabled.get(groupId) || 0) >= total / 2;
+      });
+      return result;
+    }
+
+    function activeVisibility() {
+      if (activeMode === 'multi') return majorityVisibility();
+      return statVisibilityForFile(activeFileContext ? activeFileContext.fileData : null);
+    }
+
+    function isDefaultSelected(item, visibility) {
+      if (item.disabled) return true;
+      if (!visibility) return item.defaultSelected !== false;
+      if (!item.group) return item.defaultSelected !== false;
+      if (!Object.prototype.hasOwnProperty.call(visibility, item.group)) {
+        return item.defaultSelected !== false;
+      }
+      return visibility[item.group] !== false;
+    }
+
+    function selectedStatIds() {
+      return Array.from(statList.querySelectorAll('input[type="checkbox"]:checked'))
+        .map((input) => input.value)
+        .filter(Boolean);
+    }
+
     function defaultSelectedIds() {
-      const visibility = statVisibilityForFile(activeFileContext ? activeFileContext.fileData : null);
+      const visibility = activeVisibility();
       return items
         .filter((item) => isDefaultSelected(item, visibility))
         .map((item) => item.id);
@@ -187,36 +358,139 @@
       });
     }
 
-    function updateCount() {
-      const selected = selectedIds();
-      const count = selected.length;
-      if (countEl) {
-        countEl.textContent = count === 1 ? '1 statistic selected' : `${count} statistics selected`;
+    function updateFormatState() {
+      if (formatToggle) {
+        formatToggle.dataset.activeFormat = activeFormat;
       }
-      confirmBtn.disabled = count === 0;
+      formatButtons.forEach((button) => {
+        const isActive = normalizeFormat(button.dataset.exportFormat) === activeFormat;
+        button.classList.toggle('active', isActive);
+        button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+    }
+
+    function setActiveFormat(format) {
+      activeFormat = normalizeFormat(format);
+      updateFormatState();
+    }
+
+    function updateCountState(element, count) {
+      if (!element) return;
+      const hasSelection = count > 0;
+      element.classList.toggle('has-selection', count > 0);
+      element.classList.toggle('is-empty', count === 0);
+      element.dataset.selectionState = hasSelection ? 'selected' : 'empty';
+      element.style.setProperty(
+        'color',
+        hasSelection ? SELECTED_COUNT_COLOR : EMPTY_COUNT_COLOR,
+        'important'
+      );
+    }
+
+    function updateStatCount() {
+      const selected = selectedStatIds();
+      const count = selected.length;
+      if (statCountEl) {
+        statCountEl.textContent = count === 1 ? '1 statistic selected' : `${count} statistics selected`;
+        updateCountState(statCountEl, count);
+      }
+      confirmBtn.disabled = count === 0 || downloading;
       updatePresetState(selected);
     }
 
-    function setSelection(mode) {
-      const visibility = statVisibilityForFile(activeFileContext ? activeFileContext.fileData : null);
-      list.querySelectorAll('input[type="checkbox"]').forEach((input) => {
+    function setStatSelection(mode) {
+      const visibility = activeVisibility();
+      const selected = selectedStatIds();
+      const shouldToggleAllOff = mode === 'all' && selected.length === items.length;
+      let checkedCount = 0;
+      statList.querySelectorAll('input[type="checkbox"]').forEach((input) => {
         const item = items.find((candidate) => candidate.id === input.value);
         if (!item) return;
         if (mode === 'all') {
-          input.checked = true;
+          input.checked = !shouldToggleAllOff;
         } else if (mode === 'clear') {
           input.checked = false;
         } else {
           input.checked = isDefaultSelected(item, visibility);
         }
+        if (input.checked) checkedCount += 1;
       });
-      updateCount();
+      updateStatCount();
+      if (mode === 'calculated' && checkedCount === 0) {
+        showNotice(
+          'Calculated statistics could not be selected for the current file set. Select statistics manually or choose different files.',
+          'warning'
+        );
+      }
     }
 
-    function buildRows() {
-      const visibility = statVisibilityForFile(activeFileContext ? activeFileContext.fileData : null);
-      const headerLabels = getHeaderLabels(items);
-      list.innerHTML = '';
+    function updateFileCount() {
+      const selected = selectedFileIdsInOrder();
+      const count = selected.length;
+      if (fileCountEl) {
+        fileCountEl.textContent = count === 1 ? '1 file selected' : `${count} files selected`;
+        updateCountState(fileCountEl, count);
+      }
+      continueFileBtn.disabled = count === 0;
+      fileActionButtons.forEach((button) => {
+        const action = button.dataset.exportFileAction;
+        const isActive = (action === 'clear' && count === 0)
+          || (action === 'all' && count === selectableFiles().length && count > 0);
+        button.classList.toggle('active', isActive);
+        button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+    }
+
+    function setFileSelection(mode) {
+      if (mode === 'all') {
+        const allFileIds = selectableFiles().map((file) => file.id);
+        activeFileIds = selectedFileIdsInOrder().length === allFileIds.length
+          ? new Set()
+          : new Set(allFileIds);
+      } else if (mode === 'clear') {
+        activeFileIds = new Set();
+      }
+      fileList.querySelectorAll('input[type="checkbox"]').forEach((input) => {
+        input.checked = activeFileIds.has(input.value);
+      });
+      updateFileCount();
+    }
+
+    function buildFileRows() {
+      fileList.innerHTML = '';
+      selectableFiles().forEach((file) => {
+        const row = document.createElement('label');
+        row.className = 'export-selection-row file-export-row';
+
+        const text = document.createElement('span');
+        text.className = 'export-selection-row-text';
+        text.textContent = file.label;
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.value = file.id;
+        checkbox.checked = activeFileIds.has(file.id);
+        checkbox.addEventListener('change', () => {
+          if (checkbox.checked) {
+            activeFileIds.add(file.id);
+          } else {
+            activeFileIds.delete(file.id);
+          }
+          updateFileCount();
+        });
+
+        row.appendChild(text);
+        row.appendChild(checkbox);
+        fileList.appendChild(row);
+      });
+      updateFileCount();
+    }
+
+    function buildStatRows() {
+      const visibility = activeVisibility();
+      const useCurrentTableLabels = activeMode === 'single';
+      const headerLabels = getHeaderLabels(items, useCurrentTableLabels);
+      statList.innerHTML = '';
 
       const grouped = new Map();
       items.forEach((item) => {
@@ -236,7 +510,7 @@
 
         groupItems.forEach((item) => {
           const row = document.createElement('label');
-          row.className = 'export-selection-row';
+          row.className = 'export-selection-row stat-export-row';
 
           const text = document.createElement('span');
           text.className = 'export-selection-row-text';
@@ -247,39 +521,193 @@
           checkbox.value = item.id;
           checkbox.checked = isDefaultSelected(item, visibility);
           checkbox.disabled = !!item.disabled;
-          checkbox.addEventListener('change', updateCount);
+          checkbox.addEventListener('change', updateStatCount);
 
           row.appendChild(text);
           row.appendChild(checkbox);
           section.appendChild(row);
         });
 
-        list.appendChild(section);
+        statList.appendChild(section);
       });
-      updateCount();
+      updateStatCount();
+    }
+
+    function configureStatsView() {
+      const isMulti = activeMode === 'multi';
+      const fileCount = selectedFileIdsInOrder().length;
+      if (titleEl) titleEl.textContent = 'Download statistics';
+      if (messageEl) {
+        messageEl.textContent = isMulti
+          ? `Choose the statistics to include for ${fileCount} selected ${fileCount === 1 ? 'file' : 'files'}.`
+          : 'Choose the statistics to include in this download.';
+      }
+      cancelBtn.textContent = statsCanBack ? 'Back' : 'Cancel';
+      confirmBtn.textContent = 'Download';
+      if (chooseFilesBtn) chooseFilesBtn.hidden = !selectableFiles().length;
+      updateFormatState();
+    }
+
+    function focusFirst(view) {
+      const firstInput = view.querySelector('input[type="checkbox"]');
+      if (firstInput) {
+        firstInput.focus();
+        return;
+      }
+      const button = view.querySelector('button:not(:disabled)');
+      if (button) button.focus();
     }
 
     function open(format) {
-      activeFormat = normalizeFormat(format);
+      activeMode = 'single';
+      activeView = 'stats';
+      statsCanBack = false;
+      setActiveFormat(format);
       activeFileContext = fileContext();
-      buildRows();
-      if (messageEl) {
-        messageEl.textContent = `Choose the statistics to include in this ${formatLabel(activeFormat)} download.`;
-      }
-      confirmBtn.textContent = `Download ${formatLabel(activeFormat)}`;
+      activeFileIds = new Set(
+        activeFileContext && activeFileContext.fileUUID
+          ? [String(activeFileContext.fileUUID)]
+          : []
+      );
+      buildStatRows();
+      configureStatsView();
+      switchView('stats', false, 'forward');
       modalVisibility.show();
-      const firstInput = list.querySelector('input[type="checkbox"]');
-      if (firstInput) {
-        firstInput.focus();
-      } else {
-        confirmBtn.focus();
+      focusFirst(statsView);
+    }
+
+    function openFiles(initialFileIds) {
+      const selectedIds = Array.isArray(initialFileIds) && initialFileIds.length
+        ? initialFileIds.map((id) => String(id))
+        : selectedSidebarFileIds();
+      if (!selectedIds.length) return;
+      activeMode = 'multi';
+      activeView = 'files';
+      statsCanBack = false;
+      setActiveFormat('csv');
+      activeFileContext = null;
+      activeFileIds = new Set(selectedIds);
+      if (fileMessageEl) {
+        fileMessageEl.textContent = 'Choose the files to include in this download.';
       }
+      buildFileRows();
+      switchView('files', false, 'forward');
+      modalVisibility.show();
+      focusFirst(fileView);
     }
 
     function close() {
+      clearViewTimer();
       modalVisibility.hide(() => {
         activeFileContext = null;
+        activeFileIds = new Set();
+        statsCanBack = false;
+        downloading = false;
+        confirmBtn.disabled = false;
       });
+    }
+
+    function continueToStats() {
+      if (!selectedFileIdsInOrder().length) return;
+      activeMode = 'multi';
+      statsCanBack = true;
+      buildStatRows();
+      configureStatsView();
+      switchView('stats', true, 'forward');
+      focusFirst(statsView);
+    }
+
+    function backToFiles() {
+      buildFileRows();
+      switchView('files', true, 'backward');
+      focusFirst(fileView);
+    }
+
+    function editFilesFromStats() {
+      let currentIds = selectedFileIdsInOrder();
+      if (!currentIds.length && activeFileContext && activeFileContext.fileUUID) {
+        currentIds = [String(activeFileContext.fileUUID)];
+      }
+      if (!currentIds.length) {
+        currentIds = selectedSidebarFileIds();
+      }
+      if (!currentIds.length) return;
+      activeMode = 'multi';
+      activeFileIds = new Set(currentIds);
+      buildFileRows();
+      switchView('files', true, 'backward');
+      focusFirst(fileView);
+    }
+
+    function showNotice(message, tone) {
+      if (typeof options.showError === 'function') {
+        options.showError(message);
+        return;
+      }
+      if (window.showGlobalMessage) {
+        window.showGlobalMessage(message, tone || 'error', {
+          scope: 'analysis-warning',
+          top: 'calc(var(--nav-height) + 8px)',
+          timeoutMs: 7000,
+        });
+        return;
+      }
+      window.alert(message);
+    }
+
+    function showError(message) {
+      showNotice(message, 'error');
+    }
+
+    async function bulkDownload() {
+      const selectedColumns = selectedStatIds();
+      const fileIds = selectedFileIdsInOrder();
+      if (!selectedColumns.length || !fileIds.length || downloading) return;
+      if (!options.bulkExportUrl || typeof options.buildBulkExportPayload !== 'function') return;
+
+      downloading = true;
+      updateStatCount();
+      try {
+        const response = await fetch(options.bulkExportUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': options.csrfToken || getCookie('csrftoken') || '',
+          },
+          credentials: 'same-origin',
+          body: JSON.stringify(options.buildBulkExportPayload({
+            fileIds,
+            format: activeFormat,
+            columns: selectedColumns,
+          })),
+        });
+        if (!response.ok) {
+          let message = 'Unable to download selected files.';
+          const errorResponse = response.clone();
+          try {
+            const payload = await response.json();
+            message = payload.error || message;
+          } catch (error) {
+            const text = await errorResponse.text();
+            if (text) message = text;
+          }
+          throw new Error(message);
+        }
+        const blob = await response.blob();
+        triggerBlobDownload(
+          blob,
+          filenameFromDisposition(
+            response.headers.get('Content-Disposition'),
+            `selected-statistics.${activeFormat}`
+          )
+        );
+        close();
+      } catch (error) {
+        showError(error && error.message ? error.message : 'Unable to download selected files.');
+      } finally {
+        downloading = false;
+        updateStatCount();
+      }
     }
 
     Object.entries(triggerFormats).forEach(([triggerId, format]) => {
@@ -295,34 +723,69 @@
     presetButtons.forEach((button) => {
       button.setAttribute('aria-pressed', 'false');
       button.addEventListener('click', () => {
-        setSelection(button.dataset.exportSelectionAction || 'calculated');
+        setStatSelection(button.dataset.exportSelectionAction || 'calculated');
       });
     });
 
-    cancelBtn.addEventListener('click', close);
-    backdrop.addEventListener('click', (event) => {
-      if (event.target === backdrop) close();
-    });
-    document.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape' && backdrop.getAttribute('aria-hidden') === 'false') {
-        close();
-      }
+    fileActionButtons.forEach((button) => {
+      button.setAttribute('aria-pressed', 'false');
+      button.addEventListener('click', () => {
+        setFileSelection(button.dataset.exportFileAction || 'all');
+      });
     });
 
+    formatButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        setActiveFormat(button.dataset.exportFormat || 'csv');
+      });
+    });
+
+    backFileBtn.addEventListener('click', close);
+    continueFileBtn.addEventListener('click', continueToStats);
+    cancelBtn.addEventListener('click', () => {
+      if (statsCanBack && activeView === 'stats') {
+        backToFiles();
+        return;
+      }
+      close();
+    });
     confirmBtn.addEventListener('click', () => {
-      const selected = selectedIds();
-      if (!selected.length || typeof options.buildExportUrl !== 'function') return;
+      const selected = selectedStatIds();
+      if (!selected.length) return;
+      if (activeMode === 'multi') {
+        void bulkDownload();
+        return;
+      }
+      if (typeof options.buildExportUrl !== 'function') return;
       const context = activeFileContext || fileContext();
       const url = options.buildExportUrl(context.fileUUID, activeFormat, selected);
       if (url) {
         window.location.href = url;
       }
     });
+    if (chooseFilesBtn) {
+      chooseFilesBtn.addEventListener('click', () => {
+        editFilesFromStats();
+      });
+    }
+
+    backdrop.addEventListener('click', (event) => {
+      if (event.target === backdrop) close();
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key !== 'Escape' || backdrop.getAttribute('aria-hidden') !== 'false') return;
+      if (statsCanBack && activeView === 'stats') {
+        backToFiles();
+        return;
+      }
+      close();
+    });
 
     return {
       open,
+      openFiles,
       close,
-      refresh: buildRows,
+      refresh: buildStatRows,
     };
   }
 

--- a/cytocv/core/static/js/workflow_defaults.js
+++ b/cytocv/core/static/js/workflow_defaults.js
@@ -1044,8 +1044,8 @@
   };
 
   const normalizeLengthUnit = (value) => (value === 'um' ? 'um' : 'px');
-  const normalizeGreenDotSplitMode = (value) => (value === 'aggressive' ? 'aggressive' : 'balanced');
-  const normalizeRedDotSplitMode = (value) => (value === 'aggressive' ? 'aggressive' : 'balanced');
+  const normalizeGreenDotSplitMode = (value) => (value === 'balanced' ? 'balanced' : 'aggressive');
+  const normalizeRedDotSplitMode = (value) => (value === 'balanced' ? 'balanced' : 'aggressive');
   const normalizeDotSplitTarget = (value) => {
     if (value === 'red' || value === 'green' || value === 'both') return value;
     return 'both';

--- a/cytocv/core/tests/test_accounts_preferences.py
+++ b/cytocv/core/tests/test_accounts_preferences.py
@@ -1427,7 +1427,7 @@ class DisplayManualSaveTests(TestCase):
             [
                 ["combined_second", "1", "1.000", "5.000"],
                 ["combined_first", "1", "1.000", "5.000"],
-                ["combined_first", "2", "1.000", "5.000"],
+                ["", "2", "1.000", "5.000"],
             ],
         )
 

--- a/cytocv/core/tests/test_accounts_preferences.py
+++ b/cytocv/core/tests/test_accounts_preferences.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+from datetime import datetime
 from io import BytesIO, StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -14,6 +15,7 @@ from uuid import uuid4
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 from openpyxl import load_workbook
 
 from accounts.preferences import (
@@ -36,6 +38,7 @@ from core.services.signal_quantification import (
     resolve_effective_alternate_nucleus_detection,
     resolve_signal_quantification_selection,
 )
+from core.services.stat_export_selection import USER_SELECTABLE_TABLE_FIELDS
 from core.stats_plugins import PLUGIN_DEFINITIONS
 
 
@@ -775,6 +778,17 @@ class DisplayManualSaveTests(TestCase):
         sheet = workbook.active
         return [list(row) for row in sheet.iter_rows(values_only=True)]
 
+    @staticmethod
+    def _fixed_export_time():
+        return timezone.make_aware(
+            datetime(2026, 5, 10, 18, 34),
+            timezone.get_current_timezone(),
+        )
+
+    @staticmethod
+    def _all_metric_columns() -> str:
+        return ",".join(USER_SELECTABLE_TABLE_FIELDS)
+
     def assertExportFilename(
         self,
         response,
@@ -790,6 +804,22 @@ class DisplayManualSaveTests(TestCase):
             (
                 rf'filename="cytocv_{scope}_cell-metrics_{file_count}files_'
                 rf'\d{{4}}-\d{{2}}-\d{{2}}_\d{{4}}\.{extension}"'
+            ),
+        )
+
+    def assertExactExportFilename(
+        self,
+        response,
+        *,
+        scope: str,
+        file_count: int,
+        extension: str,
+    ) -> None:
+        self.assertEqual(
+            response["Content-Disposition"],
+            (
+                f'attachment; filename="cytocv_{scope}_cell-metrics_'
+                f'{file_count}files_2026-05-10_1834.{extension}"'
             ),
         )
 
@@ -1239,6 +1269,71 @@ class DisplayManualSaveTests(TestCase):
         self.assertNotIn("Green/Red ratio 1", headers)
         self.assertIn("Measurement/Contour Ratio 1 (Green/Red)", headers)
 
+    def test_dashboard_single_export_filename_scope_tracks_metric_selection(self):
+        saved_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="dashboard_filename_metric_scope",
+        )
+        other_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="dashboard_filename_other_file",
+        )
+        self._add_cell_stat(saved_uuid)
+        self._add_cell_stat(other_uuid)
+
+        cases = [
+            ("csv", {}, "all", "csv"),
+            ("xlsx", {}, "all", "xlsx"),
+            (
+                "csv",
+                {"_columns": self._all_metric_columns()},
+                "all",
+                "csv",
+            ),
+            (
+                "xlsx",
+                {"_columns": self._all_metric_columns()},
+                "all",
+                "xlsx",
+            ),
+            (
+                "csv",
+                {"_columns": "red_intensity_1,puncta_distance"},
+                "selected",
+                "csv",
+            ),
+            (
+                "xlsx",
+                {"_columns": "red_intensity_1,puncta_distance"},
+                "selected",
+                "xlsx",
+            ),
+        ]
+        with patch(
+            "core.services.export_filenames.timezone.now",
+            return_value=self._fixed_export_time(),
+        ):
+            for export_format, extra_params, expected_scope, extension in cases:
+                with self.subTest(export_format=export_format, params=extra_params):
+                    response = self.client.get(
+                        reverse("dashboard"),
+                        {
+                            "file_uuid": saved_uuid,
+                            "_export": export_format,
+                            **extra_params,
+                        },
+                    )
+
+                    self.assertEqual(response.status_code, 200)
+                    self.assertExactExportFilename(
+                        response,
+                        scope=expected_scope,
+                        file_count=1,
+                        extension=extension,
+                    )
+
     def test_dashboard_csv_export_filters_selected_columns(self):
         saved_uuid = self._create_display_file(
             uploaded_owner=self.user,
@@ -1461,7 +1556,7 @@ class DisplayManualSaveTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertExportFilename(
             response,
-            scope="all",
+            scope="selected",
             file_count=2,
             extension="xlsx",
         )
@@ -1479,6 +1574,68 @@ class DisplayManualSaveTests(TestCase):
             [row[0] for row in rows[1:]],
             ["combined_xlsx_first", "combined_xlsx_second"],
         )
+
+    def test_dashboard_combined_export_filename_scope_tracks_metric_selection(self):
+        first_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="dashboard_combined_metric_scope_first",
+        )
+        second_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="dashboard_combined_metric_scope_second",
+        )
+        self._add_cell_stat(first_uuid)
+        self._add_cell_stat(second_uuid)
+
+        cases = [
+            ("csv", [first_uuid, second_uuid], ["red_intensity_1"], "selected", 2),
+            ("xlsx", [first_uuid, second_uuid], ["red_intensity_1"], "selected", 2),
+            (
+                "csv",
+                [first_uuid],
+                list(USER_SELECTABLE_TABLE_FIELDS),
+                "all",
+                1,
+            ),
+            (
+                "xlsx",
+                [first_uuid],
+                list(USER_SELECTABLE_TABLE_FIELDS),
+                "all",
+                1,
+            ),
+        ]
+        with patch(
+            "core.services.export_filenames.timezone.now",
+            return_value=self._fixed_export_time(),
+        ):
+            for export_format, uuids, columns, expected_scope, file_count in cases:
+                with self.subTest(
+                    export_format=export_format,
+                    expected_scope=expected_scope,
+                ):
+                    response = self.client.post(
+                        reverse("dashboard_bulk_export"),
+                        data=json.dumps(
+                            {
+                                "uuids": uuids,
+                                "_export": export_format,
+                                "_columns": columns,
+                                "_unit": "px",
+                            }
+                        ),
+                        content_type="application/json",
+                    )
+
+                    self.assertEqual(response.status_code, 200)
+                    self.assertExactExportFilename(
+                        response,
+                        scope=expected_scope,
+                        file_count=file_count,
+                        extension=export_format,
+                    )
 
     def test_display_combined_csv_export_uses_visible_order_not_request_order(self):
         first_uuid = self._create_display_file(
@@ -1511,7 +1668,7 @@ class DisplayManualSaveTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertExportFilename(
             response,
-            scope="all",
+            scope="selected",
             file_count=2,
             extension="csv",
         )
@@ -1560,6 +1717,69 @@ class DisplayManualSaveTests(TestCase):
             self._xlsx_headers(response),
             ["File Name", "Cell ID", "Red In Red Intensity 1"],
         )
+
+    def test_display_combined_export_filename_scope_tracks_metric_selection(self):
+        first_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="display_combined_metric_scope_first",
+        )
+        second_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="display_combined_metric_scope_second",
+        )
+        self._add_cell_stat(first_uuid)
+        self._add_cell_stat(second_uuid)
+
+        cases = [
+            ("csv", [first_uuid, second_uuid], ["red_intensity_1"], "selected", 2),
+            ("xlsx", [first_uuid, second_uuid], ["red_intensity_1"], "selected", 2),
+            (
+                "csv",
+                [first_uuid],
+                list(USER_SELECTABLE_TABLE_FIELDS),
+                "all",
+                1,
+            ),
+            (
+                "xlsx",
+                [first_uuid],
+                list(USER_SELECTABLE_TABLE_FIELDS),
+                "all",
+                1,
+            ),
+        ]
+        with patch(
+            "core.services.export_filenames.timezone.now",
+            return_value=self._fixed_export_time(),
+        ):
+            for export_format, uuids, columns, expected_scope, file_count in cases:
+                with self.subTest(
+                    export_format=export_format,
+                    expected_scope=expected_scope,
+                ):
+                    response = self.client.post(
+                        reverse("display_export_files"),
+                        data=json.dumps(
+                            {
+                                "visible_uuids": [first_uuid, second_uuid],
+                                "uuids": uuids,
+                                "_export": export_format,
+                                "_columns": columns,
+                                "_unit": "px",
+                            }
+                        ),
+                        content_type="application/json",
+                    )
+
+                    self.assertEqual(response.status_code, 200)
+                    self.assertExactExportFilename(
+                        response,
+                        scope=expected_scope,
+                        file_count=file_count,
+                        extension=export_format,
+                    )
 
     def test_dashboard_combined_csv_export_respects_micron_unit_request(self):
         saved_uuid = self._create_display_file(
@@ -1788,6 +2008,70 @@ class DisplayManualSaveTests(TestCase):
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             response["Content-Type"],
         )
+
+    def test_display_single_export_filename_scope_tracks_metric_selection(self):
+        saved_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="display_filename_metric_scope",
+        )
+        other_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="display_filename_other_visible",
+        )
+        self._add_cell_stat(saved_uuid)
+        self._add_cell_stat(other_uuid)
+
+        cases = [
+            ("csv", {}, "all", "csv"),
+            ("xlsx", {}, "all", "xlsx"),
+            (
+                "csv",
+                {"_columns": self._all_metric_columns()},
+                "all",
+                "csv",
+            ),
+            (
+                "xlsx",
+                {"_columns": self._all_metric_columns()},
+                "all",
+                "xlsx",
+            ),
+            (
+                "csv",
+                {"_columns": "red_intensity_1,puncta_distance"},
+                "selected",
+                "csv",
+            ),
+            (
+                "xlsx",
+                {"_columns": "red_intensity_1,puncta_distance"},
+                "selected",
+                "xlsx",
+            ),
+        ]
+        with patch(
+            "core.services.export_filenames.timezone.now",
+            return_value=self._fixed_export_time(),
+        ):
+            for export_format, extra_params, expected_scope, extension in cases:
+                with self.subTest(export_format=export_format, params=extra_params):
+                    response = self.client.get(
+                        reverse("display", args=[f"{saved_uuid},{other_uuid}"]),
+                        {
+                            "_export": export_format,
+                            **extra_params,
+                        },
+                    )
+
+                    self.assertEqual(response.status_code, 200)
+                    self.assertExactExportFilename(
+                        response,
+                        scope=expected_scope,
+                        file_count=1,
+                        extension=extension,
+                    )
 
     def test_display_csv_and_xlsx_exports_filter_selected_columns(self):
         saved_uuid = self._create_display_file(

--- a/cytocv/core/tests/test_accounts_preferences.py
+++ b/cytocv/core/tests/test_accounts_preferences.py
@@ -769,6 +769,30 @@ class DisplayManualSaveTests(TestCase):
         sheet = workbook.active
         return [cell.value for cell in sheet[1]]
 
+    @staticmethod
+    def _xlsx_rows(response) -> list[list]:
+        workbook = load_workbook(BytesIO(response.content))
+        sheet = workbook.active
+        return [list(row) for row in sheet.iter_rows(values_only=True)]
+
+    def assertExportFilename(
+        self,
+        response,
+        *,
+        scope: str,
+        file_count: int,
+        extension: str,
+    ) -> None:
+        disposition = response["Content-Disposition"]
+        self.assertIn("attachment;", disposition)
+        self.assertRegex(
+            disposition,
+            (
+                rf'filename="cytocv_{scope}_cell-metrics_{file_count}files_'
+                rf'\d{{4}}-\d{{2}}-\d{{2}}_\d{{4}}\.{extension}"'
+            ),
+        )
+
     def test_display_save_endpoint_rejects_invalid_payload(self):
         response = self.client.post(
             reverse("display_save_files"),
@@ -854,9 +878,19 @@ class DisplayManualSaveTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'id="celltable"', html=False)
         self.assertContains(response, 'id="exportButtons"', html=False)
-        self.assertContains(response, 'id="downloadCsvBtn"', html=False)
-        self.assertContains(response, 'id="downloadXlsxBtn"', html=False)
+        self.assertContains(response, 'id="downloadStatsBtn"', html=False)
+        self.assertContains(response, 'Download Statistics', html=False)
+        self.assertNotContains(response, 'id="downloadCsvBtn"', html=False)
+        self.assertNotContains(response, 'id="downloadXlsxBtn"', html=False)
+        self.assertContains(response, 'id="downloadSelectedBtn"', html=False)
         self.assertContains(response, 'id="exportSelectionBackdrop"', html=False)
+        self.assertContains(response, 'id="exportFileSelectionView"', html=False)
+        self.assertContains(response, 'id="exportStatSelectionView"', html=False)
+        self.assertContains(response, 'id="exportFormatToggle"', html=False)
+        self.assertContains(response, 'data-active-format="csv"', html=False)
+        self.assertContains(response, 'data-export-format="csv"', html=False)
+        self.assertContains(response, 'data-export-format="xlsx"', html=False)
+        self.assertContains(response, 'Edit files', html=False)
         self.assertContains(response, 'id="exportSelectionConfig"', html=False)
         self.assertContains(response, "export_selection_modal.js", html=False)
         self.assertNotContains(response, "sort=cell_id", html=False)
@@ -878,11 +912,7 @@ class DisplayManualSaveTests(TestCase):
             f'href="/dashboard/?file_uuid={saved_uuid}&amp;_export=csv&amp;_unit=px"',
             html=False,
         )
-        self.assertContains(
-            response,
-            f'href="/dashboard/?file_uuid={saved_uuid}&amp;_export=xlsx&amp;_unit=px"',
-            html=False,
-        )
+        self.assertNotContains(response, "_export=xlsx", html=False)
 
     def test_dashboard_template_renders_glass_layout_and_existing_hooks(self):
         self._create_display_file(
@@ -909,8 +939,7 @@ class DisplayManualSaveTests(TestCase):
         self.assertContains(response, 'id="sidebarSpatialUnitToggle"', html=False)
         self.assertContains(response, 'id="tableFullscreenBtn"', html=False)
         self.assertContains(response, 'id="tableScrollFrame"', html=False)
-        self.assertContains(response, 'id="downloadCsvBtn"', html=False)
-        self.assertContains(response, 'id="downloadXlsxBtn"', html=False)
+        self.assertContains(response, 'id="downloadStatsBtn"', html=False)
         self.assertContains(response, 'data-action="select-cells"', html=False)
         self.assertContains(response, 'id="selectCellsBackdrop"', html=False)
         self.assertContains(response, "const initialSidebarSpatialStatsUnit =", html=False)
@@ -950,9 +979,19 @@ class DisplayManualSaveTests(TestCase):
         self.assertContains(response, 'id="tableScrollFrame"', html=False)
         self.assertContains(response, 'id="celltable"', html=False)
         self.assertContains(response, 'id="displayExportButtons"', html=False)
-        self.assertContains(response, 'id="displayDownloadCsvBtn"', html=False)
-        self.assertContains(response, 'id="displayDownloadXlsxBtn"', html=False)
+        self.assertContains(response, 'id="displayDownloadStatsBtn"', html=False)
+        self.assertContains(response, 'Download Statistics', html=False)
+        self.assertNotContains(response, 'id="displayDownloadCsvBtn"', html=False)
+        self.assertNotContains(response, 'id="displayDownloadXlsxBtn"', html=False)
+        self.assertContains(response, 'id="downloadSelectedBtn"', html=False)
         self.assertContains(response, 'id="exportSelectionBackdrop"', html=False)
+        self.assertContains(response, 'id="exportFileSelectionView"', html=False)
+        self.assertContains(response, 'id="exportStatSelectionView"', html=False)
+        self.assertContains(response, 'id="exportFormatToggle"', html=False)
+        self.assertContains(response, 'data-active-format="csv"', html=False)
+        self.assertContains(response, 'data-export-format="csv"', html=False)
+        self.assertContains(response, 'data-export-format="xlsx"', html=False)
+        self.assertContains(response, 'Edit files', html=False)
         self.assertContains(response, 'id="exportSelectionConfig"', html=False)
         self.assertContains(response, "export_selection_modal.js", html=False)
         self.assertContains(response, 'data-action="select-cells"', html=False)
@@ -1129,7 +1168,7 @@ class DisplayManualSaveTests(TestCase):
         self.assertContains(response, 'id="preprocessScaleSummary"', html=False)
         self.assertContains(response, 'id="sidebarSpatialUnitToggle"', html=False)
 
-    def test_dashboard_csv_export_for_file_uuid_returns_attachment(self):
+    def test_dashboard_csv_export_for_file_uuid_returns_named_attachment(self):
         file_name = "dashboard_csv_export"
         saved_uuid = self._create_display_file(
             uploaded_owner=self.user,
@@ -1144,8 +1183,12 @@ class DisplayManualSaveTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("attachment;", response["Content-Disposition"])
-        self.assertIn(f"{file_name}.csv", response["Content-Disposition"])
+        self.assertExportFilename(
+            response,
+            scope="all",
+            file_count=1,
+            extension="csv",
+        )
         self.assertIn("text/csv", response["Content-Type"])
         csv_text = response.content.decode("utf-8")
         self.assertIn("Cell ID", csv_text)
@@ -1160,7 +1203,7 @@ class DisplayManualSaveTests(TestCase):
         self.assertIn("Cen Dot Location", csv_text)
         self.assertIn("Mother and daughter", csv_text)
 
-    def test_dashboard_xlsx_export_for_file_uuid_returns_attachment(self):
+    def test_dashboard_xlsx_export_for_file_uuid_returns_named_attachment(self):
         file_name = "dashboard_xlsx_export"
         saved_uuid = self._create_display_file(
             uploaded_owner=self.user,
@@ -1175,8 +1218,12 @@ class DisplayManualSaveTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("attachment;", response["Content-Disposition"])
-        self.assertIn(f"{file_name}.xlsx", response["Content-Disposition"])
+        self.assertExportFilename(
+            response,
+            scope="all",
+            file_count=1,
+            extension="xlsx",
+        )
         self.assertIn(
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             response["Content-Type"],
@@ -1330,7 +1377,370 @@ class DisplayManualSaveTests(TestCase):
         gfp_dot_col = headers.index("Cen Dot Location") + 1
         self.assertEqual(sheet.cell(row=2, column=gfp_dot_col).value, "Mother and daughter")
 
-    def test_display_csv_export_uses_uploaded_file_name(self):
+    def test_dashboard_combined_csv_export_filters_stats_and_preserves_file_order(self):
+        first_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="combined_first",
+        )
+        second_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="combined_second",
+        )
+        self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="combined_not_selected",
+        )
+        self._add_cell_stat(first_uuid, cell_id=2)
+        self._add_cell_stat(first_uuid, cell_id=1)
+        self._add_cell_stat(second_uuid, cell_id=1)
+
+        response = self.client.post(
+            reverse("dashboard_bulk_export"),
+            data=json.dumps(
+                {
+                    "uuids": [second_uuid, first_uuid],
+                    "_export": "csv",
+                    "_columns": ["red_intensity_1", "puncta_distance"],
+                    "_unit": "px",
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertExportFilename(
+            response,
+            scope="selected",
+            file_count=2,
+            extension="csv",
+        )
+        rows = self._csv_rows(response)
+        self.assertEqual(
+            rows[0],
+            ["File Name", "Cell ID", "Puncta Distance (px)", "Red In Red Intensity 1"],
+        )
+        self.assertEqual(
+            rows[1:],
+            [
+                ["combined_second", "1", "1.000", "5.000"],
+                ["combined_first", "1", "1.000", "5.000"],
+                ["combined_first", "2", "1.000", "5.000"],
+            ],
+        )
+
+    def test_dashboard_combined_xlsx_export_matches_filtered_headers_and_order(self):
+        first_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="combined_xlsx_first",
+        )
+        second_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="combined_xlsx_second",
+        )
+        self._add_cell_stat(first_uuid)
+        self._add_cell_stat(second_uuid)
+
+        response = self.client.post(
+            reverse("dashboard_bulk_export"),
+            data=json.dumps(
+                {
+                    "uuids": [first_uuid, second_uuid],
+                    "_export": "xlsx",
+                    "_columns": ["red_intensity_1", "measurement_contour_ratio_1"],
+                    "_unit": "px",
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertExportFilename(
+            response,
+            scope="all",
+            file_count=2,
+            extension="xlsx",
+        )
+        rows = self._xlsx_rows(response)
+        self.assertEqual(
+            rows[0],
+            [
+                "File Name",
+                "Cell ID",
+                "Red In Red Intensity 1",
+                "Measurement/Contour Ratio 1",
+            ],
+        )
+        self.assertEqual(
+            [row[0] for row in rows[1:]],
+            ["combined_xlsx_first", "combined_xlsx_second"],
+        )
+
+    def test_display_combined_csv_export_uses_visible_order_not_request_order(self):
+        first_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="display_combined_first",
+        )
+        second_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="display_combined_second",
+        )
+        self._add_cell_stat(first_uuid)
+        self._add_cell_stat(second_uuid)
+
+        response = self.client.post(
+            reverse("display_export_files"),
+            data=json.dumps(
+                {
+                    "visible_uuids": [first_uuid, second_uuid],
+                    "uuids": [second_uuid, first_uuid],
+                    "_export": "csv",
+                    "_columns": ["red_intensity_1"],
+                    "_unit": "px",
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertExportFilename(
+            response,
+            scope="all",
+            file_count=2,
+            extension="csv",
+        )
+        rows = self._csv_rows(response)
+        self.assertEqual(rows[0], ["File Name", "Cell ID", "Red In Red Intensity 1"])
+        self.assertEqual(
+            [row[0] for row in rows[1:]],
+            ["display_combined_first", "display_combined_second"],
+        )
+
+    def test_display_combined_xlsx_export_filters_headers(self):
+        saved_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="display_combined_xlsx",
+        )
+        other_visible_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="display_combined_xlsx_not_selected",
+        )
+        self._add_cell_stat(saved_uuid)
+
+        response = self.client.post(
+            reverse("display_export_files"),
+            data=json.dumps(
+                {
+                    "visible_uuids": [saved_uuid, other_visible_uuid],
+                    "uuids": [saved_uuid],
+                    "_export": "xlsx",
+                    "_columns": ["red_intensity_1"],
+                    "_unit": "px",
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertExportFilename(
+            response,
+            scope="selected",
+            file_count=1,
+            extension="xlsx",
+        )
+        self.assertEqual(
+            self._xlsx_headers(response),
+            ["File Name", "Cell ID", "Red In Red Intensity 1"],
+        )
+
+    def test_dashboard_combined_csv_export_respects_micron_unit_request(self):
+        saved_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="combined_um_export",
+        )
+        uploaded = UploadedImage.objects.get(uuid=saved_uuid)
+        uploaded.scale_info = build_scale_info(manual_um_per_px=0.5, prefer_metadata=False)
+        uploaded.save(update_fields=["scale_info"])
+        self._add_cell_stat(saved_uuid)
+
+        response = self.client.post(
+            reverse("dashboard_bulk_export"),
+            data=json.dumps(
+                {
+                    "uuids": [saved_uuid],
+                    "_export": "csv",
+                    "_columns": ["puncta_distance"],
+                    "_unit": "um",
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        rows = self._csv_rows(response)
+        self.assertEqual(rows[0], ["File Name", "Cell ID", "Puncta Distance (µm)"])
+        self.assertEqual(rows[1], ["combined_um_export", "1", "0.500"])
+
+    def test_combined_exports_reject_invalid_empty_and_inaccessible_requests(self):
+        owned_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="combined_owned",
+        )
+        foreign_uuid = self._create_display_file(
+            uploaded_owner=self.other_user,
+            segmented_owner_id=self.other_user.id,
+            filename="combined_foreign",
+        )
+        outside_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="combined_outside_visible",
+        )
+        self._add_cell_stat(owned_uuid)
+        self._add_cell_stat(outside_uuid)
+
+        no_files = self.client.post(
+            reverse("dashboard_bulk_export"),
+            data=json.dumps(
+                {"uuids": [], "_export": "csv", "_columns": ["red_intensity_1"]}
+            ),
+            content_type="application/json",
+        )
+        invalid_columns = self.client.post(
+            reverse("dashboard_bulk_export"),
+            data=json.dumps({"uuids": [owned_uuid], "_export": "csv", "_columns": []}),
+            content_type="application/json",
+        )
+        inaccessible = self.client.post(
+            reverse("dashboard_bulk_export"),
+            data=json.dumps(
+                {
+                    "uuids": [owned_uuid, foreign_uuid],
+                    "_export": "csv",
+                    "_columns": ["red_intensity_1"],
+                }
+            ),
+            content_type="application/json",
+        )
+        not_visible = self.client.post(
+            reverse("display_export_files"),
+            data=json.dumps(
+                {
+                    "visible_uuids": [owned_uuid],
+                    "uuids": [outside_uuid],
+                    "_export": "csv",
+                    "_columns": ["red_intensity_1"],
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(no_files.status_code, 400)
+        self.assertEqual(invalid_columns.status_code, 400)
+        self.assertEqual(inaccessible.status_code, 403)
+        self.assertEqual(not_visible.status_code, 403)
+
+    def test_combined_export_rejects_files_without_statistics(self):
+        empty_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="combined_empty_stats",
+        )
+
+        response = self.client.post(
+            reverse("dashboard_bulk_export"),
+            data=json.dumps(
+                {
+                    "uuids": [empty_uuid],
+                    "_export": "csv",
+                    "_columns": ["red_intensity_1"],
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_combined_export_excludes_deleted_cell_rows(self):
+        saved_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="combined_deleted_cells",
+        )
+        self._add_cell_stat(saved_uuid, cell_id=1)
+        self._add_cell_stat(saved_uuid, cell_id=2)
+        segmented = SegmentedImage.objects.get(UUID=saved_uuid)
+        CellStatistics.objects.filter(segmented_image=segmented, cell_id=2).delete()
+
+        response = self.client.post(
+            reverse("dashboard_bulk_export"),
+            data=json.dumps(
+                {
+                    "uuids": [saved_uuid],
+                    "_export": "csv",
+                    "_columns": ["red_intensity_1"],
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        rows = self._csv_rows(response)
+        self.assertEqual([row[1] for row in rows[1:]], ["1"])
+
+    def test_combined_nuclear_export_can_include_uncomputed_stats_as_na(self):
+        saved_uuid = self._create_display_file(
+            uploaded_owner=self.user,
+            segmented_owner_id=self.user.id,
+            filename="combined_nuclear_filtered_export",
+        )
+        self._add_cell_stat(
+            saved_uuid,
+            properties={
+                "selected_analysis": ["NuclearCellPairIntensity"],
+                "nuclear_cell_pair_mode": "green_nucleus",
+                "nuclear_cell_pair_status": "ok",
+                "nuclear_cell_pair_contour_source": "canonical_slot_1",
+            },
+        )
+
+        response = self.client.post(
+            reverse("dashboard_bulk_export"),
+            data=json.dumps(
+                {
+                    "uuids": [saved_uuid],
+                    "_export": "csv",
+                    "_columns": ["cell_pair_intensity_sum", "puncta_distance"],
+                    "_unit": "px",
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        rows = self._csv_rows(response)
+        self.assertEqual(
+            rows[0],
+            [
+                "File Name",
+                "Cell ID",
+                "Puncta Distance (px)",
+                "Measured Cell-Pair Intensity",
+            ],
+        )
+        self.assertEqual(rows[1], ["combined_nuclear_filtered_export", "1", "N/A", "4.000"])
+
+    def test_display_csv_export_uses_generated_download_name(self):
         file_name = "display_csv_export_source"
         saved_uuid = self._create_display_file(
             uploaded_owner=self.user,
@@ -1345,11 +1755,15 @@ class DisplayManualSaveTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("attachment;", response["Content-Disposition"])
-        self.assertIn(f"{file_name}.csv", response["Content-Disposition"])
+        self.assertExportFilename(
+            response,
+            scope="all",
+            file_count=1,
+            extension="csv",
+        )
         self.assertIn("text/csv", response["Content-Type"])
 
-    def test_display_xlsx_export_uses_uploaded_file_name(self):
+    def test_display_xlsx_export_uses_generated_download_name(self):
         file_name = "display_xlsx_export_source"
         saved_uuid = self._create_display_file(
             uploaded_owner=self.user,
@@ -1364,8 +1778,12 @@ class DisplayManualSaveTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("attachment;", response["Content-Disposition"])
-        self.assertIn(f"{file_name}.xlsx", response["Content-Disposition"])
+        self.assertExportFilename(
+            response,
+            scope="all",
+            file_count=1,
+            extension="xlsx",
+        )
         self.assertIn(
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             response["Content-Type"],

--- a/cytocv/core/tests/test_accounts_preferences.py
+++ b/cytocv/core/tests/test_accounts_preferences.py
@@ -59,9 +59,9 @@ class PreferenceNormalizationTests(TestCase):
         self.assertEqual(defaults["puncta_line_mode"], "red_puncta")
         self.assertEqual(defaults["nuclear_cell_pair_mode"], "green_nucleus")
         self.assertTrue(defaults["green_dot_split_enabled"])
-        self.assertEqual(defaults["green_dot_split_mode"], "balanced")
+        self.assertEqual(defaults["green_dot_split_mode"], "aggressive")
         self.assertTrue(defaults["red_dot_split_enabled"])
-        self.assertEqual(defaults["red_dot_split_mode"], "balanced")
+        self.assertEqual(defaults["red_dot_split_mode"], "aggressive")
         self.assertTrue(defaults["use_metadata_scale"])
         self.assertEqual(defaults["spatial_stats_unit"], "px")
         self.assertTrue(normalized["show_saved_file_channels"])
@@ -117,9 +117,9 @@ class PreferenceNormalizationTests(TestCase):
         self.assertEqual(defaults["biorientation_collinearity_threshold"], 3)
         self.assertEqual(defaults["puncta_line_mode"], "red_puncta")
         self.assertEqual(defaults["nuclear_cell_pair_mode"], "green_nucleus")
-        self.assertEqual(defaults["green_dot_split_mode"], "balanced")
+        self.assertEqual(defaults["green_dot_split_mode"], "aggressive")
         self.assertFalse(defaults["red_dot_split_enabled"])
-        self.assertEqual(defaults["red_dot_split_mode"], "balanced")
+        self.assertEqual(defaults["red_dot_split_mode"], "aggressive")
         self.assertFalse(defaults["use_metadata_scale"])
         self.assertEqual(defaults["spatial_stats_unit"], "px")
         self.assertFalse(normalized["auto_save_experiments"])
@@ -3166,7 +3166,7 @@ class ChannelVisibilityPreferenceTests(TestCase):
         self.assertEqual(defaults["puncta_line_mode"], "red_puncta")
         self.assertEqual(defaults["nuclear_cell_pair_mode"], "green_nucleus")
         self.assertTrue(defaults["green_dot_split_enabled"])
-        self.assertEqual(defaults["green_dot_split_mode"], "balanced")
+        self.assertEqual(defaults["green_dot_split_mode"], "aggressive")
 
     def test_plugin_settings_form_persists_measurement_defaults(self):
         response = self.client.post(
@@ -3348,9 +3348,9 @@ class ChannelVisibilityPreferenceTests(TestCase):
         self.user.refresh_from_db()
         defaults = get_user_preferences(self.user)["experiment_defaults"]
         self.assertTrue(defaults["green_dot_split_enabled"])
-        self.assertEqual(defaults["green_dot_split_mode"], "balanced")
+        self.assertEqual(defaults["green_dot_split_mode"], "aggressive")
         self.assertFalse(defaults["red_dot_split_enabled"])
-        self.assertEqual(defaults["red_dot_split_mode"], "balanced")
+        self.assertEqual(defaults["red_dot_split_mode"], "aggressive")
 
     def test_advanced_settings_pauses_optional_checks_when_module_disabled(self):
         response = self.client.post(

--- a/cytocv/core/tests/test_dot_split_config.py
+++ b/cytocv/core/tests/test_dot_split_config.py
@@ -24,7 +24,7 @@ class DotSplitConfigTests(SimpleTestCase):
     def test_analysis_snapshot_defaults_invalid_green_dot_split_mode(self):
         normalized = normalize_analysis_config_snapshot({"greenDotSplitMode": "bad"})
 
-        self.assertEqual(normalized["greenDotSplitMode"], "balanced")
+        self.assertEqual(normalized["greenDotSplitMode"], "aggressive")
 
     def test_analysis_snapshot_preserves_red_dot_split_mode(self):
         normalized = normalize_analysis_config_snapshot(
@@ -40,7 +40,7 @@ class DotSplitConfigTests(SimpleTestCase):
     def test_analysis_snapshot_defaults_invalid_red_dot_split_mode(self):
         normalized = normalize_analysis_config_snapshot({"redDotSplitMode": "bad"})
 
-        self.assertEqual(normalized["redDotSplitMode"], "balanced")
+        self.assertEqual(normalized["redDotSplitMode"], "aggressive")
 
     def test_analysis_snapshot_derives_puncta_without_contour_intensity(self):
         normalized = normalize_analysis_config_snapshot(

--- a/cytocv/core/tests/test_stat_export_selection.py
+++ b/cytocv/core/tests/test_stat_export_selection.py
@@ -5,12 +5,14 @@ from django.utils import timezone
 
 from core.services.export_filenames import (
     build_statistics_export_filename,
-    export_scope_for_selection,
 )
 from core.services.stat_export_selection import (
     ExportColumnSelectionError,
+    CLIENT_FIELD_ALIASES,
+    USER_SELECTABLE_TABLE_FIELDS,
     export_exclude_columns,
     export_included_columns,
+    export_metric_scope,
     export_selection_config,
     normalize_export_columns,
 )
@@ -42,15 +44,54 @@ class StatExportSelectionTests(SimpleTestCase):
             "cytocv_all_cell-metrics_24files_2026-05-10_1834.xlsx",
         )
 
-    def test_export_scope_for_selection_distinguishes_all_from_selected(self):
+    def test_export_metric_scope_treats_omitted_columns_as_all_metrics(self):
         self.assertEqual(
-            export_scope_for_selection(selected_count=24, available_count=24),
+            export_metric_scope(None, columns_present=False),
             "all",
         )
+
+    def test_export_metric_scope_detects_all_user_selectable_metrics(self):
         self.assertEqual(
-            export_scope_for_selection(selected_count=8, available_count=24),
+            export_metric_scope(USER_SELECTABLE_TABLE_FIELDS, columns_present=True),
+            "all",
+        )
+
+    def test_export_metric_scope_resolves_aliases_duplicates_and_canonical_fields(self):
+        alias_by_table_field = {
+            table_field: client_field
+            for client_field, table_field in CLIENT_FIELD_ALIASES.items()
+        }
+        raw_columns = [
+            alias_by_table_field.get(table_field, table_field)
+            for table_field in USER_SELECTABLE_TABLE_FIELDS
+        ]
+        raw_columns.extend(
+            [
+                "measurement_contour_ratio_1",
+                "measurement_contour_ratio_2",
+                "puncta_distance",
+            ]
+        )
+
+        self.assertEqual(
+            export_metric_scope(raw_columns, columns_present=True),
+            "all",
+        )
+
+    def test_export_metric_scope_detects_selected_metric_subset(self):
+        self.assertEqual(
+            export_metric_scope(
+                "cytoplasmic_intensity,red_intensity_1,puncta_distance",
+                columns_present=True,
+            ),
             "selected",
         )
+
+    def test_export_metric_scope_uses_existing_validation(self):
+        with self.assertRaises(ExportColumnSelectionError):
+            export_metric_scope("cell_id", columns_present=True)
+        with self.assertRaises(ExportColumnSelectionError):
+            export_metric_scope("unknown_field", columns_present=True)
 
     def test_valid_columns_are_returned_in_table_order(self):
         selected = normalize_export_columns(

--- a/cytocv/core/tests/test_stat_export_selection.py
+++ b/cytocv/core/tests/test_stat_export_selection.py
@@ -1,14 +1,57 @@
-from django.test import SimpleTestCase
+from datetime import datetime
 
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from core.services.export_filenames import (
+    build_statistics_export_filename,
+    export_scope_for_selection,
+)
 from core.services.stat_export_selection import (
     ExportColumnSelectionError,
     export_exclude_columns,
+    export_included_columns,
     export_selection_config,
     normalize_export_columns,
 )
 
 
 class StatExportSelectionTests(SimpleTestCase):
+    def test_statistics_export_filename_uses_scope_count_timestamp_and_extension(self):
+        exported_at = timezone.make_aware(
+            datetime(2026, 5, 10, 18, 34),
+            timezone.get_current_timezone(),
+        )
+
+        self.assertEqual(
+            build_statistics_export_filename(
+                scope="selected",
+                file_count=8,
+                export_format="csv",
+                exported_at=exported_at,
+            ),
+            "cytocv_selected_cell-metrics_8files_2026-05-10_1834.csv",
+        )
+        self.assertEqual(
+            build_statistics_export_filename(
+                scope="all",
+                file_count=24,
+                export_format="xlsx",
+                exported_at=exported_at,
+            ),
+            "cytocv_all_cell-metrics_24files_2026-05-10_1834.xlsx",
+        )
+
+    def test_export_scope_for_selection_distinguishes_all_from_selected(self):
+        self.assertEqual(
+            export_scope_for_selection(selected_count=24, available_count=24),
+            "all",
+        )
+        self.assertEqual(
+            export_scope_for_selection(selected_count=8, available_count=24),
+            "selected",
+        )
+
     def test_valid_columns_are_returned_in_table_order(self):
         selected = normalize_export_columns(
             "cytoplasmic_intensity,puncta_distance,red_intensity_1"
@@ -56,6 +99,17 @@ class StatExportSelectionTests(SimpleTestCase):
     def test_cell_id_is_not_user_selectable(self):
         with self.assertRaises(ExportColumnSelectionError):
             normalize_export_columns("cell_id")
+
+    def test_included_columns_always_keep_cell_id_first(self):
+        included_columns = export_included_columns(
+            "red_intensity_1,puncta_distance",
+            columns_present=True,
+        )
+
+        self.assertEqual(
+            included_columns,
+            ("cell_id", "puncta_distance", "red_intensity_1"),
+        )
 
     def test_exclude_columns_excludes_every_unselected_stat_field(self):
         exclude_columns = export_exclude_columns(

--- a/cytocv/core/views/display.py
+++ b/cytocv/core/views/display.py
@@ -41,6 +41,15 @@ from core.services.artifact_storage import (
 )
 from core.services.cell_deletion import delete_multiple_cells, delete_single_cell
 from core.services.cell_statistics_payload import serialize_cell_statistics_payload
+from core.services.combined_stat_export import (
+    CombinedStatisticsExportError,
+    StatisticsExportFile,
+    build_combined_statistics_export_response,
+)
+from core.services.export_filenames import (
+    build_statistics_export_filename,
+    export_scope_for_selection,
+)
 from core.services.main_image_urls import build_main_image_paths
 from core.services.overlay_rendering import build_overlay_image_url, overlay_image_available
 from core.services.puncta_line_mode import VALID_PUNCTA_LINE_MODES
@@ -88,17 +97,6 @@ def _sanitize_for_json(value):
     if isinstance(value, (list, tuple, set)):
         return [_sanitize_for_json(item) for item in value]
     return value
-
-
-def _build_export_download_name(raw_name, export_format, fallback):
-    stem = Path(str(raw_name or "").strip()).stem
-    if not stem:
-        stem = fallback
-    # Keep the uploaded name visible while avoiding header-breaking characters.
-    stem = re.sub(r"[\\/\r\n\t]+", "_", stem).strip()
-    if not stem:
-        stem = fallback
-    return f"{stem}.{export_format}"
 
 
 def _scan_output_frames(uuid: str):
@@ -363,10 +361,13 @@ def display(request, uuids):
                     exclude_columns=exclude_columns,
                 )
                 return exporter.response(
-                    _build_export_download_name(
-                        image_name,
-                        export_format,
-                        fallback="table",
+                    build_statistics_export_filename(
+                        scope=export_scope_for_selection(
+                            selected_count=1,
+                            available_count=len(uuid_list),
+                        ),
+                        file_count=1,
+                        export_format=export_format,
                     )
                 )
 
@@ -724,6 +725,95 @@ def sync_display_file_selection(request):
             "storage_percentage": round(min(100, max(0, (used_storage / total_storage) * 100)), 2),
         }
     )
+
+
+@require_POST
+def export_display_files(request):
+    """Download one combined statistics export for selected visible files."""
+
+    try:
+        payload = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return JsonResponse(
+            {"error": "Your request could not be processed. Please try again."},
+            status=400,
+        )
+
+    visible_uuids = _normalize_uuid_list(payload.get("visible_uuids", []))
+    requested_uuids = _normalize_uuid_list(payload.get("uuids", []))
+    if not requested_uuids:
+        return JsonResponse({"error": "Select at least one file to continue."}, status=400)
+    if not visible_uuids:
+        return JsonResponse(
+            {"error": "Visible files are no longer available. Refresh and try again."},
+            status=400,
+        )
+
+    visible_set = set(visible_uuids)
+    selected_set = set(requested_uuids)
+    if not selected_set.issubset(visible_set):
+        return JsonResponse(
+            {"error": "One or more selected files are no longer available. Refresh and try again."},
+            status=403,
+        )
+    ordered_uuids = [uuid for uuid in visible_uuids if uuid in selected_set]
+
+    uploaded_map = {
+        str(item.uuid): item
+        for item in UploadedImage.objects.filter(
+            user=request.user,
+            uuid__in=ordered_uuids,
+        )
+    }
+    segmented_map = {
+        str(item.UUID): item
+        for item in SegmentedImage.objects.filter(UUID__in=ordered_uuids)
+    }
+    if (
+        len(uploaded_map) != len(set(ordered_uuids))
+        or len(segmented_map) != len(set(ordered_uuids))
+    ):
+        return JsonResponse(
+            {"error": "One or more selected files are no longer available. Refresh and try again."},
+            status=403,
+        )
+
+    sources = []
+    for uuid in ordered_uuids:
+        uploaded = uploaded_map[uuid]
+        segmented = segmented_map[uuid]
+        if not _can_access_display_uuid(request, uploaded, segmented):
+            return JsonResponse(
+                {"error": "One or more selected files are no longer available. Refresh and try again."},
+                status=403,
+            )
+        sources.append(
+            StatisticsExportFile(
+                uuid=uuid,
+                file_name=uploaded.name,
+                segmented_image=segmented,
+                scale_info=uploaded.scale_info,
+            )
+        )
+
+    preferences = get_user_preferences(request.user)
+    default_manual_scale = (
+        preferences.get("experiment_defaults", {}).get("microns_per_pixel", 0.1)
+    )
+    try:
+        return build_combined_statistics_export_response(
+            sources,
+            export_format=str(payload.get("_export") or ""),
+            raw_columns=payload.get("_columns"),
+            spatial_stats_unit=str(payload.get("_unit") or "px"),
+            default_manual_scale=default_manual_scale,
+            export_scope=export_scope_for_selection(
+                selected_count=len(selected_set),
+                available_count=len(visible_set),
+            ),
+        )
+    except (CombinedStatisticsExportError, ExportColumnSelectionError) as exc:
+        return JsonResponse({"error": str(exc)}, status=400)
 
 
 def main_image_channel(request, uuid):

--- a/cytocv/core/views/display.py
+++ b/cytocv/core/views/display.py
@@ -48,7 +48,6 @@ from core.services.combined_stat_export import (
 )
 from core.services.export_filenames import (
     build_statistics_export_filename,
-    export_scope_for_selection,
 )
 from core.services.main_image_urls import build_main_image_paths
 from core.services.overlay_rendering import build_overlay_image_url, overlay_image_available
@@ -56,6 +55,7 @@ from core.services.puncta_line_mode import VALID_PUNCTA_LINE_MODES
 from core.services.stat_export_selection import (
     ExportColumnSelectionError,
     export_exclude_columns,
+    export_metric_scope,
     export_selection_config,
 )
 from core.scale import (
@@ -340,10 +340,16 @@ def display(request, uuids):
             export_format = request.GET.get('_export', None)
             export_unit = normalize_spatial_stats_unit(request.GET.get('_unit'), default="px")
             if TableExport.is_valid_format(export_format) and cell_table is not None:
+                raw_columns = request.GET.getlist("_columns")
+                columns_present = "_columns" in request.GET
                 try:
                     exclude_columns = export_exclude_columns(
-                        request.GET.getlist("_columns"),
-                        columns_present="_columns" in request.GET,
+                        raw_columns,
+                        columns_present=columns_present,
+                    )
+                    metric_scope = export_metric_scope(
+                        raw_columns,
+                        columns_present=columns_present,
                     )
                 except ExportColumnSelectionError as exc:
                     return HttpResponse(str(exc), status=400)
@@ -362,10 +368,7 @@ def display(request, uuids):
                 )
                 return exporter.response(
                     build_statistics_export_filename(
-                        scope=export_scope_for_selection(
-                            selected_count=1,
-                            available_count=len(uuid_list),
-                        ),
+                        scope=metric_scope,
                         file_count=1,
                         export_format=export_format,
                     )
@@ -807,10 +810,6 @@ def export_display_files(request):
             raw_columns=payload.get("_columns"),
             spatial_stats_unit=str(payload.get("_unit") or "px"),
             default_manual_scale=default_manual_scale,
-            export_scope=export_scope_for_selection(
-                selected_count=len(selected_set),
-                available_count=len(visible_set),
-            ),
         )
     except (CombinedStatisticsExportError, ExportColumnSelectionError) as exc:
         return JsonResponse({"error": str(exc)}, status=400)

--- a/cytocv/cytocv/urls.py
+++ b/cytocv/cytocv/urls.py
@@ -23,6 +23,7 @@ from accounts.views import (
     auth_login,
     auth_logout,
     dashboard_bulk_delete_view,
+    dashboard_bulk_export_view,
     dashboard_channel_visibility_view,
     dashboard_view,
     oauth_verification_status,
@@ -34,6 +35,7 @@ from core.views.display import (
     delete_cell_view,
     delete_cells_view,
     display,
+    export_display_files,
     main_image_channel,
     save_display_files,
     sync_display_file_selection,
@@ -89,6 +91,11 @@ urlpatterns = [
         'dashboard/files/delete/',
         login_required(dashboard_bulk_delete_view),
         name="dashboard_bulk_delete",
+    ),
+    path(
+        'dashboard/files/export/',
+        login_required(dashboard_bulk_export_view),
+        name="dashboard_bulk_export",
     ),
     path(
         'dashboard/preferences/channels/',
@@ -171,6 +178,11 @@ urlpatterns = [
         'experiment/display/files/sync-selection/',
         login_required(sync_display_file_selection),
         name='display_sync_file_selection',
+    ),
+    path(
+        'experiment/display/files/export/',
+        login_required(export_display_files),
+        name='display_export_files',
     ),
     path(
         'experiment/<str:uuid>/main-channel/',

--- a/cytocv/templates/dashboard.html
+++ b/cytocv/templates/dashboard.html
@@ -5,7 +5,7 @@
 
 {% block head %}
     <script src="{% static 'js/viewer_overlay_prefetch.js' %}"></script>
-    <script src="{% static 'js/export_selection_modal.js' %}"></script>
+    <script src="{% static 'js/export_selection_modal.js' %}?v=selectable-export-format-pill-state"></script>
     <style>
         .channel-chip.dic { background-color: black; }
         .channel-chip.blue { background-color: blue; }
@@ -896,13 +896,14 @@
             min-width: 0;
         }
         .sidebar.select-mode .selection-extra {
-            max-width: 240px;
+            max-width: 330px;
             opacity: 1;
             transform: translateX(0);
         }
         .select-mode-btn,
         .select-all-btn,
         .delete-selected-btn,
+        .download-selected-btn,
         .channel-visibility-btn,
         .scale-visibility-btn {
             border: 1px solid var(--panel-border);
@@ -931,7 +932,16 @@
             background: #911b25;
             border-color: #911b25;
         }
-        .delete-selected-btn:disabled {
+        .download-selected-btn {
+            background: var(--accent);
+            border-color: var(--accent);
+        }
+        .download-selected-btn:hover:not(:disabled) {
+            background: #0f70d8;
+            border-color: #0f70d8;
+        }
+        .delete-selected-btn:disabled,
+        .download-selected-btn:disabled {
             opacity: 0.45;
             cursor: not-allowed;
         }
@@ -1158,8 +1168,9 @@
         }
         .cell-select-toolbar {
             display: flex;
-            justify-content: flex-end;
+            justify-content: flex-start;
             align-items: center;
+            gap: 8px;
         }
         .cell-select-toggle-all {
             background: transparent;
@@ -1179,6 +1190,13 @@
             border-color: rgba(90, 170, 255, 0.6);
             color: #e8f1ff;
             outline: none;
+        }
+        .cell-select-toggle-all.active,
+        .cell-select-toggle-all[aria-pressed="true"] {
+            background-color: rgba(0, 123, 255, 0.18);
+            border-color: rgba(0, 123, 255, 0.72);
+            color: #ffffff;
+            box-shadow: inset 0 0 0 1px rgba(130, 190, 255, 0.22), var(--btn-shadow);
         }
         .cell-select-toggle-all:disabled {
             opacity: 0.5;
@@ -2096,6 +2114,15 @@
                     <div class="selection-extra">
                         <button class="select-all-btn" id="selectAllBtn" type="button">Select All</button>
                         <button class="delete-selected-btn" id="deleteSelectedBtn" type="button" disabled>Delete</button>
+                        <button
+                            class="download-selected-btn"
+                            id="downloadSelectedBtn"
+                            type="button"
+                            disabled
+                            title="Select files first."
+                        >
+                            Download
+                        </button>
                     </div>
                 </div>
                 <div class="visibility-controls">
@@ -2502,8 +2529,7 @@
                         </div>
                     </div>
                     <div class="export-buttons" id="exportButtons">
-                        <a class="export_btn" id="downloadCsvBtn" href="{% if table_uuid %}{% url 'dashboard' %}?file_uuid={{ table_uuid|urlencode }}&amp;_export=csv&amp;_unit={{ sidebar_spatial_stats_unit|urlencode }}{% else %}#{% endif %}">Download CSV</a>
-                        <a class="export_btn" id="downloadXlsxBtn" href="{% if table_uuid %}{% url 'dashboard' %}?file_uuid={{ table_uuid|urlencode }}&amp;_export=xlsx&amp;_unit={{ sidebar_spatial_stats_unit|urlencode }}{% else %}#{% endif %}">Download Excel</a>
+                        <a class="export_btn" id="downloadStatsBtn" href="{% if table_uuid %}{% url 'dashboard' %}?file_uuid={{ table_uuid|urlencode }}&amp;_export=csv&amp;_unit={{ sidebar_spatial_stats_unit|urlencode }}{% else %}#{% endif %}">Download Statistics</a>
                     </div>
 
                 </div>
@@ -2535,7 +2561,8 @@
                 <h3 id="selectCellsTitle">Select Cells</h3>
                 <p id="selectCellsMessage">Choose the cells to delete from this file.</p>
                 <div class="cell-select-toolbar">
-                    <button class="cell-select-toggle-all" id="selectCellsToggleAllBtn" type="button">Select all</button>
+                    <button class="cell-select-toggle-all" id="selectCellsToggleAllBtn" type="button">Select</button>
+                    <button class="cell-select-toggle-all" id="selectCellsClearBtn" type="button">Clear</button>
                 </div>
                 <div class="cell-select-list-box">
                     <ul class="cell-select-list" id="selectCellsList"></ul>
@@ -3514,23 +3541,19 @@
                 return;
             }
 
-            const csvBtn = document.getElementById('downloadCsvBtn');
-            const xlsxBtn = document.getElementById('downloadXlsxBtn');
-            if (csvBtn) {
-                csvBtn.href = buildDashboardExportUrl(fileUUID, 'csv');
-            }
-            if (xlsxBtn) {
-                xlsxBtn.href = buildDashboardExportUrl(fileUUID, 'xlsx');
+            const statsBtn = document.getElementById('downloadStatsBtn');
+            if (statsBtn) {
+                statsBtn.href = buildDashboardExportUrl(fileUUID, 'csv');
             }
         }
 
+        let dashboardExportSelectionController = null;
         if (window.CytoCVExportSelection) {
-            window.CytoCVExportSelection.init({
+            dashboardExportSelectionController = window.CytoCVExportSelection.init({
                 configScriptId: 'exportSelectionConfig',
                 modalId: 'exportSelectionBackdrop',
                 triggerFormats: {
-                    downloadCsvBtn: 'csv',
-                    downloadXlsxBtn: 'xlsx',
+                    downloadStatsBtn: 'csv',
                 },
                 getCurrentFileContext: () => {
                     const fileUUID = fileUUIDs[currentFileIndex];
@@ -3540,7 +3563,22 @@
                     };
                 },
                 buildExportUrl: buildDashboardExportUrl,
+                bulkExportUrl: '/dashboard/files/export/',
+                getSelectableFiles: () => fileUUIDs.map((fileUUID) => ({
+                    id: fileUUID,
+                    label: filesData[fileUUID] && filesData[fileUUID].Image_Name
+                        ? filesData[fileUUID].Image_Name
+                        : fileUUID,
+                    fileData: filesData[fileUUID] || null,
+                })),
+                buildBulkExportPayload: ({ fileIds, format, columns }) => ({
+                    uuids: fileIds,
+                    _export: format,
+                    _columns: columns,
+                    _unit: getCurrentSpatialUnit(),
+                }),
             });
+            window.dashboardExportSelectionController = dashboardExportSelectionController;
         }
 
         function updateTableState(fileUUID, fileData) {
@@ -4415,6 +4453,7 @@
             const selectCellsBackBtn = document.getElementById('selectCellsBackBtn');
             const selectCellsDeleteBtn = document.getElementById('selectCellsDeleteBtn');
             const selectCellsToggleAllBtn = document.getElementById('selectCellsToggleAllBtn');
+            const selectCellsClearBtn = document.getElementById('selectCellsClearBtn');
             const confirmCellsBackBtn = document.getElementById('confirmCellsBackBtn');
             const confirmCellsDeleteBtn = document.getElementById('confirmCellsDeleteBtn');
             const confirmCellsMessage = document.getElementById('confirmCellsMessage');
@@ -4887,12 +4926,25 @@
                 const checkboxes = getSelectCellsCheckboxes();
                 if (!checkboxes.length) {
                     selectCellsToggleAllBtn.disabled = true;
-                    selectCellsToggleAllBtn.textContent = 'Select all';
+                    selectCellsToggleAllBtn.classList.remove('active');
+                    selectCellsToggleAllBtn.setAttribute('aria-pressed', 'false');
+                    if (selectCellsClearBtn) {
+                        selectCellsClearBtn.disabled = true;
+                        selectCellsClearBtn.classList.remove('active');
+                        selectCellsClearBtn.setAttribute('aria-pressed', 'false');
+                    }
                     return;
                 }
                 selectCellsToggleAllBtn.disabled = false;
+                if (selectCellsClearBtn) selectCellsClearBtn.disabled = false;
                 const allChecked = checkboxes.every((cb) => cb.checked);
-                selectCellsToggleAllBtn.textContent = allChecked ? 'Deselect all' : 'Select all';
+                const noneChecked = checkboxes.every((cb) => !cb.checked);
+                selectCellsToggleAllBtn.classList.toggle('active', allChecked);
+                selectCellsToggleAllBtn.setAttribute('aria-pressed', allChecked ? 'true' : 'false');
+                if (selectCellsClearBtn) {
+                    selectCellsClearBtn.classList.toggle('active', noneChecked);
+                    selectCellsClearBtn.setAttribute('aria-pressed', noneChecked ? 'true' : 'false');
+                }
             }
 
             function renderCellListItem(list, cellId, { selectable = false } = {}) {
@@ -5065,10 +5117,20 @@
                 selectCellsToggleAllBtn.addEventListener('click', () => {
                     const checkboxes = getSelectCellsCheckboxes();
                     if (!checkboxes.length) return;
-                    const target = !checkboxes.every((cb) => cb.checked);
                     checkboxes.forEach((cb) => {
-                        if (cb.checked === target) return;
-                        cb.checked = target;
+                        if (cb.checked) return;
+                        cb.checked = true;
+                        cb.dispatchEvent(new Event('change'));
+                    });
+                });
+            }
+            if (selectCellsClearBtn) {
+                selectCellsClearBtn.addEventListener('click', () => {
+                    const checkboxes = getSelectCellsCheckboxes();
+                    if (!checkboxes.length) return;
+                    checkboxes.forEach((cb) => {
+                        if (!cb.checked) return;
+                        cb.checked = false;
                         cb.dispatchEvent(new Event('change'));
                     });
                 });
@@ -5320,6 +5382,7 @@
             const selectModeBtn = document.getElementById('selectModeBtn');
             const selectAllBtn = document.getElementById('selectAllBtn');
             const deleteSelectedBtn = document.getElementById('deleteSelectedBtn');
+            const downloadSelectedBtn = document.getElementById('downloadSelectedBtn');
             const channelVisibilityBtn = document.getElementById('toggleChannelVisibilityBtn');
             const scaleVisibilityBtn = document.getElementById('toggleScaleVisibilityBtn');
             const deleteBackdrop = document.getElementById('deleteFilesBackdrop');
@@ -5328,7 +5391,10 @@
             const cancelDeleteFilesBtn = document.getElementById('cancelDeleteFilesBtn');
             const confirmDeleteFilesBtn = document.getElementById('confirmDeleteFilesBtn');
 
-            if (!sidebar || !selectModeBtn || !selectAllBtn || !deleteSelectedBtn || !channelVisibilityBtn || !scaleVisibilityBtn) {
+            if (
+                !sidebar || !selectModeBtn || !selectAllBtn || !deleteSelectedBtn
+                || !downloadSelectedBtn || !channelVisibilityBtn || !scaleVisibilityBtn
+            ) {
                 return;
             }
 
@@ -5373,6 +5439,10 @@
             function syncSelectionUI() {
                 fileItems.forEach((item) => item.classList.toggle('selected', selectedFileUUIDs.has(item.dataset.uuid)));
                 deleteSelectedBtn.disabled = selectedFileUUIDs.size === 0;
+                downloadSelectedBtn.disabled = selectedFileUUIDs.size === 0;
+                downloadSelectedBtn.title = downloadSelectedBtn.disabled
+                    ? 'Select files first.'
+                    : 'Download selected files.';
             }
 
             function setSelectMode(enabled) {
@@ -5499,6 +5569,14 @@
             selectModeBtn.addEventListener('click', () => setSelectMode(!selectModeActive));
             selectAllBtn.addEventListener('click', toggleSelectAll);
             deleteSelectedBtn.addEventListener('click', openDeleteModal);
+            downloadSelectedBtn.addEventListener('click', () => {
+                if (!window.dashboardExportSelectionController || selectedFileUUIDs.size === 0) {
+                    return;
+                }
+                window.dashboardExportSelectionController.openFiles(
+                    fileUUIDs.filter((uuid) => selectedFileUUIDs.has(uuid))
+                );
+            });
             channelVisibilityBtn.addEventListener('click', () => {
                 applyChannelVisibility(sidebar.classList.contains('channels-hidden'), true);
             });

--- a/cytocv/templates/dashboard.html
+++ b/cytocv/templates/dashboard.html
@@ -1260,13 +1260,14 @@
             color: inherit;
         }
         .cell-select-card.selected {
-            background-color: #007bff;
-            color: #fff;
-            border-color: rgba(90, 170, 255, 0.78);
-            box-shadow: 0 10px 24px rgba(0, 123, 255, 0.18);
+            background-color: var(--surface-muted);
+            color: inherit;
+            border-color: var(--panel-border);
+            box-shadow: none;
         }
         .cell-select-card.selected:hover {
-            background-color: #0056b3;
+            background-color: #3399ff;
+            color: #fff;
         }
         .cell-select-input {
             position: absolute;

--- a/cytocv/templates/display.html
+++ b/cytocv/templates/display.html
@@ -5,7 +5,7 @@
 
 {% block head %}
     <script src="{% static 'js/viewer_overlay_prefetch.js' %}"></script>
-    <script src="{% static 'js/export_selection_modal.js' %}"></script>
+    <script src="{% static 'js/export_selection_modal.js' %}?v=selectable-export-format-pill-state"></script>
     <style>
         .channel-chip.dic { background-color: black; }
         .channel-chip.blue { background-color: blue; }
@@ -384,13 +384,14 @@
             min-width: 0;
         }
         .sidebar.select-mode .selection-extra {
-            max-width: 340px;
+            max-width: 450px;
             opacity: 1;
             transform: translateX(0);
         }
         .select-mode-btn,
         .select-all-btn,
         .save-selected-btn,
+        .download-selected-btn,
         .channel-visibility-btn,
         .scale-visibility-btn {
             border: 1px solid var(--panel-border);
@@ -436,7 +437,12 @@
             background: var(--accent);
             border-color: var(--accent);
         }
-        .save-selected-btn:hover:not(:disabled) {
+        .download-selected-btn {
+            background: var(--accent);
+            border-color: var(--accent);
+        }
+        .save-selected-btn:hover:not(:disabled),
+        .download-selected-btn:hover:not(:disabled) {
             background: #0f70d8;
             border-color: #0f70d8;
         }
@@ -466,7 +472,8 @@
             background: #0f70d8;
             border-color: rgba(255, 255, 255, 0.4);
         }
-        .save-selected-btn:disabled {
+        .save-selected-btn:disabled,
+        .download-selected-btn:disabled {
             opacity: 0.45;
             cursor: not-allowed;
         }
@@ -1175,8 +1182,9 @@
         }
         .cell-select-toolbar {
             display: flex;
-            justify-content: flex-end;
+            justify-content: flex-start;
             align-items: center;
+            gap: 8px;
         }
         .cell-select-toggle-all {
             background: transparent;
@@ -1196,6 +1204,13 @@
             border-color: rgba(90, 170, 255, 0.6);
             color: #e8f1ff;
             outline: none;
+        }
+        .cell-select-toggle-all.active,
+        .cell-select-toggle-all[aria-pressed="true"] {
+            background-color: rgba(0, 123, 255, 0.18);
+            border-color: rgba(0, 123, 255, 0.72);
+            color: #ffffff;
+            box-shadow: inset 0 0 0 1px rgba(130, 190, 255, 0.22), var(--btn-shadow);
         }
         .cell-select-toggle-all:disabled {
             opacity: 0.5;
@@ -2050,12 +2065,21 @@
                             disabled
                             title="Selected files will be saved and unselected files will not be saved."
                         >
-                            <span>Save Selection</span>
+                            <span>Save</span>
                             <span
                                 class="selection-info-dot"
                                 data-info-text="Selected files will be saved and unselected files will not be saved."
                                 aria-label="Selected files will be saved and unselected files will not be saved."
                             >i</span>
+                        </button>
+                        <button
+                            class="download-selected-btn"
+                            id="downloadSelectedBtn"
+                            type="button"
+                            disabled
+                            title="Select files first."
+                        >
+                            Download
                         </button>
                     </div>
                 </div>
@@ -2470,8 +2494,7 @@
                     </div>
                     {% load export_url from django_tables2 %}
                     <div class="export-buttons" id="displayExportButtons">
-                        <a class="export_btn" id="displayDownloadCsvBtn" href="{% export_url 'csv' %}">Download CSV</a>
-                        <a class="export_btn" id="displayDownloadXlsxBtn" href="{% export_url 'xlsx' %}">Download Excel</a>
+                        <a class="export_btn" id="displayDownloadStatsBtn" href="{% export_url 'csv' %}">Download Statistics</a>
                     </div>
 
                 </div>
@@ -2496,7 +2519,8 @@
                 <h3 id="selectCellsTitle">Select Cells</h3>
                 <p id="selectCellsMessage">Choose the cells to delete from this file.</p>
                 <div class="cell-select-toolbar">
-                    <button class="cell-select-toggle-all" id="selectCellsToggleAllBtn" type="button">Select all</button>
+                    <button class="cell-select-toggle-all" id="selectCellsToggleAllBtn" type="button">Select</button>
+                    <button class="cell-select-toggle-all" id="selectCellsClearBtn" type="button">Clear</button>
                 </div>
                 <div class="cell-select-list-box">
                     <ul class="cell-select-list" id="selectCellsList"></ul>
@@ -3784,23 +3808,19 @@
                 return;
             }
 
-            const csvBtn = document.getElementById('displayDownloadCsvBtn');
-            const xlsxBtn = document.getElementById('displayDownloadXlsxBtn');
-            if (csvBtn) {
-                csvBtn.href = buildDisplayExportUrl(fileUUID, 'csv');
-            }
-            if (xlsxBtn) {
-                xlsxBtn.href = buildDisplayExportUrl(fileUUID, 'xlsx');
+            const statsBtn = document.getElementById('displayDownloadStatsBtn');
+            if (statsBtn) {
+                statsBtn.href = buildDisplayExportUrl(fileUUID, 'csv');
             }
         }
 
+        let displayExportSelectionController = null;
         if (window.CytoCVExportSelection) {
-            window.CytoCVExportSelection.init({
+            displayExportSelectionController = window.CytoCVExportSelection.init({
                 configScriptId: 'exportSelectionConfig',
                 modalId: 'exportSelectionBackdrop',
                 triggerFormats: {
-                    displayDownloadCsvBtn: 'csv',
-                    displayDownloadXlsxBtn: 'xlsx',
+                    displayDownloadStatsBtn: 'csv',
                 },
                 getCurrentFileContext: () => {
                     const fileUUID = fileUUIDs[currentFileIndex];
@@ -3810,7 +3830,23 @@
                     };
                 },
                 buildExportUrl: buildDisplayExportUrl,
+                bulkExportUrl: '/experiment/display/files/export/',
+                getSelectableFiles: () => fileUUIDs.map((fileUUID) => ({
+                    id: fileUUID,
+                    label: filesData[fileUUID] && filesData[fileUUID].Image_Name
+                        ? filesData[fileUUID].Image_Name
+                        : fileUUID,
+                    fileData: filesData[fileUUID] || null,
+                })),
+                buildBulkExportPayload: ({ fileIds, format, columns }) => ({
+                    visible_uuids: Array.from(fileUUIDs),
+                    uuids: fileIds,
+                    _export: format,
+                    _columns: columns,
+                    _unit: getCurrentSpatialUnit(),
+                }),
             });
+            window.displayExportSelectionController = displayExportSelectionController;
         }
 
         function updateTableState(fileUUID, fileData) {
@@ -4189,6 +4225,7 @@
         const selectModeBtn = document.getElementById('selectModeBtn');
         const selectAllBtn = document.getElementById('selectAllBtn');
         const saveSelectedBtn = document.getElementById('saveSelectedBtn');
+        const downloadSelectedBtn = document.getElementById('downloadSelectedBtn');
         const channelVisibilityBtn = document.getElementById('toggleChannelVisibilityBtn');
         const scaleVisibilityBtn = document.getElementById('toggleScaleVisibilityBtn');
         const saveBackdrop = document.getElementById('saveFilesBackdrop');
@@ -4352,6 +4389,12 @@
 
             selectAllBtn.disabled = !hasFiles;
             saveSelectedBtn.disabled = !selectModeActive || !hasFiles || !hasChanges;
+            if (downloadSelectedBtn) {
+                downloadSelectedBtn.disabled = !selectModeActive || !hasFiles || selectedFileUUIDs.size === 0;
+                downloadSelectedBtn.title = downloadSelectedBtn.disabled
+                    ? 'Select files first.'
+                    : 'Download selected files.';
+            }
             if (!selectModeActive) {
                 saveSelectedBtn.title = 'Select files first.';
             } else if (!hasChanges) {
@@ -4653,6 +4696,16 @@
         selectModeBtn.addEventListener('click', () => setSelectMode(!selectModeActive));
         selectAllBtn.addEventListener('click', toggleSelectAll);
         saveSelectedBtn.addEventListener('click', openSaveModal);
+        if (downloadSelectedBtn) {
+            downloadSelectedBtn.addEventListener('click', () => {
+                if (!window.displayExportSelectionController || selectedFileUUIDs.size === 0) {
+                    return;
+                }
+                window.displayExportSelectionController.openFiles(
+                    fileUUIDs.filter((uuid) => selectedFileUUIDs.has(uuid))
+                );
+            });
+        }
         channelVisibilityBtn.addEventListener('click', () => {
             applyChannelVisibility(sidebar.classList.contains('channels-hidden'), true);
         });
@@ -4788,6 +4841,7 @@
             const selectCellsBackBtn = document.getElementById('selectCellsBackBtn');
             const selectCellsDeleteBtn = document.getElementById('selectCellsDeleteBtn');
             const selectCellsToggleAllBtn = document.getElementById('selectCellsToggleAllBtn');
+            const selectCellsClearBtn = document.getElementById('selectCellsClearBtn');
             const confirmCellsBackBtn = document.getElementById('confirmCellsBackBtn');
             const confirmCellsDeleteBtn = document.getElementById('confirmCellsDeleteBtn');
             const confirmCellsMessage = document.getElementById('confirmCellsMessage');
@@ -5260,12 +5314,25 @@
                 const checkboxes = getSelectCellsCheckboxes();
                 if (!checkboxes.length) {
                     selectCellsToggleAllBtn.disabled = true;
-                    selectCellsToggleAllBtn.textContent = 'Select all';
+                    selectCellsToggleAllBtn.classList.remove('active');
+                    selectCellsToggleAllBtn.setAttribute('aria-pressed', 'false');
+                    if (selectCellsClearBtn) {
+                        selectCellsClearBtn.disabled = true;
+                        selectCellsClearBtn.classList.remove('active');
+                        selectCellsClearBtn.setAttribute('aria-pressed', 'false');
+                    }
                     return;
                 }
                 selectCellsToggleAllBtn.disabled = false;
+                if (selectCellsClearBtn) selectCellsClearBtn.disabled = false;
                 const allChecked = checkboxes.every((cb) => cb.checked);
-                selectCellsToggleAllBtn.textContent = allChecked ? 'Deselect all' : 'Select all';
+                const noneChecked = checkboxes.every((cb) => !cb.checked);
+                selectCellsToggleAllBtn.classList.toggle('active', allChecked);
+                selectCellsToggleAllBtn.setAttribute('aria-pressed', allChecked ? 'true' : 'false');
+                if (selectCellsClearBtn) {
+                    selectCellsClearBtn.classList.toggle('active', noneChecked);
+                    selectCellsClearBtn.setAttribute('aria-pressed', noneChecked ? 'true' : 'false');
+                }
             }
 
             function renderCellListItem(list, cellId, { selectable = false } = {}) {
@@ -5438,10 +5505,20 @@
                 selectCellsToggleAllBtn.addEventListener('click', () => {
                     const checkboxes = getSelectCellsCheckboxes();
                     if (!checkboxes.length) return;
-                    const target = !checkboxes.every((cb) => cb.checked);
                     checkboxes.forEach((cb) => {
-                        if (cb.checked === target) return;
-                        cb.checked = target;
+                        if (cb.checked) return;
+                        cb.checked = true;
+                        cb.dispatchEvent(new Event('change'));
+                    });
+                });
+            }
+            if (selectCellsClearBtn) {
+                selectCellsClearBtn.addEventListener('click', () => {
+                    const checkboxes = getSelectCellsCheckboxes();
+                    if (!checkboxes.length) return;
+                    checkboxes.forEach((cb) => {
+                        if (!cb.checked) return;
+                        cb.checked = false;
                         cb.dispatchEvent(new Event('change'));
                     });
                 });

--- a/cytocv/templates/display.html
+++ b/cytocv/templates/display.html
@@ -1274,13 +1274,14 @@
             color: inherit;
         }
         .cell-select-card.selected {
-            background-color: #007bff;
-            color: #fff;
-            border-color: rgba(90, 170, 255, 0.78);
-            box-shadow: 0 10px 24px rgba(0, 123, 255, 0.18);
+            background-color: var(--surface-muted);
+            color: inherit;
+            border-color: var(--panel-border);
+            box-shadow: none;
         }
         .cell-select-card.selected:hover {
-            background-color: #0056b3;
+            background-color: #3399ff;
+            color: #fff;
         }
         .cell-select-input {
             position: absolute;

--- a/cytocv/templates/form/experiment.html
+++ b/cytocv/templates/form/experiment.html
@@ -2272,9 +2272,9 @@
         punctaContourIntensityEnabled: true,
         alternateNucleusDetectionEnabled: false,
         greenDotSplitEnabled: true,
-        greenDotSplitMode: 'balanced',
+        greenDotSplitMode: 'aggressive',
         redDotSplitEnabled: true,
-        redDotSplitMode: 'balanced',
+        redDotSplitMode: 'aggressive',
         punctaLineMode: 'red_puncta',
         nuclearCellPairMode: 'green_nucleus',
         greenContourFilterEnabled: false,
@@ -2333,11 +2333,11 @@
     let activeInfoAnchor = null;
 
     function normalizeGreenDotSplitMode(value) {
-        return value === 'aggressive' ? 'aggressive' : 'balanced';
+        return value === 'balanced' ? 'balanced' : 'aggressive';
     }
 
     function normalizeRedDotSplitMode(value) {
-        return value === 'aggressive' ? 'aggressive' : 'balanced';
+        return value === 'balanced' ? 'balanced' : 'aggressive';
     }
 
     function normalizeDotSplitTarget(value) {

--- a/cytocv/templates/partials/export_selection_modal.html
+++ b/cytocv/templates/partials/export_selection_modal.html
@@ -20,17 +20,17 @@
     }
     .export-selection-modal {
         width: min(560px, 94vw);
-        max-height: min(720px, 92vh);
+        height: min(720px, calc(100vh - 24px));
+        max-height: calc(100vh - 24px);
         background: var(--popup-surface-bg);
         border: 1px solid var(--popup-surface-border);
         border-radius: 14px;
         box-shadow: var(--popup-surface-shadow);
         backdrop-filter: var(--popup-surface-filter);
         -webkit-backdrop-filter: var(--popup-surface-filter);
+        box-sizing: border-box;
         padding: 18px;
-        display: grid;
-        grid-template-rows: auto auto minmax(0, 1fr) auto;
-        gap: 12px;
+        overflow: hidden;
     }
     .export-selection-modal.modal-enter {
         animation: settingsModalIn 170ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
@@ -48,11 +48,131 @@
         font-size: 13px;
         line-height: 1.35;
     }
+    .export-selection-view {
+        display: grid;
+        grid-template-rows: auto auto minmax(0, 1fr) auto;
+        gap: 12px;
+        height: 100%;
+        min-height: 0;
+        min-width: 0;
+    }
+    .export-selection-view.has-status-row {
+        grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+    }
+    .export-selection-view[hidden] {
+        display: none !important;
+    }
+    .export-selection-view.anim-enter-forward {
+        animation: exportSelectionEnterForward 150ms ease-out both;
+    }
+    .export-selection-view.anim-enter-backward {
+        animation: exportSelectionEnterBackward 150ms ease-out both;
+    }
+    .export-selection-view.anim-exit-forward {
+        animation: exportSelectionExitForward 120ms ease-in both;
+        pointer-events: none;
+    }
+    .export-selection-view.anim-exit-backward {
+        animation: exportSelectionExitBackward 120ms ease-in both;
+        pointer-events: none;
+    }
     .export-selection-toolbar {
         display: flex;
         align-items: center;
         gap: 8px;
         flex-wrap: wrap;
+    }
+    .export-format-toggle {
+        position: relative;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        align-items: center;
+        flex: 0 0 auto;
+        min-width: 110px;
+        border: none;
+        border-radius: 999px;
+        background: transparent;
+        overflow: hidden;
+    }
+    .export-format-control {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        min-width: 0;
+        border: 1px solid var(--popup-secondary-button-border);
+        border-radius: 8px;
+        background: var(--popup-secondary-button-bg);
+        padding: 2px 4px 2px 10px;
+    }
+    .export-format-label {
+        color: rgba(255, 255, 255, 0.82);
+        font-size: 12px;
+        font-weight: 600;
+        line-height: 1;
+        white-space: nowrap;
+    }
+    .export-format-toggle[data-active-format="xlsx"] .export-format-indicator {
+        left: calc(50% + 1px);
+    }
+    .export-format-indicator {
+        position: absolute;
+        top: 1px;
+        bottom: 1px;
+        left: 1px;
+        width: calc(50% - 2px);
+        border-radius: 999px;
+        background: #007bff;
+        transition: left 0.25s ease;
+        pointer-events: none;
+        z-index: 0;
+    }
+    .export-selection-modal .export-format-btn {
+        position: relative;
+        z-index: 1;
+        border: none;
+        border-radius: 999px;
+        background: transparent !important;
+        background-color: transparent !important;
+        box-shadow: none !important;
+        filter: none !important;
+        color: rgba(255, 255, 255, 0.55);
+        cursor: pointer;
+        font-size: 12px;
+        font-weight: 700;
+        line-height: 1;
+        padding: 6px 14px;
+        text-align: center;
+        transition: color 0.25s ease;
+    }
+    .export-selection-modal .export-format-btn:hover,
+    .export-selection-modal .export-format-btn:focus-visible,
+    .export-selection-modal .export-format-btn:active {
+        color: rgba(255, 255, 255, 0.85);
+        background: transparent !important;
+        background-color: transparent !important;
+        box-shadow: none !important;
+        filter: none !important;
+        outline: none;
+    }
+    .export-selection-modal .export-format-btn.active,
+    .export-selection-modal .export-format-btn[aria-pressed="true"] {
+        background: transparent !important;
+        background-color: transparent !important;
+        box-shadow: none !important;
+        filter: none !important;
+        color: #ffffff;
+    }
+    .export-selection-modal .export-format-btn.active:hover,
+    .export-selection-modal .export-format-btn[aria-pressed="true"]:hover,
+    .export-selection-modal .export-format-btn.active:focus-visible,
+    .export-selection-modal .export-format-btn[aria-pressed="true"]:focus-visible,
+    .export-selection-modal .export-format-btn.active:active,
+    .export-selection-modal .export-format-btn[aria-pressed="true"]:active {
+        background: transparent !important;
+        background-color: transparent !important;
+        box-shadow: none !important;
+        filter: none !important;
+        color: #ffffff;
     }
     .export-selection-list-box {
         border: 1px solid var(--panel-border);
@@ -60,7 +180,32 @@
         background: var(--surface-muted-alt);
         overflow-y: auto;
         padding: 10px;
+        min-height: 0;
         scrollbar-color: #7f7f7f transparent;
+        scrollbar-width: thin;
+    }
+    .export-selection-list-box::-webkit-scrollbar {
+        width: 10px;
+    }
+    .export-selection-list-box::-webkit-scrollbar-track {
+        background: transparent;
+    }
+    .export-selection-list-box::-webkit-scrollbar-thumb {
+        background: rgba(155, 166, 180, 0.62);
+        border: 2px solid transparent;
+        border-radius: 999px;
+        background-clip: padding-box;
+    }
+    .export-selection-list-box::-webkit-scrollbar-thumb:hover {
+        background: rgba(180, 190, 204, 0.82);
+        border: 2px solid transparent;
+        background-clip: padding-box;
+    }
+    #exportFileSelectionList.export-selection-list-box,
+    #exportSelectionList.export-selection-list-box {
+        background: transparent;
+        border: none;
+        padding: 0;
     }
     .export-selection-group {
         display: grid;
@@ -72,23 +217,41 @@
         border-top: 1px solid var(--panel-border);
     }
     .export-selection-group-title {
-        color: #f0f4ff;
-        font-size: 12px;
+        color: #ffffff;
+        font-size: 13px;
         font-weight: 700;
+        line-height: 1.25;
+        padding: 0;
     }
     .export-selection-row {
         display: grid;
         grid-template-columns: minmax(0, 1fr) auto;
         align-items: center;
         gap: 12px;
-        border: 1px solid rgba(var(--glass-border-rgb), 0.22);
         border-radius: 8px;
-        background: rgba(18, 28, 40, 0.42);
         padding: 8px 10px;
         cursor: pointer;
     }
-    .export-selection-row:hover {
-        background: rgba(36, 54, 76, 0.66);
+    .export-selection-row.stat-export-row {
+        border: 1px solid var(--settings-module-border);
+        background: var(--settings-module-bg);
+        transition: background-color 0.2s ease, border-color 0.2s ease;
+    }
+    .export-selection-row.stat-export-row:hover {
+        background: var(--surface-hover-strong);
+    }
+    .export-selection-row.file-export-row {
+        display: flex;
+        justify-content: space-between;
+        gap: 8px;
+        background: var(--surface-muted);
+        border: 1px solid var(--panel-border);
+        margin-top: 8px;
+        border-radius: 10px;
+        font-size: 13px;
+    }
+    .export-selection-row.file-export-row:hover {
+        background: var(--surface-hover-strong);
     }
     .export-selection-row-text {
         color: #f0f4ff;
@@ -97,11 +260,19 @@
         min-width: 0;
         overflow-wrap: anywhere;
     }
+    .file-export-row .export-selection-row-text {
+        flex: 1 1 auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 13px;
+    }
     .export-selection-row input {
         width: 18px;
         height: 18px;
         accent-color: var(--accent);
         justify-self: end;
+        flex: 0 0 auto;
     }
     .export-selection-actions {
         display: flex;
@@ -109,6 +280,17 @@
         align-items: center;
         gap: 10px;
         flex-wrap: wrap;
+    }
+    .export-selection-actions-right {
+        display: inline-flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 10px;
+        margin-left: auto;
+        flex-wrap: wrap;
+    }
+    .export-selection-actions-right[hidden] {
+        display: none !important;
     }
     .export-selection-btn {
         display: inline-flex;
@@ -144,18 +326,13 @@
         color: #ffffff;
         box-shadow: inset 0 0 0 1px rgba(130, 190, 255, 0.22), var(--btn-shadow);
     }
-    .export-selection-btn.active:not(.confirm)::before,
-    .export-selection-btn[aria-pressed="true"]:not(.confirm)::before {
-        content: "\2713";
-        font-size: 11px;
-        line-height: 1;
-        color: #8fc7ff;
-    }
     .export-selection-btn.cancel {
         margin-right: auto;
     }
-    .export-selection-btn.confirm {
+    .export-selection-btn.secondary-nav {
         margin-left: auto;
+    }
+    .export-selection-btn.confirm {
         background: var(--accent);
         border-color: var(--accent);
     }
@@ -170,10 +347,44 @@
         opacity: 0.52;
         cursor: not-allowed;
     }
-    .export-selection-count {
+    .export-selection-modal .export-selection-count {
         margin-left: auto;
         color: var(--muted);
         font-size: 12px;
+        font-weight: 600;
+        white-space: nowrap;
+        transition: color 0.18s ease;
+    }
+    .export-selection-modal .export-selection-count.has-selection,
+    .export-selection-modal .export-selection-count[data-selection-state="selected"] {
+        color: #61d394 !important;
+    }
+    .export-selection-modal .export-selection-count.is-empty,
+    .export-selection-modal .export-selection-count[data-selection-state="empty"] {
+        color: #f0c95a !important;
+    }
+    .export-selection-status-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        min-width: 0;
+    }
+    @keyframes exportSelectionEnterForward {
+        from { opacity: 0; transform: translateX(10px); }
+        to { opacity: 1; transform: translateX(0); }
+    }
+    @keyframes exportSelectionEnterBackward {
+        from { opacity: 0; transform: translateX(-10px); }
+        to { opacity: 1; transform: translateX(0); }
+    }
+    @keyframes exportSelectionExitForward {
+        from { opacity: 1; transform: translateX(0); }
+        to { opacity: 0; transform: translateX(-8px); }
+    }
+    @keyframes exportSelectionExitBackward {
+        from { opacity: 1; transform: translateX(0); }
+        to { opacity: 0; transform: translateX(8px); }
     }
     @media (max-width: 560px) {
         .export-selection-actions {
@@ -188,28 +399,66 @@
         .export-selection-backdrop.modal-enter,
         .export-selection-backdrop.modal-exit,
         .export-selection-modal.modal-enter,
-        .export-selection-modal.modal-exit {
+        .export-selection-modal.modal-exit,
+        .export-selection-view.anim-enter-forward,
+        .export-selection-view.anim-enter-backward,
+        .export-selection-view.anim-exit-forward,
+        .export-selection-view.anim-exit-backward {
             animation: none;
+        }
+        .export-selection-modal .export-selection-count {
+            transition: none;
         }
     }
 </style>
 
 <div class="export-selection-backdrop popup-backdrop" id="exportSelectionBackdrop" aria-hidden="true">
     <div class="export-selection-modal popup-surface" role="dialog" aria-modal="true" aria-labelledby="exportSelectionTitle">
-        <div>
-            <h3 id="exportSelectionTitle">Download statistics</h3>
-            <p id="exportSelectionMessage">Choose the statistics to include in this download.</p>
+        <div class="export-selection-view" id="exportFileSelectionView" hidden>
+            <div>
+                <h3 id="exportFileSelectionTitle">Download selected files</h3>
+                <p id="exportFileSelectionMessage">Choose the files to include in this download.</p>
+            </div>
+            <div class="export-selection-toolbar" aria-label="File export selection controls">
+                <button type="button" class="export-selection-btn" data-export-file-action="all">Select All</button>
+                <button type="button" class="export-selection-btn" data-export-file-action="clear">Clear</button>
+                <span class="export-selection-count" id="exportFileSelectionCount" aria-live="polite"></span>
+            </div>
+            <div class="export-selection-list-box" id="exportFileSelectionList" role="group" aria-label="Files available for export"></div>
+            <div class="export-selection-actions">
+                <button type="button" class="export-selection-btn cancel" id="backExportFileSelectionBtn">Cancel</button>
+                <button type="button" class="export-selection-btn confirm" id="continueExportFileSelectionBtn">Continue</button>
+            </div>
         </div>
-        <div class="export-selection-toolbar" aria-label="Export selection controls">
-            <button type="button" class="export-selection-btn" data-export-selection-action="calculated">Calculated</button>
-            <button type="button" class="export-selection-btn" data-export-selection-action="all">Select All</button>
-            <button type="button" class="export-selection-btn" data-export-selection-action="clear">Clear</button>
-            <span class="export-selection-count" id="exportSelectionCount" aria-live="polite"></span>
-        </div>
-        <div class="export-selection-list-box" id="exportSelectionList" role="group" aria-label="Statistics available for export"></div>
-        <div class="export-selection-actions">
-            <button type="button" class="export-selection-btn cancel" id="cancelExportSelectionBtn">Cancel</button>
-            <button type="button" class="export-selection-btn confirm" id="confirmExportSelectionBtn">Download</button>
+        <div class="export-selection-view has-status-row" id="exportStatSelectionView">
+            <div>
+                <h3 id="exportSelectionTitle">Download statistics</h3>
+                <p id="exportSelectionMessage">Choose the statistics to include in this download.</p>
+            </div>
+            <div class="export-selection-toolbar" aria-label="Export selection controls">
+                <button type="button" class="export-selection-btn" data-export-selection-action="calculated">Calculated</button>
+                <button type="button" class="export-selection-btn" data-export-selection-action="all">Select All</button>
+                <button type="button" class="export-selection-btn" data-export-selection-action="clear">Clear</button>
+                <button type="button" class="export-selection-btn secondary-nav" id="chooseExportFilesBtn">Edit files</button>
+            </div>
+            <div class="export-selection-status-row">
+                <div class="export-format-control">
+                    <span class="export-format-label">File Type:</span>
+                    <div class="export-format-toggle" id="exportFormatToggle" role="group" aria-label="Download format" data-active-format="csv">
+                        <div class="export-format-indicator" aria-hidden="true"></div>
+                        <button type="button" class="export-format-btn active" data-export-format="csv" aria-pressed="true">CSV</button>
+                        <button type="button" class="export-format-btn" data-export-format="xlsx" aria-pressed="false">Excel</button>
+                    </div>
+                </div>
+                <span class="export-selection-count" id="exportSelectionCount" aria-live="polite"></span>
+            </div>
+            <div class="export-selection-list-box" id="exportSelectionList" role="group" aria-label="Statistics available for export"></div>
+            <div class="export-selection-actions">
+                <button type="button" class="export-selection-btn cancel" id="cancelExportSelectionBtn">Cancel</button>
+                <div class="export-selection-actions-right">
+                    <button type="button" class="export-selection-btn confirm" id="confirmExportSelectionBtn">Download</button>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/docs/reference/file-format-and-artifact-spec.md
+++ b/docs/reference/file-format-and-artifact-spec.md
@@ -94,7 +94,13 @@ Observed output naming patterns include:
 
 ## Export Output
 
-CytoCV exports result tables as CSV and XLSX files. In the current implementation, the download name is usually based on the uploaded image stem.
+CytoCV exports statistics tables as CSV and XLSX files from both Display and Dashboard. Single-file exports contain one statistics table. Multi-file exports contain one combined table with `File Name` as the first column, `Cell ID` as the second column, and selected metric columns after that. In combined exports, `File Name` is written only on the first row for each file group; following rows for the same file leave that cell blank.
+
+Download filenames use:
+
+`cytocv_<all-or-selected>_cell-metrics_<number>files_<YYYY-MM-DD_HHMM>.<extension>`
+
+The `all` or `selected` token describes metric scope, not file scope. `all` means every user-selectable cell metric was included. `selected` means the export includes only a subset of cell metrics. The `<number>files` token is the actual number of files included in the export, and the extension is `.csv` or `.xlsx`.
 
 ## Related Documents
 

--- a/docs/user/account-and-dashboard.md
+++ b/docs/user/account-and-dashboard.md
@@ -55,7 +55,9 @@ The dashboard shows saved runs owned by the current user. For each saved run, th
 - detected channel badges
 - scale summary
 - cell count
-- CSV or XLSX statistics-table exports
+- CSV or XLSX statistics-table exports for one saved file or selected saved files
+
+Dashboard statistics downloads can include all cell metrics or a selected metric subset. Download filenames use `cytocv_<all-or-selected>_cell-metrics_<number>files_<YYYY-MM-DD_HHMM>.<extension>`, where `all` or `selected` refers to metric selection and the file count reports how many files were exported. Combined exports list `File Name` only on the first row for each exported file group.
 
 The dashboard also reports storage information:
 

--- a/docs/user/output-guide.md
+++ b/docs/user/output-guide.md
@@ -88,14 +88,21 @@ Run metadata also stores contextual information such as:
 
 CytoCV supports CSV and XLSX table exports. Export behavior is available in:
 
-- the display view for the first UUID with statistics
+- the display view for the current statistics table
 - the dashboard for a selected saved file
+- combined statistics downloads for selected files in Display or Dashboard
 
 The on-page statistics tables and the CSV/XLSX exports include both:
 
 - the raw integrated contour intensity sums as the primary table/export values
 - the three mode-driven `Measurement/Contour Ratio` columns as explicitly labeled derived values
 - canonical contour slot numbering, so size, intensity, line-distance, and nucleus-derived modern red/green outputs stay aligned
+
+Statistics downloads can include all metrics or a selected subset. Export filenames follow:
+
+`cytocv_<all-or-selected>_cell-metrics_<number>files_<YYYY-MM-DD_HHMM>.<extension>`
+
+The `all` or `selected` token describes whether all cell metrics or only selected metrics were exported. The file count separately reflects how many files were included. In combined exports, `File Name` appears only on the first row for each file group, with later rows for that same file left blank until the next file begins.
 
 ## Expected Outputs
 

--- a/docs/user/workflow-guide.md
+++ b/docs/user/workflow-guide.md
@@ -88,7 +88,7 @@ The display view provides:
 - one main outlined image per file
 - per-cell image panels in channel order
 - software-generated measurements for each cell
-- CSV and XLSX table export for the current statistics table
+- CSV and XLSX statistics export for the current table, with optional metric selection
 - save, unsave, and selection synchronization actions
 
 Main display frames can be switched by channel, and channel order is based on the stored `channel_config.json`.
@@ -97,7 +97,8 @@ Main display frames can be switched by channel, and channel order is based on th
 
 From display or dashboard, users can:
 
-- export table data as CSV or XLSX
+- export single-file or selected-file statistics as CSV or XLSX
+- choose all metrics or a selected subset of metrics for statistics downloads
 - save transient runs to their account if quota allows
 - unsave retained runs back to transient status
 - bulk-delete saved runs from the dashboard
@@ -106,7 +107,7 @@ From display or dashboard, users can:
 
 - saved or transient segmentation results
 - per-cell software-generated measurements saved with the run
-- exportable tabular summaries
+- exportable tabular summaries with filenames that indicate metric scope, file count, and timestamp
 - dashboard-visible history for retained runs
 
 ## Common Errors


### PR DESCRIPTION
This pull request introduces a new combined statistics export feature, allowing users to export data from multiple files at once, and standardizes the default dot split mode to "aggressive" throughout the application. It also refactors and centralizes export filename generation and metric scope logic, and updates tests and normalization logic to reflect the new defaults.

**Combined statistics export:**
- Added `core/services/combined_stat_export.py`, which implements the logic to export statistics from multiple files into a single CSV or Excel file, including validation, file aggregation, and response generation.
- Added `dashboard_bulk_export_view` in `accounts/views/profile.py` to handle bulk export requests from the dashboard, using the new combined export logic.
- Added `_dashboard_available_export_uuid_set` to determine which files are available for export.

**Export filename and metric scope refactoring:**
- Centralized export filename generation in `core/services/export_filenames.py` with `build_statistics_export_filename`, and updated all usages to use this function. [[1]](diffhunk://#diff-42273fddd7e86d8ac6561ab0f30ec6a27ef85481daacb3fd66fdba1e68b691f6R1-R44) [[2]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL991-R1016)
- Added logic to determine export metric scope and included columns in `core/services/stat_export_selection.py` (`export_metric_scope`, `export_included_columns`). [[1]](diffhunk://#diff-f6abbe68869616ba24ac8c15ce15e1a1b0b6b302876aec8fa12cfce8fab68601R55-R66) [[2]](diffhunk://#diff-f6abbe68869616ba24ac8c15ce15e1a1b0b6b302876aec8fa12cfce8fab68601R188-R198)

**Default dot split mode update:**
- Changed the default for `green_dot_split_mode` and `red_dot_split_mode` to "aggressive" across backend (`accounts/preferences.py`, `core/services/dot_split.py`) and frontend normalization logic (`workflow_defaults.js`). [[1]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379L64-R66) [[2]](diffhunk://#diff-58f3d0d63b067f2ead2e4a2246aa4066ef3354f4178f19097be89bfdf6d1d379L638-R638) [[3]](diffhunk://#diff-ac0c9e3eb5cc0aa334be88152e0629e3299eb176408f2f0d64de053d79355214L5-R5) [[4]](diffhunk://#diff-16346bdca41f9007ac9a5735d62486f3a35ec35249af6c4b3e22ec98db1aeea9L1047-R1048)
- Updated tests to expect "aggressive" as the default for invalid dot split modes. [[1]](diffhunk://#diff-89d5b3aedd4d667e2eb6b1c1f0dca8dccd026549674f06a46a83d3b5175c4705L27-R27) [[2]](diffhunk://#diff-89d5b3aedd4d667e2eb6b1c1f0dca8dccd026549674f06a46a83d3b5175c4705L43-R43)

**Code cleanup and minor refactoring:**
- Removed the now-obsolete `_build_export_download_name` function in `accounts/views/profile.py` in favor of the centralized filename builder.
- Updated imports and code organization to support the new features and refactors. [[1]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR56-R63) [[2]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR81)

These changes collectively improve the export capabilities, increase consistency in defaults, and simplify code maintenance.