### PR TITLE
Fix multi-cell delete confirmation button sizing and layout

### DIFF
--- a/cytocv/templates/dashboard.html
+++ b/cytocv/templates/dashboard.html
@@ -1166,6 +1166,9 @@
             gap: 10px;
             min-height: 320px;
         }
+        #confirmCellsView {
+            grid-template-rows: auto auto minmax(0, 1fr) auto;
+        }
         .cell-select-toolbar {
             display: flex;
             justify-content: flex-start;
@@ -1329,6 +1332,7 @@
         }
         .delete-modal-actions {
             display: flex;
+            align-items: center;
             justify-content: flex-end;
             gap: 10px;
         }

--- a/cytocv/templates/display.html
+++ b/cytocv/templates/display.html
@@ -1180,6 +1180,9 @@
             gap: 10px;
             min-height: 320px;
         }
+        #confirmCellsView {
+            grid-template-rows: auto auto minmax(0, 1fr) auto;
+        }
         .cell-select-toolbar {
             display: flex;
             justify-content: flex-start;
@@ -1343,6 +1346,7 @@
         }
         .save-modal-actions {
             display: flex;
+            align-items: center;
             justify-content: flex-end;
             gap: 10px;
         }


### PR DESCRIPTION
This pull request makes minor CSS improvements to the layout and alignment of elements in the `dashboard.html` and `display.html` templates. The changes enhance the grid structure and vertical alignment of modal action buttons for a more consistent UI.

Layout improvements:

* Added a specific grid template for `#confirmCellsView` to both `dashboard.html` and `display.html` for better control over row sizing. [[1]](diffhunk://#diff-fea3e6a6c8bf668330e0e4ea2c49fb168b3ecfd097762b3da0e5207e1d2736e1R1169-R1171) [[2]](diffhunk://#diff-cbe6ab771c4c8f906e093c76cf9c1db6ebeb1edcfe307d8d214710e9ae3f5d3fR1183-R1185)

UI alignment enhancements:

* Ensured modal action buttons are vertically centered by adding `align-items: center` to `.delete-modal-actions` and `.save-modal-actions`. [[1]](diffhunk://#diff-fea3e6a6c8bf668330e0e4ea2c49fb168b3ecfd097762b3da0e5207e1d2736e1R1335) [[2]](diffhunk://#diff-cbe6ab771c4c8f906e093c76cf9c1db6ebeb1edcfe307d8d214710e9ae3f5d3fR1349)Give the multi-cell confirmation view its own grid row layout so the action bar stays in the footer row instead of the flexible content row.

Align modal action bars to the center in dashboard and display so Back and Confirm Delete keep their normal button height.