### PR TITLE
Enhance TIFF file support and validation in image-source adapter

### DIFF
--- a/cytocv/core/config.py
+++ b/cytocv/core/config.py
@@ -45,7 +45,7 @@ def get_channel_config_for_uuid(uuid: str) -> dict[str, Any]:
     """Load per-file channel mapping or fall back to defaults.
 
     Args:
-        uuid: UUID for the uploaded DV file directory.
+        uuid: UUID for the uploaded source image directory.
 
     Returns:
         Channel mapping for the given UUID.

--- a/cytocv/core/image_sources.py
+++ b/cytocv/core/image_sources.py
@@ -1,0 +1,165 @@
+"""Shared loaders for supported source microscopy image files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import tifffile
+from mrc import DVFile
+
+SUPPORTED_IMAGE_EXTENSIONS = frozenset({".dv", ".tif", ".tiff"})
+SUPPORTED_IMAGE_EXTENSIONS_LABEL = ".dv, .tif, .tiff"
+TIFF_IMAGE_EXTENSIONS = frozenset({".tif", ".tiff"})
+DV_IMAGE_EXTENSION = ".dv"
+
+_SPATIAL_AXES = {"Y", "X"}
+_NON_STACK_AXES = _SPATIAL_AXES | {"S"}
+_SMALL_AXIS_MAX = 16
+
+
+def source_image_extension(path_or_name: str | Path) -> str:
+    """Return the lowercase suffix used to identify a supported source format."""
+
+    return Path(str(path_or_name)).suffix.lower()
+
+
+def is_supported_image_filename(name: object) -> bool:
+    """Return True when the filename extension is accepted for upload."""
+
+    return source_image_extension(str(name or "")) in SUPPORTED_IMAGE_EXTENSIONS
+
+
+def _load_dv_array(path: str | Path) -> np.ndarray:
+    dv_file = DVFile(path)
+    try:
+        return np.asarray(dv_file.asarray())
+    finally:
+        dv_file.close()
+
+
+def _squeeze_singleton_non_spatial_axes(
+    array: np.ndarray,
+    axes: str | None,
+) -> tuple[np.ndarray, str | None]:
+    if not axes or len(axes) != array.ndim:
+        return array, axes
+
+    squeeze_axes = [
+        index
+        for index, axis in enumerate(axes)
+        if axis not in _SPATIAL_AXES and array.shape[index] == 1
+    ]
+    if not squeeze_axes:
+        return array, axes
+
+    squeezed = np.squeeze(array, axis=tuple(squeeze_axes))
+    next_axes = "".join(axis for index, axis in enumerate(axes) if index not in squeeze_axes)
+    return squeezed, next_axes
+
+
+def _normalize_stack_with_axes(
+    array: np.ndarray,
+    axes: str | None,
+    source_path: Path,
+) -> np.ndarray | None:
+    if not axes or len(axes) != array.ndim:
+        return None
+
+    axes = axes.upper()
+    if array.ndim == 2 and axes == "YX":
+        return np.expand_dims(array, axis=0)
+
+    if "Y" not in axes or "X" not in axes:
+        return None
+
+    stack_axes = [
+        index for index, axis in enumerate(axes) if axis not in _NON_STACK_AXES
+    ]
+    if "S" in axes and not stack_axes:
+        raise ValueError(f"Unsupported RGB/sample image shape {array.shape} for {source_path}")
+    if len(stack_axes) != 1:
+        return None
+
+    y_axis = axes.index("Y")
+    x_axis = axes.index("X")
+    stack_axis = stack_axes[0]
+    normalized = np.moveaxis(array, [stack_axis, y_axis, x_axis], [0, 1, 2])
+    if normalized.ndim != 3:
+        raise ValueError(f"Unsupported image stack shape {array.shape} for {source_path}")
+    return normalized
+
+
+def _normalize_stack_without_axes(array: np.ndarray, source_path: Path) -> np.ndarray:
+    if array.ndim == 2:
+        return np.expand_dims(array, axis=0)
+
+    if array.ndim == 3:
+        if array.shape[0] <= _SMALL_AXIS_MAX:
+            return array
+        if array.shape[-1] <= _SMALL_AXIS_MAX:
+            return np.moveaxis(array, -1, 0)
+        stack_axis = int(np.argmin(array.shape))
+        return np.moveaxis(array, stack_axis, 0)
+
+    raise ValueError(f"Unsupported image stack shape {array.shape} for {source_path}")
+
+
+def _normalize_image_stack(
+    array: np.ndarray,
+    source_path: Path,
+    *,
+    axes: str | None = None,
+) -> np.ndarray:
+    array = np.asarray(array)
+    if array.ndim == 0:
+        raise ValueError(f"Unsupported scalar image data for {source_path}")
+
+    normalized_axes = axes.upper() if axes else None
+    array, normalized_axes = _squeeze_singleton_non_spatial_axes(
+        array,
+        normalized_axes,
+    )
+
+    normalized = _normalize_stack_with_axes(array, normalized_axes, source_path)
+    if normalized is not None:
+        return np.asarray(normalized)
+    return np.asarray(_normalize_stack_without_axes(array, source_path))
+
+
+def _load_tiff_stack(path: Path) -> np.ndarray:
+    with tifffile.TiffFile(path) as tiff:
+        series = tiff.series[0]
+        axes = getattr(series, "axes", None)
+        array = series.asarray()
+    return _normalize_image_stack(array, path, axes=axes)
+
+
+def load_image_stack(path: str | Path) -> np.ndarray:
+    """Load a supported source image and return a channel-first stack."""
+
+    source_path = Path(path)
+    extension = source_image_extension(source_path)
+    if extension == DV_IMAGE_EXTENSION:
+        return _normalize_image_stack(_load_dv_array(source_path), source_path)
+    if extension in TIFF_IMAGE_EXTENSIONS:
+        return _load_tiff_stack(source_path)
+    raise ValueError(f"Unsupported image file extension '{extension}' for {source_path}")
+
+
+def get_image_layer_count(path: str | Path) -> int:
+    """Return the number of channel/layer images in the source file."""
+
+    stack = load_image_stack(path)
+    return int(stack.shape[0])
+
+
+def is_recognized_image_file(path: str | Path) -> bool:
+    """Return True when the file can be opened as a supported source image."""
+
+    try:
+        get_image_layer_count(path)
+        return True
+    except Exception:
+        return False
+

--- a/cytocv/core/metadata_processing/dv_channel_parser.py
+++ b/cytocv/core/metadata_processing/dv_channel_parser.py
@@ -8,6 +8,14 @@ from core.channel_roles import (
     CHANNEL_ROLE_GREEN,
     CHANNEL_ROLE_RED,
 )
+from core.image_sources import (
+    DV_IMAGE_EXTENSION,
+    TIFF_IMAGE_EXTENSIONS,
+    get_image_layer_count,
+    is_recognized_image_file,
+    source_image_extension,
+)
+from core.metadata_processing.tiff_channel_parser import extract_tiff_channel_config
 
 
 def _safe_float(value):
@@ -81,11 +89,18 @@ def _extract_from_dv_header(dv_file_path):
 
 def extract_channel_config(dv_file_path):
     """
-    Reads a DV file and returns a channel-name -> channel-index mapping.
+    Reads a source image file and returns a channel-name -> channel-index mapping.
 
     Primary source: structured DV metadata header (nc + wave1..waveN).
     Fallback source: XML snippets in the DV header text.
+    TIFF uploads use dedicated TIFF metadata parsing with default fallback.
     """
+    extension = source_image_extension(dv_file_path)
+    if extension in TIFF_IMAGE_EXTENSIONS:
+        return extract_tiff_channel_config(dv_file_path)
+    if extension != DV_IMAGE_EXTENSION:
+        return {}
+
     header_config = _extract_from_dv_header(dv_file_path)
     if header_config:
         return header_config
@@ -131,43 +146,16 @@ def extract_channel_config(dv_file_path):
 
 def is_recognized_dv_file(dv_file_path):
     """
-    Returns True if the file can be opened as a DV file.
+    Returns True if the file can be opened as a supported source image file.
     """
-    dv = None
-    try:
-        dv = DVFile(dv_file_path)
-        return True
-    except Exception:
-        return False
-    finally:
-        if dv is not None:
-            dv.close()
+    return is_recognized_image_file(dv_file_path)
 
 
 def get_dv_layer_count(dv_file_path):
     """
-    Returns the number of image layers/channels in the DV file.
+    Returns the number of image layers/channels in the source image file.
     """
-    dv = DVFile(dv_file_path)
-    try:
-        sizes = getattr(dv, "sizes", {}) or {}
-        c_count = sizes.get("C")
-        if c_count is not None:
-            try:
-                return int(c_count)
-            except (TypeError, ValueError):
-                pass
-
-        arr = dv.asarray()
-        if arr.ndim == 2:
-            return 1
-        if arr.ndim == 3:
-            return min(arr.shape)
-        if arr.ndim > 3:
-            return max(1, min(arr.shape[:-2]))
-        return 0
-    finally:
-        dv.close()
+    return get_image_layer_count(dv_file_path)
 
 
 def is_valid_dv_file(dv_file_path):

--- a/cytocv/core/metadata_processing/dv_scale_parser.py
+++ b/cytocv/core/metadata_processing/dv_scale_parser.py
@@ -9,6 +9,12 @@ from typing import Any
 
 from mrc import DVFile
 
+from core.image_sources import (
+    TIFF_IMAGE_EXTENSIONS,
+    source_image_extension,
+)
+from core.metadata_processing.tiff_scale_parser import extract_tiff_scale_metadata
+
 
 def _safe_float(value: Any) -> float | None:
     try:
@@ -24,10 +30,8 @@ def _valid_scale_value(value: float | None) -> bool:
     return value is not None and value > 0
 
 
-def extract_dv_scale_metadata(dv_file_path: str | Path) -> dict[str, Any]:
-    """Extract um/px scale metadata from DV header fields (dx/dy/dz)."""
-
-    result = {
+def _empty_scale_result() -> dict[str, Any]:
+    return {
         "metadata_um_per_px": None,
         "status": "missing",
         "dx": None,
@@ -35,6 +39,15 @@ def extract_dv_scale_metadata(dv_file_path: str | Path) -> dict[str, Any]:
         "dz": None,
         "note": "",
     }
+
+
+def extract_dv_scale_metadata(dv_file_path: str | Path) -> dict[str, Any]:
+    """Extract um/px scale metadata from supported source image metadata."""
+
+    if source_image_extension(dv_file_path) in TIFF_IMAGE_EXTENSIONS:
+        return extract_tiff_scale_metadata(dv_file_path)
+
+    result = _empty_scale_result()
 
     dv_file = None
     try:

--- a/cytocv/core/metadata_processing/error_handling/__init__.py
+++ b/cytocv/core/metadata_processing/error_handling/__init__.py
@@ -1,8 +1,8 @@
-from .dv_validation import (
-    DVValidationOptions,
-    DVValidationResult,
+from .source_image_validation import (
     EXPECTED_LAYER_COUNT,
     REQUIRED_CHANNELS,
-    build_dv_error_messages,
-    validate_dv_file,
+    SourceImageValidationOptions,
+    SourceImageValidationResult,
+    build_source_image_error_messages,
+    validate_source_image_file,
 )

--- a/cytocv/core/metadata_processing/error_handling/source_image_validation.py
+++ b/cytocv/core/metadata_processing/error_handling/source_image_validation.py
@@ -10,7 +10,8 @@ from ...channel_roles import (
     channel_display_label,
     normalize_channel_role,
 )
-from ..dv_channel_parser import extract_channel_config, get_dv_layer_count, is_recognized_dv_file
+from ...image_sources import get_image_layer_count, is_recognized_image_file
+from ..dv_channel_parser import extract_channel_config
 from ...stats_plugins import CHANNEL_ORDER
 
 EXPECTED_LAYER_COUNT = 4
@@ -45,7 +46,7 @@ def _available_channels_from_config(channel_config: dict, layer_count: int) -> S
 
 
 @dataclass(frozen=True)
-class DVValidationOptions:
+class SourceImageValidationOptions:
     """Control which metadata checks run before preprocessing."""
 
     enforce_layer_count: bool = False
@@ -54,8 +55,8 @@ class DVValidationOptions:
 
 
 @dataclass(frozen=True)
-class DVValidationResult:
-    """Hold metadata validation results for a single DV file."""
+class SourceImageValidationResult:
+    """Hold metadata validation results for a single source image file."""
 
     is_valid: bool
     layer_count: int | None
@@ -64,7 +65,7 @@ class DVValidationResult:
     error_message: str | None = None
 
 
-def get_effective_required_channels(options: DVValidationOptions) -> Set[str]:
+def get_effective_required_channels(options: SourceImageValidationOptions) -> Set[str]:
     """Return the full set of required channels for this validation run."""
 
     required = set(options.required_channels or set())
@@ -73,34 +74,37 @@ def get_effective_required_channels(options: DVValidationOptions) -> Set[str]:
     return required
 
 
-def validate_dv_file(dv_file_path: Path, options: DVValidationOptions) -> DVValidationResult:
-    """Run metadata validation and return the results for the DV file."""
+def validate_source_image_file(
+    source_image_path: Path,
+    options: SourceImageValidationOptions,
+) -> SourceImageValidationResult:
+    """Run metadata validation and return results for a source image file."""
 
     required_channels = get_effective_required_channels(options)
 
-    if not is_recognized_dv_file(str(dv_file_path)):
-        return DVValidationResult(
+    if not is_recognized_image_file(str(source_image_path)):
+        return SourceImageValidationResult(
             is_valid=False,
             layer_count=None,
             missing_channels=set(),
             required_channels=required_channels,
-            error_message="not a recognized DV file",
+            error_message="not a recognized supported image file",
         )
 
     layer_count = None
     if options.enforce_layer_count:
         try:
-            layer_count = get_dv_layer_count(str(dv_file_path))
+            layer_count = get_image_layer_count(str(source_image_path))
         except Exception:
-            return DVValidationResult(
+            return SourceImageValidationResult(
                 is_valid=False,
                 layer_count=None,
                 missing_channels=set(),
                 required_channels=required_channels,
-                error_message="not a recognized DV file",
+                error_message="not a recognized supported image file",
             )
         if layer_count != EXPECTED_LAYER_COUNT:
-            return DVValidationResult(
+            return SourceImageValidationResult(
                 is_valid=False,
                 layer_count=layer_count,
                 missing_channels=set(),
@@ -108,30 +112,30 @@ def validate_dv_file(dv_file_path: Path, options: DVValidationOptions) -> DVVali
             )
 
     if required_channels:
-        channel_config = extract_channel_config(dv_file_path)
+        channel_config = extract_channel_config(source_image_path)
         if layer_count is None:
             try:
-                layer_count = get_dv_layer_count(str(dv_file_path))
+                layer_count = get_image_layer_count(str(source_image_path))
             except Exception:
-                return DVValidationResult(
+                return SourceImageValidationResult(
                     is_valid=False,
                     layer_count=None,
                     missing_channels=set(),
                     required_channels=required_channels,
-                    error_message="not a recognized DV file",
+                    error_message="not a recognized supported image file",
                 )
 
         available_channels = _available_channels_from_config(channel_config, layer_count)
         missing_channels = set(required_channels) - available_channels
         if missing_channels:
-            return DVValidationResult(
+            return SourceImageValidationResult(
                 is_valid=False,
                 layer_count=layer_count,
                 missing_channels=missing_channels,
                 required_channels=required_channels,
             )
 
-    return DVValidationResult(
+    return SourceImageValidationResult(
         is_valid=True,
         layer_count=layer_count,
         missing_channels=set(),
@@ -157,9 +161,16 @@ def _sorted_channel_labels(channels: Set[str]) -> list[str]:
     return [channel_display_label(channel) for channel in _sorted_channels(channels)]
 
 
-def build_dv_error_messages(
-    failures: Iterable[Tuple[str, DVValidationResult]],
-    options: DVValidationOptions,
+def _failure_file_name(name: object) -> str:
+    file_name = Path(str(name or "")).name
+    if Path(file_name).suffix:
+        return file_name
+    return f"{file_name}.dv"
+
+
+def build_source_image_error_messages(
+    failures: Iterable[Tuple[str, SourceImageValidationResult]],
+    options: SourceImageValidationOptions,
 ) -> list[str]:
     """Create user-facing error messages based on the enabled checks."""
 
@@ -169,7 +180,7 @@ def build_dv_error_messages(
     required_channels = get_effective_required_channels(options)
 
     for name, result in failures:
-        file_name = f"{name}.dv"
+        file_name = _failure_file_name(name)
         if result.error_message:
             invalid_file_errors.append(f"- {file_name} is {result.error_message}")
             continue
@@ -199,7 +210,7 @@ def build_dv_error_messages(
         messages.extend(items)
 
     append_section(
-        "Could not process the following files because they are not recognized DV files:",
+        "Could not process the following files because they are not recognized supported image files:",
         invalid_file_errors,
     )
     append_section(

--- a/cytocv/core/metadata_processing/tiff_channel_parser.py
+++ b/cytocv/core/metadata_processing/tiff_channel_parser.py
@@ -1,0 +1,102 @@
+"""TIFF channel metadata parsing helpers."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import tifffile
+
+from core.channel_roles import (
+    CHANNEL_ROLE_BLUE,
+    CHANNEL_ROLE_DIC,
+    CHANNEL_ROLE_GREEN,
+    CHANNEL_ROLE_RED,
+)
+from core.config import DEFAULT_CHANNEL_CONFIG
+
+_CHANNEL_ROLES = frozenset(DEFAULT_CHANNEL_CONFIG)
+_WAVELENGTH_PATTERN = re.compile(r"(?i)(?:^|[^a-z0-9])w[_\s-]*(\d{3,4})(?=[^a-z0-9]|$)")
+
+
+def read_tiff_imagej_metadata(path: str | Path) -> dict[str, Any]:
+    """Read ImageJ metadata from a TIFF file."""
+
+    with tifffile.TiffFile(path) as tiff:
+        metadata = getattr(tiff, "imagej_metadata", None)
+        return dict(metadata or {})
+
+
+def extract_tiff_channel_labels_from_metadata(metadata: dict[str, Any]) -> list[str]:
+    """Return channel labels from ImageJ metadata."""
+
+    raw_labels = metadata.get("Labels") or metadata.get("labels")
+    if not isinstance(raw_labels, (list, tuple)):
+        return []
+    return [str(label) for label in raw_labels if str(label).strip()]
+
+
+def _role_from_wavelength(wavelength: float) -> str | None:
+    if abs(wavelength - 625) < 12:
+        return CHANNEL_ROLE_RED
+    if abs(wavelength - 525) < 12:
+        return CHANNEL_ROLE_GREEN
+    if abs(wavelength - 435) < 12:
+        return CHANNEL_ROLE_BLUE
+    return None
+
+
+def map_tiff_label_to_channel_role(label: str) -> str | None:
+    """Map one ImageJ/softWoRx TIFF label to a canonical channel role."""
+
+    normalized = str(label or "").strip()
+    lower = normalized.lower()
+    compact = "".join(ch for ch in lower if ch.isalnum())
+
+    wavelength_match = _WAVELENGTH_PATTERN.search(lower)
+    if wavelength_match:
+        role = _role_from_wavelength(float(wavelength_match.group(1)))
+        if role:
+            return role
+
+    if "dic" in compact or "brightfield" in compact or "transmission" in compact:
+        return CHANNEL_ROLE_DIC
+    if "r3dref" in compact or "_ref" in lower or lower.endswith("ref.tif"):
+        return CHANNEL_ROLE_DIC
+    return None
+
+
+def build_tiff_channel_config_from_labels(labels: list[str]) -> dict[str, int] | None:
+    """Build a complete channel config from TIFF labels, or None when ambiguous."""
+
+    if len(labels) != len(_CHANNEL_ROLES):
+        return None
+
+    config: dict[str, int] = {}
+    for index, label in enumerate(labels):
+        role = map_tiff_label_to_channel_role(label)
+        if role is None or role in config:
+            return None
+        config[role] = index
+
+    if set(config) != _CHANNEL_ROLES:
+        return None
+    return config
+
+
+def extract_tiff_metadata_channel_config(path: str | Path) -> dict[str, int] | None:
+    """Return a metadata-derived TIFF channel config when labels are complete."""
+
+    try:
+        metadata = read_tiff_imagej_metadata(path)
+        labels = extract_tiff_channel_labels_from_metadata(metadata)
+        return build_tiff_channel_config_from_labels(labels)
+    except Exception:
+        return None
+
+
+def extract_tiff_channel_config(path: str | Path) -> dict[str, int]:
+    """Return TIFF channel config, falling back to the existing default order."""
+
+    return extract_tiff_metadata_channel_config(path) or dict(DEFAULT_CHANNEL_CONFIG)

--- a/cytocv/core/metadata_processing/tiff_scale_parser.py
+++ b/cytocv/core/metadata_processing/tiff_scale_parser.py
@@ -1,0 +1,156 @@
+"""TIFF physical scale metadata parsing helpers."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import tifffile
+
+
+def _empty_scale_result() -> dict[str, Any]:
+    return {
+        "metadata_um_per_px": None,
+        "status": "missing",
+        "dx": None,
+        "dy": None,
+        "dz": None,
+        "note": "",
+    }
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
+def _valid_scale_value(value: float | None) -> bool:
+    return value is not None and value > 0
+
+
+def _ratio_to_float(value: Any) -> float | None:
+    if isinstance(value, tuple) and len(value) == 2:
+        numerator = _safe_float(value[0])
+        denominator = _safe_float(value[1])
+        if numerator is None or denominator in {None, 0}:
+            return None
+        return numerator / denominator
+    return _safe_float(value)
+
+
+def _unit_um_from_resolution_unit(unit: Any) -> float | None:
+    raw_value = getattr(unit, "value", unit)
+    try:
+        unit_int = int(raw_value)
+    except (TypeError, ValueError):
+        unit_text = str(raw_value or "").strip().lower()
+        if unit_text in {"inch", "inches"}:
+            unit_int = 2
+        elif unit_text in {"centimeter", "centimeters", "cm"}:
+            unit_int = 3
+        else:
+            unit_int = 0
+
+    if unit_int == 2:
+        return 25400.0
+    if unit_int == 3:
+        return 10000.0
+    return None
+
+
+def _unit_um_from_imagej_unit(unit: Any) -> float | None:
+    unit_text = str(unit or "").strip().lower()
+    if unit_text in {"um", "µm", "micron", "microns", "micrometer", "micrometers"}:
+        return 1.0
+    if unit_text in {"nm", "nanometer", "nanometers"}:
+        return 0.001
+    if unit_text in {"mm", "millimeter", "millimeters"}:
+        return 1000.0
+    return None
+
+
+def read_tiff_scale_metadata(path: str | Path) -> dict[str, Any]:
+    """Read raw TIFF scale-related metadata through tifffile."""
+
+    with tifffile.TiffFile(path) as tiff:
+        if len(tiff.pages) == 0:
+            return {"tags": {}, "imagej": {}}
+        tags = tiff.pages[0].tags
+        imagej_metadata = getattr(tiff, "imagej_metadata", None) or {}
+        return {
+            "tags": {
+                "XResolution": tags["XResolution"].value if "XResolution" in tags else None,
+                "YResolution": tags["YResolution"].value if "YResolution" in tags else None,
+                "ResolutionUnit": tags["ResolutionUnit"].value if "ResolutionUnit" in tags else None,
+            },
+            "imagej": dict(imagej_metadata),
+        }
+
+
+def _build_scale_result(
+    *,
+    unit_um: float | None,
+    x_resolution: float | None,
+    y_resolution: float | None,
+    missing_unit_note: str,
+) -> dict[str, Any]:
+    result = _empty_scale_result()
+    if unit_um is None:
+        result["status"] = "missing"
+        result["note"] = missing_unit_note
+        return result
+    if not _valid_scale_value(x_resolution) or not _valid_scale_value(y_resolution):
+        result["status"] = "invalid"
+        result["note"] = "TIFF resolution values are missing, non-finite, or non-positive."
+        return result
+
+    dx = unit_um / x_resolution
+    dy = unit_um / y_resolution
+    result["dx"] = dx
+    result["dy"] = dy
+    result["metadata_um_per_px"] = (dx + dy) / 2.0
+    if abs(dx - dy) > 1e-9:
+        result["status"] = "anisotropic_avg"
+        result["note"] = "TIFF X/Y resolution tags differ; using their average."
+    else:
+        result["status"] = "ok"
+    return result
+
+
+def extract_tiff_scale_metadata(path: str | Path) -> dict[str, Any]:
+    """Extract um/px scale metadata from TIFF resolution metadata."""
+
+    try:
+        metadata = read_tiff_scale_metadata(path)
+    except Exception:
+        result = _empty_scale_result()
+        result["status"] = "invalid"
+        result["note"] = "Unable to read TIFF resolution metadata."
+        return result
+
+    tags = metadata["tags"]
+    imagej_metadata = metadata["imagej"]
+    x_resolution = _ratio_to_float(tags.get("XResolution"))
+    y_resolution = _ratio_to_float(tags.get("YResolution"))
+    unit_um = _unit_um_from_resolution_unit(tags.get("ResolutionUnit"))
+    if unit_um is not None:
+        return _build_scale_result(
+            unit_um=unit_um,
+            x_resolution=x_resolution,
+            y_resolution=y_resolution,
+            missing_unit_note="TIFF resolution metadata does not include a physical unit.",
+        )
+
+    imagej_unit_um = _unit_um_from_imagej_unit(imagej_metadata.get("unit"))
+    return _build_scale_result(
+        unit_um=imagej_unit_um,
+        x_resolution=x_resolution,
+        y_resolution=y_resolution,
+        missing_unit_note="TIFF resolution metadata does not include a physical unit.",
+    )

--- a/cytocv/core/models.py
+++ b/cytocv/core/models.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 import uuid
 from enum import Enum
 
@@ -11,10 +10,10 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.db.models import Q
-from mrc import DVFile
 from PIL import Image
 
 from core.config import get_channel_config_for_uuid
+from core.image_sources import is_supported_image_filename, load_image_stack
 
 
 def get_guest_user() -> int:
@@ -206,7 +205,7 @@ class UploadPreparationJob(models.Model):
 
 
 class DVLayerTifPreview(models.Model):
-    """Stores a single channel preview for a DV file."""
+    """Stores a single channel preview for a source image file."""
 
     wavelength = models.CharField(max_length=30)
     uploaded_image_uuid = models.ForeignKey(UploadedImage, on_delete=models.CASCADE)
@@ -368,7 +367,7 @@ class CellStatistics(models.Model):
             outline: Whether to include the outline suffix for filenames.
 
         Returns:
-            A PIL Image when reading from a DV file, or a filename string.
+            A PIL Image when reading from a source image file, or a filename string.
         """
         channel_config = get_channel_config_for_uuid(self.segmented_image.UUID)
         image_channel = channel_config.get(channel)
@@ -378,12 +377,9 @@ class CellStatistics(models.Model):
             outlinestr = "-no_outline"
         if use_id:
             return f"{self.get_base_name()}_PRJ-{image_channel}-{self.cell_id}{outlinestr}.png"
-        extspl = os.path.splitext(self.image_name)
-        if extspl[1] == ".dv":
-            f = DVFile(self.dv_file_path)
-            image = f.asarray()
-            img = Image.fromarray(image[image_channel])
-            return img
+        if is_supported_image_filename(self.image_name):
+            image_stack = load_image_stack(self.dv_file_path)
+            return Image.fromarray(image_stack[image_channel])
         return f"{self.get_base_name()}_PRJ-{image_channel}{outlinestr}.png"
 
 

--- a/cytocv/core/mrcnn/preprocess_images.py
+++ b/cytocv/core/mrcnn/preprocess_images.py
@@ -6,14 +6,17 @@ from pathlib import Path
 import numpy as np
 from PIL import Image
 import skimage.exposure
-from mrc import DVFile
 import logging
 
-from cytocv.settings import MEDIA_ROOT
 from core.artifact_constants import PRE_PROCESS_FOLDER_NAME
 from core.config import get_channel_config_for_uuid
+from core.image_sources import load_image_stack
 from core.models import UploadedImage
-from core.services.artifact_storage import PNG_PROFILE_ANALYSIS_FAST, save_png_image
+from core.services.artifact_storage import (
+    PNG_PROFILE_ANALYSIS_FAST,
+    resolve_uploaded_file_path,
+    save_png_image,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -67,41 +70,15 @@ def preprocess_images(
     # constants, easily can be changed 
     logger.debug("Preprocess output directory: %s", output_dir)
     
-    #converts windows file path to linux path and joins 
-    image_path = Path(MEDIA_ROOT, str(uploaded_image.file_location)) #.replace("/", "\\")
-    f = DVFile(image_path)
-    try:
-        image_stack = f.asarray()
-    finally:
-        f.close()
+    image_path = resolve_uploaded_file_path(uploaded_image)
+    image_stack = load_image_stack(image_path)
 
-    # gets raw image from uploaded dv file
+    # gets raw image from uploaded source file
     channel_config = get_channel_config_for_uuid(str(uuid))
     dic_index = channel_config.get("DIC", 3)
     image = _select_dic_image_layer(image_stack, dic_index)
     if image is None:
         return None
-    # fileSize = os.path.getsize(uploaded_image.file_location)
-    # if fileSize > 8230000:
-        #File is a live cell imaging that has more than 4 images
-    #     f = DVFile(uploaded_image)
-    #     image = f.asarray()[0]
-    # if extspl[1] == '.dv':
-    #     f = DVFile(uploaded_image)
-    #     image = f.asarray()[0]
-        #if we don't have .dv files, see if there are tifs in the directory with the proper name structure
-
-        # elif len(extspl) != 2 or extspl[1] != '.tif':  # ignore files that aren't tifs
-        #     continue
-        # else:
-        #     image = np.array(Image.open(inputdirectory + imagename))
-    # try:
-        # if verbose:
-        # print ("Preprocessing ", imagename)
-        # existing_files = os.listdir(mask_dir)
-        # if imagename in existing_files and use_cache:   #skip this if we have a mask already
-            # continue
-    # outputdirectory = imagePath
     # grabs only file name
  
     height = image.shape[0]

--- a/cytocv/core/services/artifact_storage.py
+++ b/cytocv/core/services/artifact_storage.py
@@ -14,10 +14,10 @@ import skimage.exposure
 from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
-from mrc import DVFile
 from PIL import Image
 
 from core.artifact_constants import PRE_PROCESS_FOLDER_NAME, PREVIEW_FOLDER_NAME
+from core.image_sources import load_image_stack
 from core.models import CellStatistics, DVLayerTifPreview, SegmentedImage, UploadedImage
 
 logger = logging.getLogger(__name__)
@@ -382,7 +382,7 @@ def _media_path_from_field(field_value: object) -> Path | None:
 
 
 def resolve_uploaded_file_path(uploaded_image: UploadedImage) -> Path:
-    """Return the on-disk path for an uploaded source DV file."""
+    """Return the on-disk path for an uploaded source image file."""
 
     file_field = uploaded_image.file_location
     if not file_field:
@@ -397,7 +397,7 @@ def resolve_uploaded_file_path(uploaded_image: UploadedImage) -> Path:
 
     if not dv_path.exists():
         raise FileNotFoundError(
-            f"Stored DV file not found for upload {uploaded_image.pk}: {dv_path}"
+            f"Stored source image file not found for upload {uploaded_image.pk}: {dv_path}"
         )
 
     return dv_path
@@ -468,21 +468,10 @@ def optimize_png_file(path: Path) -> bool:
     return True
 
 
-def _load_dv_layers(dv_path: Path) -> np.ndarray:
-    """Load a DV file and return a channel-first layer stack."""
+def _load_source_layers(source_path: Path) -> np.ndarray:
+    """Load a source image file and return a channel-first layer stack."""
 
-    dv_file = DVFile(dv_path)
-    try:
-        array = dv_file.asarray()
-    finally:
-        dv_file.close()
-
-    if array.ndim == 2:
-        return np.expand_dims(array, axis=0)
-    if array.ndim == 3:
-        z_axis = int(np.argmin(array.shape))
-        return np.moveaxis(array, z_axis, 0)
-    raise ValueError(f"Unexpected DV array rank {array.ndim} for {dv_path}")
+    return load_image_stack(source_path)
 
 
 def _build_preview_rgb_image(layer: np.ndarray) -> Image.Image:
@@ -535,10 +524,10 @@ def generate_preview_assets(
     *,
     expected_layers: int = 4,
 ) -> list[DVLayerTifPreview]:
-    """Generate browser preview images for a DV upload."""
+    """Generate browser preview images for a source image upload."""
 
-    dv_path = resolve_uploaded_file_path(uploaded_image)
-    layers = _load_dv_layers(dv_path)
+    source_path = resolve_uploaded_file_path(uploaded_image)
+    layers = _load_source_layers(source_path)
     layer_count = min(expected_layers, int(layers.shape[0]))
 
     delete_preview_assets(uploaded_image)

--- a/cytocv/core/services/segmentation_pipeline.py
+++ b/cytocv/core/services/segmentation_pipeline.py
@@ -20,7 +20,6 @@ from PIL import Image, ImageDraw, ImageFont
 from cv2_rolling_ball import subtract_background_rolling_ball
 from django.conf import settings
 from django.db import transaction
-from mrc import DVFile
 
 from core.channel_roles import (
     CHANNEL_ROLE_BLUE,
@@ -30,6 +29,7 @@ from core.channel_roles import (
 )
 from core.config import DEFAULT_CHANNEL_CONFIG, DEFAULT_PROCESS_CONFIG, input_dir
 from core.contour_processing import get_contour_center, get_neighbor_count
+from core.image_sources import load_image_stack
 from core.image_processing.dashed_line import draw_dashed_line
 from core.models import CellStatistics, SegmentedImage, UploadedImage, get_guest_user
 from core.scale import (
@@ -506,6 +506,7 @@ def run_segmentation_batch(
         uploaded_image = UploadedImage.objects.get(pk=uuid, **owner_filter)
         dv_name = uploaded_image.name
         file_name = _display_file_name(uploaded_image)
+        source_image_name = Path(file_name).name or f"{dv_name}.dv"
         segment_phase = _phase_with_run_count(
             "Segmenting Cell-Pairs",
             index=run_index,
@@ -530,11 +531,7 @@ def run_segmentation_batch(
             logger.debug("Fell back to default channel config for %s", uuid)
         layer_channel_lookup = _build_layer_channel_lookup(channel_config)
 
-        dv_file = DVFile(dv_path)
-        try:
-            image_stack = dv_file.asarray()
-        finally:
-            dv_file.close()
+        image_stack = load_image_stack(dv_path)
         if image_stack.ndim == 2:
             image_stack = np.expand_dims(image_stack, axis=0)
 
@@ -588,12 +585,8 @@ def run_segmentation_batch(
 
             resolve_cells_using_spc110 = False
             if resolve_cells_using_spc110:
-                dv_file = DVFile(dv_path)
-                try:
-                    red_index = channel_config.get(CHANNEL_ROLE_RED)
-                    red_image = dv_file.asarray()[red_index]
-                finally:
-                    dv_file.close()
+                red_index = channel_config.get(CHANNEL_ROLE_RED)
+                red_image = image_stack[red_index]
 
                 red_image = np.round(red_image * 255).astype(np.uint8)
                 if len(red_image.shape) != 3 or red_image.shape[2] != 3:
@@ -701,7 +694,7 @@ def run_segmentation_batch(
         pair_geometry_cache = _build_pair_geometry_cache(seg)
         _write_neck_split_manifest_for_run(
             os.path.join(str(settings.MEDIA_ROOT), str(uuid)),
-            image_name=f"{dv_name}.dv",
+            image_name=source_image_name,
             pair_geometry_cache=pair_geometry_cache,
             use_cache=use_cache,
         )
@@ -755,11 +748,7 @@ def run_segmentation_batch(
                 profile=PNG_PROFILE_ANALYSIS_FAST,
             )
 
-        dv_file = DVFile(dv_path)
-        try:
-            cell_stack = dv_file.asarray()
-        finally:
-            dv_file.close()
+        cell_stack = image_stack
         cell_image_cache: dict[int, dict[str, np.ndarray]] = defaultdict(dict)
         cell_measurement_image_cache: dict[int, dict[str, np.ndarray]] = defaultdict(dict)
         if cell_stack.ndim == 2:
@@ -1183,7 +1172,7 @@ def run_segmentation_batch(
                     "green_red_intensity_2": 0.0,
                     "green_red_intensity_3": 0.0,
                     "dv_file_path": str(dv_path),
-                    "image_name": dv_name + ".dv",
+                    "image_name": source_image_name,
                 },
             )
 

--- a/cytocv/core/services/upload_preparation.py
+++ b/cytocv/core/services/upload_preparation.py
@@ -11,10 +11,10 @@ from uuid import UUID
 from core.metadata_processing.dv_channel_parser import extract_channel_config
 from core.metadata_processing.dv_scale_parser import extract_dv_scale_metadata
 from core.metadata_processing.error_handling import (
-    DVValidationOptions,
-    DVValidationResult,
-    build_dv_error_messages,
-    validate_dv_file,
+    SourceImageValidationOptions,
+    SourceImageValidationResult,
+    build_source_image_error_messages,
+    validate_source_image_file,
 )
 from core.models import UploadedImage, UploadPreparationJob
 from core.scale import DEFAULT_MICRONS_PER_PIXEL, build_scale_info
@@ -28,7 +28,10 @@ from core.services.artifact_storage import (
     run_media_path,
 )
 from core.services.analysis_progress import normalize_progress_detail
-from core.services.upload_preparation_jobs import finalize_upload_preparation_job
+from core.services.upload_preparation_jobs import (
+    TERMINAL_UPLOAD_PREPARATION_STATUSES,
+    finalize_upload_preparation_job,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -66,11 +69,11 @@ def _normalize_config_snapshot(snapshot: dict[str, object] | None) -> dict[str, 
     return payload
 
 
-def _validation_options_from_snapshot(snapshot: dict[str, object]) -> DVValidationOptions:
+def _validation_options_from_snapshot(snapshot: dict[str, object]) -> SourceImageValidationOptions:
     validation = snapshot.get("validation_options") or {}
     if not isinstance(validation, dict):
         validation = {}
-    return DVValidationOptions(
+    return SourceImageValidationOptions(
         enforce_layer_count=bool(validation.get("enforce_layer_count", False)),
         enforce_wavelengths=bool(validation.get("enforce_wavelengths", False)),
         required_channels={str(channel) for channel in validation.get("required_channels", []) if str(channel)},
@@ -122,8 +125,8 @@ def _set_phase(
     job.progress_detail = progress_detail
 
 
-def _missing_upload_result(required_channels: set[str]) -> DVValidationResult:
-    return DVValidationResult(
+def _missing_upload_result(required_channels: set[str]) -> SourceImageValidationResult:
+    return SourceImageValidationResult(
         is_valid=False,
         layer_count=None,
         missing_channels=set(),
@@ -138,8 +141,8 @@ def _prepare_one_upload(
     manual_um_per_px: float,
     prefer_metadata_scale: bool,
 ) -> None:
-    dv_file_path = _media_path_for_uploaded(uploaded)
-    metadata_scale = extract_dv_scale_metadata(dv_file_path)
+    source_image_path = _media_path_for_uploaded(uploaded)
+    metadata_scale = extract_dv_scale_metadata(source_image_path)
     uploaded.scale_info = build_scale_info(
         manual_um_per_px=manual_um_per_px,
         prefer_metadata=prefer_metadata_scale,
@@ -152,7 +155,7 @@ def _prepare_one_upload(
     )
     uploaded.save(update_fields=["scale_info"])
 
-    channel_config = extract_channel_config(dv_file_path)
+    channel_config = extract_channel_config(source_image_path)
     _write_channel_config(str(uploaded.uuid), channel_config)
     generate_preview_assets(uploaded, expected_layers=4)
 
@@ -160,12 +163,16 @@ def _prepare_one_upload(
 def run_upload_preparation_job(job: UploadPreparationJob) -> UploadPreparationJob:
     """Run validation, metadata extraction, channel config, and preview work."""
 
+    job.refresh_from_db(fields=["status"])
+    if job.status in TERMINAL_UPLOAD_PREPARATION_STATUSES:
+        return job
+
     snapshot = _normalize_config_snapshot(job.config_snapshot)
     validation_options = _validation_options_from_snapshot(snapshot)
     manual_um_per_px = float(snapshot["manual_um_per_px"])
     prefer_metadata_scale = bool(snapshot["prefer_metadata_scale"])
     owner_filter = _owner_filter_for_job(job)
-    failures: list[tuple[str, DVValidationResult]] = []
+    failures: list[tuple[str, SourceImageValidationResult]] = []
     valid_run_uuids: list[str] = []
     new_run_uuids = [str(UUID(str(value))) for value in job.new_run_uuids if str(value)]
     restored_run_uuids = [str(UUID(str(value))) for value in job.restored_run_uuids if str(value)]
@@ -198,10 +205,10 @@ def run_upload_preparation_job(job: UploadPreparationJob) -> UploadPreparationJo
                     delete_uploaded_run_by_uuid(run_uuid)
                 continue
 
-            dv_file_path = _media_path_for_uploaded(uploaded)
-            validation_result = validate_dv_file(dv_file_path, validation_options)
+            source_image_path = _media_path_for_uploaded(uploaded)
+            validation_result = validate_source_image_file(source_image_path, validation_options)
             if not validation_result.is_valid:
-                failures.append((uploaded.name, validation_result))
+                failures.append((_display_file_name(uploaded, run_uuid), validation_result))
                 if run_uuid in new_run_uuids:
                     delete_uploaded_run(uploaded)
                 continue
@@ -209,10 +216,10 @@ def run_upload_preparation_job(job: UploadPreparationJob) -> UploadPreparationJo
             valid_run_uuids.append(run_uuid)
 
         if not valid_run_uuids:
-            error_lines = build_dv_error_messages(failures, validation_options)
+            error_lines = build_source_image_error_messages(failures, validation_options)
             if not error_lines:
                 error_lines = [
-                    "No valid DV files were uploaded. Please upload files that pass the selected checks."
+                    "No valid supported image files were uploaded. Please upload files that pass the selected checks."
                 ]
             return finalize_upload_preparation_job(
                 job,
@@ -243,7 +250,7 @@ def run_upload_preparation_job(job: UploadPreparationJob) -> UploadPreparationJo
                 prefer_metadata_scale=prefer_metadata_scale,
             )
 
-        error_lines = build_dv_error_messages(failures, validation_options)
+        error_lines = build_source_image_error_messages(failures, validation_options)
         return finalize_upload_preparation_job(
             job,
             status=UploadPreparationJob.Status.SUCCEEDED,

--- a/cytocv/core/static/js/workflow_defaults.js
+++ b/cytocv/core/static/js/workflow_defaults.js
@@ -1572,7 +1572,7 @@
     );
     pushToggleChange(
       changes,
-      'Enforce 4-Image DV Files',
+      'Enforce 4-Layer Files',
       fromSnapshot.enforceLayerCount,
       toSnapshot.enforceLayerCount
     );

--- a/cytocv/core/tests/test_artifact_storage.py
+++ b/cytocv/core/tests/test_artifact_storage.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import errno
 import json
@@ -74,7 +74,6 @@ def temporary_media_root():
             for target in (
                 "accounts.views.profile.MEDIA_ROOT",
                 "core.config.MEDIA_ROOT",
-                "core.mrcnn.preprocess_images.MEDIA_ROOT",
                 "core.views.convert_to_image.MEDIA_ROOT",
                 "core.views.display.MEDIA_ROOT",
                 "core.views.pre_process.MEDIA_ROOT",
@@ -188,7 +187,7 @@ class PreviewArtifactTests(ArtifactStorageTestCase):
 
             layer_stack = np.arange(4 * 5 * 5, dtype=np.uint16).reshape(4, 5, 5)
             with patch(
-                "core.services.artifact_storage._load_dv_layers",
+                "core.services.artifact_storage._load_source_layers",
                 return_value=layer_stack,
             ):
                 preview_rows = generate_preview_assets(uploaded, expected_layers=4)
@@ -211,7 +210,7 @@ class PreviewArtifactTests(ArtifactStorageTestCase):
 
             layer_stack = np.ones((2, 4, 4), dtype=np.uint16)
             with patch(
-                "core.services.artifact_storage._load_dv_layers",
+                "core.services.artifact_storage._load_source_layers",
                 return_value=layer_stack,
             ):
                 preview_rows = ensure_preview_assets(uploaded, expected_layers=4)
@@ -229,8 +228,10 @@ class PreprocessEncodingTests(ArtifactStorageTestCase):
             uploaded = self._create_uploaded_image(media_root, name="preprocess_png")
             self._write_channel_config(media_root, str(uploaded.uuid))
 
-            with patch("core.mrcnn.preprocess_images.DVFile") as dv_file_cls:
-                dv_file_cls.return_value.asarray.return_value = np.ones((4, 8, 8), dtype=np.uint16)
+            with patch(
+                "core.mrcnn.preprocess_images.load_image_stack",
+                return_value=np.ones((4, 8, 8), dtype=np.uint16),
+            ):
                 artifact = preprocess_images(
                     str(uploaded.uuid),
                     uploaded,
@@ -661,7 +662,7 @@ class ExperimentStorageIntegrationTests(ArtifactStorageTestCase):
                 },
             )()
             with patch(
-                "core.services.upload_preparation.validate_dv_file",
+                "core.services.upload_preparation.validate_source_image_file",
                 return_value=invalid_result,
             ):
                 response = self.client.post(
@@ -738,7 +739,7 @@ class ExperimentStorageIntegrationTests(ArtifactStorageTestCase):
                 },
             )()
 
-            with patch("core.services.upload_preparation.validate_dv_file", return_value=valid_result), patch(
+            with patch("core.services.upload_preparation.validate_source_image_file", return_value=valid_result), patch(
                 "core.services.upload_preparation.extract_channel_config",
                 return_value=DEFAULT_CHANNEL_CONFIG,
             ), patch(
@@ -869,17 +870,10 @@ class ExperimentStorageIntegrationTests(ArtifactStorageTestCase):
                 format="TIFF",
             )
 
-            class DummyDVFile:
-                def __init__(self, *_args, **_kwargs):
-                    self._array = np.ones((1, 4, 4), dtype=np.uint8)
-
-                def asarray(self):
-                    return self._array
-
-                def close(self):
-                    return None
-
-            with patch("core.views.segment_image.DVFile", DummyDVFile), patch(
+            with patch(
+                "core.views.segment_image.load_image_stack",
+                return_value=np.ones((1, 4, 4), dtype=np.uint8),
+            ), patch(
                 "matplotlib.figure.Figure.savefig",
                 side_effect=OSError(errno.ENOSPC, "No space left on device"),
             ):

--- a/cytocv/core/tests/test_core_app.py
+++ b/cytocv/core/tests/test_core_app.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 from unittest.mock import patch
 
 import numpy as np
+import tifffile
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -136,6 +137,23 @@ class RouteSurfaceRefactorTests(TestCase):
             uuid=uuid_value,
             name=name,
             file_location=f"{uuid_value}/{name}.dv",
+        )
+
+    @staticmethod
+    def _write_labeled_tiff(path: Path):
+        labels = [
+            "sample_PRJ_w625.tif",
+            "sample_PRJ_w435.tif",
+            "sample_PRJ_w525.tif",
+            "sample_R3D_REF.tif",
+        ]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tifffile.imwrite(
+            path,
+            np.ones((4, 5, 6), dtype=np.uint16),
+            photometric="minisblack",
+            imagej=True,
+            metadata={"Labels": labels, "mode": "composite"},
         )
 
     def _create_segmented_image(self, uuid_value: str, name: str = "sample") -> SegmentedImage:
@@ -539,7 +557,7 @@ class RouteSurfaceRefactorTests(TestCase):
         )
         self.assertContains(
             home_response,
-            "CytoCV helps researchers upload DeltaVision",
+            "CytoCV helps researchers upload supported",
         )
         self.assertContains(
             home_response,
@@ -884,6 +902,115 @@ class RouteSurfaceRefactorTests(TestCase):
             update_channel_response.content.decode("utf-8"),
             {"error": "Channel information for this file could not be loaded."},
         )
+
+    def test_update_channel_order_accepts_display_labels(self):
+        uuid_value = str(uuid4())
+        with temporary_media_root() as media_root:
+            self._write_channel_config(media_root, uuid_value)
+            response = self.client.post(
+                reverse("update_channel_order", args=[uuid_value]),
+                data=json.dumps({"order": ["Red", "Blue", "Green", "DIC"]}),
+                content_type="application/json",
+            )
+            payload = json.loads((media_root / uuid_value / "channel_config.json").read_text())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            payload,
+            {
+                "channel_red": 0,
+                "channel_blue": 1,
+                "channel_green": 2,
+                "DIC": 3,
+            },
+        )
+
+    def test_update_channel_order_accepts_canonical_keys(self):
+        uuid_value = str(uuid4())
+        order = ["channel_red", "channel_blue", "channel_green", "DIC"]
+        with temporary_media_root() as media_root:
+            self._write_channel_config(media_root, uuid_value)
+            response = self.client.post(
+                reverse("update_channel_order", args=[uuid_value]),
+                data=json.dumps({"order": order}),
+                content_type="application/json",
+            )
+            payload = json.loads((media_root / uuid_value / "channel_config.json").read_text())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(payload, {channel: index for index, channel in enumerate(order)})
+
+    def test_update_channel_order_rejects_duplicate_display_labels(self):
+        uuid_value = str(uuid4())
+        with temporary_media_root() as media_root:
+            self._write_channel_config(media_root, uuid_value)
+            response = self.client.post(
+                reverse("update_channel_order", args=[uuid_value]),
+                data=json.dumps({"order": ["Red", "Red", "Green", "DIC"]}),
+                content_type="application/json",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertJSONEqual(
+            response.content.decode("utf-8"),
+            {"error": "Invalid channel order."},
+        )
+
+    def test_pre_process_refreshes_default_tiff_channel_config_from_metadata(self):
+        uuid_value = str(uuid4())
+        image_name = "metadata_channels"
+        with temporary_media_root() as media_root:
+            source_path = media_root / uuid_value / f"{image_name}.tif"
+            self._write_labeled_tiff(source_path)
+            self._write_channel_config(media_root, uuid_value)
+            UploadedImage.objects.create(
+                user=self.user,
+                uuid=uuid_value,
+                name=image_name,
+                file_location=f"{uuid_value}/{image_name}.tif",
+            )
+
+            response = self.client.get(reverse("pre_process", args=[uuid_value]))
+            payload = json.loads((media_root / uuid_value / "channel_config.json").read_text())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            payload,
+            {
+                "channel_red": 0,
+                "channel_blue": 1,
+                "channel_green": 2,
+                "DIC": 3,
+            },
+        )
+
+    def test_pre_process_preserves_user_edited_tiff_channel_config(self):
+        uuid_value = str(uuid4())
+        image_name = "user_channels"
+        user_config = {
+            "channel_blue": 0,
+            "DIC": 1,
+            "channel_green": 2,
+            "channel_red": 3,
+        }
+        with temporary_media_root() as media_root:
+            source_path = media_root / uuid_value / f"{image_name}.tif"
+            self._write_labeled_tiff(source_path)
+            config_path = media_root / uuid_value / "channel_config.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(json.dumps(user_config), encoding="utf-8")
+            UploadedImage.objects.create(
+                user=self.user,
+                uuid=uuid_value,
+                name=image_name,
+                file_location=f"{uuid_value}/{image_name}.tif",
+            )
+
+            response = self.client.get(reverse("pre_process", args=[uuid_value]))
+            payload = json.loads(config_path.read_text())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(payload, user_config)
 
     def test_pre_process_uses_renamed_template_and_routes(self):
         uuid_value = str(uuid4())

--- a/cytocv/core/tests/test_image_sources.py
+++ b/cytocv/core/tests/test_image_sources.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import tifffile
+from django.test import SimpleTestCase
+
+from core.image_sources import (
+    get_image_layer_count,
+    is_recognized_image_file,
+    is_supported_image_filename,
+    load_image_stack,
+)
+
+
+class ImageSourceTests(SimpleTestCase):
+    def test_supported_source_extensions_are_case_insensitive(self):
+        self.assertTrue(is_supported_image_filename("sample.dv"))
+        self.assertTrue(is_supported_image_filename("sample.TIF"))
+        self.assertTrue(is_supported_image_filename("sample.tiff"))
+        self.assertFalse(is_supported_image_filename("sample.png"))
+
+    def test_single_page_tiff_loads_as_one_layer_stack(self):
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "single.tif"
+            tifffile.imwrite(path, np.arange(12, dtype=np.uint16).reshape(3, 4))
+
+            stack = load_image_stack(path)
+
+        self.assertEqual(stack.shape, (1, 3, 4))
+        self.assertEqual(stack.dtype, np.uint16)
+
+    def test_multi_page_tiff_loads_channel_first(self):
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "stack.tiff"
+            expected = np.arange(4 * 5 * 6, dtype=np.uint16).reshape(4, 5, 6)
+            tifffile.imwrite(path, expected, photometric="minisblack")
+
+            stack = load_image_stack(path)
+            layer_count = get_image_layer_count(path)
+            recognized = is_recognized_image_file(path)
+
+        np.testing.assert_array_equal(stack, expected)
+        self.assertEqual(layer_count, 4)
+        self.assertTrue(recognized)
+
+    def test_rgb_tiff_is_not_treated_as_microscopy_layer_stack(self):
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "rgb.tif"
+            tifffile.imwrite(path, np.zeros((5, 6, 3), dtype=np.uint8), photometric="rgb")
+
+            with self.assertRaises(ValueError):
+                load_image_stack(path)
+            self.assertFalse(is_recognized_image_file(path))

--- a/cytocv/core/tests/test_scale_upload_initialization.py
+++ b/cytocv/core/tests/test_scale_upload_initialization.py
@@ -1,4 +1,4 @@
-﻿"""Integration tests for upload-time per-file scale initialization."""
+"""Integration tests for upload-time per-file scale initialization."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
-from core.metadata_processing.error_handling.dv_validation import DVValidationResult
+from core.metadata_processing.error_handling.source_image_validation import SourceImageValidationResult
 from core.models import UploadedImage, UploadPreparationJob
 from core.services.upload_preparation import run_upload_preparation_job
 
@@ -43,7 +43,7 @@ class UploadScaleInitializationTests(TestCase):
             b"fake-dv-data",
             content_type="application/octet-stream",
         )
-        valid_result = DVValidationResult(
+        valid_result = SourceImageValidationResult(
             is_valid=True,
             layer_count=4,
             missing_channels=set(),
@@ -53,7 +53,7 @@ class UploadScaleInitializationTests(TestCase):
         with TemporaryDirectory() as temp_media:
             with override_settings(MEDIA_ROOT=temp_media):
                 with patch(
-                    "core.services.upload_preparation.validate_dv_file",
+                    "core.services.upload_preparation.validate_source_image_file",
                     return_value=valid_result,
                 ):
                     with patch(

--- a/cytocv/core/tests/test_stats_validation.py
+++ b/cytocv/core/tests/test_stats_validation.py
@@ -1,9 +1,11 @@
-﻿from django.test import SimpleTestCase
+from django.test import SimpleTestCase
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import patch
 import cv2
 import numpy as np
+import tifffile
 
 from core.cell_analysis import (
     BlueNucleusIntensity,
@@ -12,13 +14,14 @@ from core.cell_analysis import (
     PunctaDistance,
     RedBlueIntensity,
 )
+from core.config import DEFAULT_CHANNEL_CONFIG
 from core.image_processing import GrayImage
-from core.metadata_processing.error_handling.dv_validation import (
-    DVValidationOptions,
-    DVValidationResult,
-    build_dv_error_messages,
+from core.metadata_processing.error_handling.source_image_validation import (
+    SourceImageValidationOptions,
+    SourceImageValidationResult,
+    build_source_image_error_messages,
     get_effective_required_channels,
-    validate_dv_file,
+    validate_source_image_file,
 )
 from core.metadata_processing.dv_channel_parser import extract_channel_config
 from core.stats_plugins import build_plugin_ui_payload, build_requirement_summary, normalize_selected_plugins
@@ -64,27 +67,27 @@ class StatsRequirementTests(SimpleTestCase):
         self.assertIn("opposite", description)
 
 
-class DVErrorMessageTests(SimpleTestCase):
+class SourceImageErrorMessageTests(SimpleTestCase):
     def test_missing_channels_are_grouped_by_combination(self):
-        options = DVValidationOptions(
+        options = SourceImageValidationOptions(
             enforce_layer_count=True,
             enforce_wavelengths=False,
             required_channels={"DIC", "channel_blue"},
         )
         failures = [
-            ("file_a", DVValidationResult(False, 4, {"channel_blue"}, required_channels={"DIC", "channel_blue"})),
-            ("file_b", DVValidationResult(False, 4, {"channel_blue"}, required_channels={"DIC", "channel_blue"})),
-            ("file_c", DVValidationResult(False, 4, {"DIC", "channel_blue"}, required_channels={"DIC", "channel_blue"})),
+            ("file_a", SourceImageValidationResult(False, 4, {"channel_blue"}, required_channels={"DIC", "channel_blue"})),
+            ("file_b", SourceImageValidationResult(False, 4, {"channel_blue"}, required_channels={"DIC", "channel_blue"})),
+            ("file_c", SourceImageValidationResult(False, 4, {"DIC", "channel_blue"}, required_channels={"DIC", "channel_blue"})),
         ]
 
-        lines = build_dv_error_messages(failures, options)
+        lines = build_source_image_error_messages(failures, options)
         message_blob = "\n".join(lines)
         self.assertIn("The following wavelengths are required: DIC, Blue.", message_blob)
         self.assertIn("- file_a.dv, file_b.dv: missing Blue", message_blob)
         self.assertIn("- file_c.dv: missing all required wavelengths", message_blob)
 
     def test_effective_required_channels_include_advanced_full_toggle(self):
-        options = DVValidationOptions(
+        options = SourceImageValidationOptions(
             enforce_layer_count=True,
             enforce_wavelengths=True,
             required_channels={"DIC"},
@@ -93,67 +96,67 @@ class DVErrorMessageTests(SimpleTestCase):
         self.assertEqual(required, {"DIC", "channel_blue", "channel_red", "channel_green"})
 
     def test_layer_count_errors_not_reported_when_layer_enforcement_is_disabled(self):
-        options = DVValidationOptions(
+        options = SourceImageValidationOptions(
             enforce_layer_count=False,
             enforce_wavelengths=False,
             required_channels={"DIC", "channel_green"},
         )
         failures = [
-            ("file_a", DVValidationResult(False, 1, {"channel_green"}, required_channels={"DIC", "channel_green"})),
+            ("file_a", SourceImageValidationResult(False, 1, {"channel_green"}, required_channels={"DIC", "channel_green"})),
         ]
 
-        lines = build_dv_error_messages(failures, options)
+        lines = build_source_image_error_messages(failures, options)
         message_blob = "\n".join(lines)
         self.assertIn("missing required wavelengths", message_blob)
         self.assertNotIn("invalid layer counts", message_blob)
 
     def test_single_required_channel_message_does_not_use_all_required_phrase(self):
-        options = DVValidationOptions(
+        options = SourceImageValidationOptions(
             enforce_layer_count=False,
             enforce_wavelengths=False,
             required_channels={"DIC"},
         )
         failures = [
-            ("file_a", DVValidationResult(False, 1, {"DIC"}, required_channels={"DIC"})),
+            ("file_a", SourceImageValidationResult(False, 1, {"DIC"}, required_channels={"DIC"})),
         ]
-        lines = build_dv_error_messages(failures, options)
+        lines = build_source_image_error_messages(failures, options)
         message_blob = "\n".join(lines)
         self.assertIn("- file_a.dv: missing DIC", message_blob)
         self.assertNotIn("missing all required wavelengths", message_blob)
 
 
-class DVValidationPresenceTests(SimpleTestCase):
-    @patch("core.metadata_processing.error_handling.dv_validation.is_recognized_dv_file", return_value=True)
-    @patch("core.metadata_processing.error_handling.dv_validation.get_dv_layer_count", return_value=1)
+class SourceImageValidationPresenceTests(SimpleTestCase):
+    @patch("core.metadata_processing.error_handling.source_image_validation.is_recognized_image_file", return_value=True)
+    @patch("core.metadata_processing.error_handling.source_image_validation.get_image_layer_count", return_value=1)
     @patch(
-        "core.metadata_processing.error_handling.dv_validation.extract_channel_config",
+        "core.metadata_processing.error_handling.source_image_validation.extract_channel_config",
         return_value={"DIC": 0, "mCherry": 1, "GFP": 2},
     )
     def test_required_channels_must_exist_in_actual_layer_indices(self, _cfg, _layers, _recognized):
-        options = DVValidationOptions(
+        options = SourceImageValidationOptions(
             enforce_layer_count=False,
             enforce_wavelengths=False,
             required_channels={"DIC", "channel_red", "channel_green"},
         )
 
-        result = validate_dv_file(Path("dummy.dv"), options)
+        result = validate_source_image_file(Path("dummy.dv"), options)
         self.assertFalse(result.is_valid)
         self.assertEqual(result.missing_channels, {"channel_red", "channel_green"})
 
-    @patch("core.metadata_processing.error_handling.dv_validation.is_recognized_dv_file", return_value=True)
-    @patch("core.metadata_processing.error_handling.dv_validation.get_dv_layer_count", return_value=3)
+    @patch("core.metadata_processing.error_handling.source_image_validation.is_recognized_image_file", return_value=True)
+    @patch("core.metadata_processing.error_handling.source_image_validation.get_image_layer_count", return_value=3)
     @patch(
-        "core.metadata_processing.error_handling.dv_validation.extract_channel_config",
+        "core.metadata_processing.error_handling.source_image_validation.extract_channel_config",
         return_value={"DIC": 0, "red": 1, "GFP": 2},
     )
     def test_channel_name_aliases_are_accepted(self, _cfg, _layers, _recognized):
-        options = DVValidationOptions(
+        options = SourceImageValidationOptions(
             enforce_layer_count=False,
             enforce_wavelengths=False,
             required_channels={"DIC", "channel_red", "channel_green"},
         )
 
-        result = validate_dv_file(Path("dummy.dv"), options)
+        result = validate_source_image_file(Path("dummy.dv"), options)
         self.assertTrue(result.is_valid)
         self.assertEqual(result.missing_channels, set())
 
@@ -186,22 +189,62 @@ class DVChannelParserTests(SimpleTestCase):
             },
         )
 
-    @patch("core.metadata_processing.error_handling.dv_validation.is_recognized_dv_file", return_value=True)
-    @patch("core.metadata_processing.error_handling.dv_validation.get_dv_layer_count", return_value=1)
+    @patch("core.metadata_processing.error_handling.source_image_validation.is_recognized_image_file", return_value=True)
+    @patch("core.metadata_processing.error_handling.source_image_validation.get_image_layer_count", return_value=1)
     @patch(
-        "core.metadata_processing.error_handling.dv_validation.extract_channel_config",
+        "core.metadata_processing.error_handling.source_image_validation.extract_channel_config",
         return_value={"w1DIC": 0},
     )
     def test_dic_name_variants_are_accepted(self, _cfg, _layers, _recognized):
-        options = DVValidationOptions(
+        options = SourceImageValidationOptions(
             enforce_layer_count=False,
             enforce_wavelengths=False,
             required_channels={"DIC"},
         )
 
-        result = validate_dv_file(Path("dummy.dv"), options)
+        result = validate_source_image_file(Path("dummy.dv"), options)
         self.assertTrue(result.is_valid)
         self.assertEqual(result.missing_channels, set())
+
+    def test_tiff_uses_default_channel_mapping_for_required_channels(self):
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "default_channels.tif"
+            tifffile.imwrite(
+                path,
+                np.ones((4, 5, 6), dtype=np.uint16),
+                photometric="minisblack",
+            )
+            options = SourceImageValidationOptions(
+                enforce_layer_count=False,
+                enforce_wavelengths=False,
+                required_channels={"DIC", "channel_blue", "channel_red", "channel_green"},
+            )
+
+            config = extract_channel_config(path)
+            result = validate_source_image_file(path, options)
+
+        self.assertEqual(config, DEFAULT_CHANNEL_CONFIG)
+        self.assertTrue(result.is_valid)
+        self.assertEqual(result.missing_channels, set())
+
+    def test_tiff_layer_count_enforcement_uses_stack_pages(self):
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "three_layers.tiff"
+            tifffile.imwrite(
+                path,
+                np.ones((3, 5, 6), dtype=np.uint16),
+                photometric="minisblack",
+            )
+            options = SourceImageValidationOptions(
+                enforce_layer_count=True,
+                enforce_wavelengths=False,
+                required_channels=set(),
+            )
+
+            result = validate_source_image_file(path, options)
+
+        self.assertFalse(result.is_valid)
+        self.assertEqual(result.layer_count, 3)
 
 
 class AnalysisRegressionTests(SimpleTestCase):

--- a/cytocv/core/tests/test_tiff_channel_parser.py
+++ b/cytocv/core/tests/test_tiff_channel_parser.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from django.test import SimpleTestCase
+import numpy as np
+import tifffile
+
+from core.config import DEFAULT_CHANNEL_CONFIG
+from core.metadata_processing.tiff_channel_parser import (
+    build_tiff_channel_config_from_labels,
+    extract_tiff_channel_config,
+)
+
+
+class TiffChannelParserTests(SimpleTestCase):
+    def test_softworx_imagej_labels_map_complete_channel_order(self):
+        labels = [
+            "2021_1028_M2208_001_PRJ_w625.tif\nSoftware: Source: softWoRx\n",
+            "2021_1028_M2208_001_PRJ_w435.tif\nSoftware: Source: softWoRx\n",
+            "2021_1028_M2208_001_PRJ_w525.tif\nSoftware: Source: softWoRx\n",
+            "2021_1028_M2208_001_R3D_REF.tif\nSoftware: Source: softWoRx\n",
+        ]
+
+        config = build_tiff_channel_config_from_labels(labels)
+
+        self.assertEqual(
+            config,
+            {
+                "channel_red": 0,
+                "channel_blue": 1,
+                "channel_green": 2,
+                "DIC": 3,
+            },
+        )
+
+    def test_softworx_imagej_labels_map_different_valid_order(self):
+        labels = [
+            "sample_PRJ_w625.tif",
+            "sample_PRJ_w525.tif",
+            "sample_PRJ_w435.tif",
+            "sample_R3D_REF.tif",
+        ]
+
+        config = build_tiff_channel_config_from_labels(labels)
+
+        self.assertEqual(
+            config,
+            {
+                "channel_red": 0,
+                "channel_green": 1,
+                "channel_blue": 2,
+                "DIC": 3,
+            },
+        )
+
+    def test_ambiguous_labels_return_no_metadata_config(self):
+        labels = [
+            "sample_PRJ_w625.tif",
+            "sample_PRJ_w625_duplicate.tif",
+            "sample_PRJ_w525.tif",
+            "sample_R3D_REF.tif",
+        ]
+
+        self.assertIsNone(build_tiff_channel_config_from_labels(labels))
+
+    def test_unlabeled_tiff_uses_default_channel_config(self):
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "unlabeled.tif"
+            tifffile.imwrite(
+                path,
+                np.ones((4, 5, 6), dtype=np.uint16),
+                photometric="minisblack",
+            )
+
+            config = extract_tiff_channel_config(path)
+
+        self.assertEqual(config, DEFAULT_CHANNEL_CONFIG)
+
+    def test_imagej_label_metadata_is_read_from_tiff(self):
+        labels = [
+            "sample_PRJ_w625.tif",
+            "sample_PRJ_w435.tif",
+            "sample_PRJ_w525.tif",
+            "sample_R3D_REF.tif",
+        ]
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "labeled.tif"
+            tifffile.imwrite(
+                path,
+                np.ones((4, 5, 6), dtype=np.uint16),
+                photometric="minisblack",
+                imagej=True,
+                metadata={"Labels": labels, "mode": "composite"},
+            )
+
+            config = extract_tiff_channel_config(path)
+
+        self.assertEqual(
+            config,
+            {
+                "channel_red": 0,
+                "channel_blue": 1,
+                "channel_green": 2,
+                "DIC": 3,
+            },
+        )

--- a/cytocv/core/tests/test_tiff_scale_parser.py
+++ b/cytocv/core/tests/test_tiff_scale_parser.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from django.test import SimpleTestCase
+import numpy as np
+import tifffile
+
+from core.metadata_processing.tiff_scale_parser import extract_tiff_scale_metadata
+
+
+class TiffScaleParserTests(SimpleTestCase):
+    def test_missing_physical_scale_metadata_returns_missing(self):
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "no_scale.tif"
+            tifffile.imwrite(
+                path,
+                np.ones((4, 5, 6), dtype=np.uint16),
+                photometric="minisblack",
+                imagej=True,
+                metadata={"mode": "composite"},
+            )
+
+            payload = extract_tiff_scale_metadata(path)
+
+        self.assertEqual(payload["status"], "missing")
+        self.assertIsNone(payload["metadata_um_per_px"])
+
+    def test_standard_resolution_tags_produce_scale(self):
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "standard_scale.tif"
+            tifffile.imwrite(
+                path,
+                np.ones((4, 5, 6), dtype=np.uint16),
+                photometric="minisblack",
+                resolution=(10000, 10000),
+                resolutionunit="CENTIMETER",
+            )
+
+            payload = extract_tiff_scale_metadata(path)
+
+        self.assertEqual(payload["status"], "ok")
+        self.assertAlmostEqual(payload["metadata_um_per_px"], 1.0, places=6)
+        self.assertAlmostEqual(payload["dx"], 1.0, places=6)
+        self.assertAlmostEqual(payload["dy"], 1.0, places=6)
+
+    def test_imagej_unit_and_resolution_produce_scale(self):
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "imagej_scale.tif"
+            tifffile.imwrite(
+                path,
+                np.ones((4, 5, 6), dtype=np.uint16),
+                photometric="minisblack",
+                imagej=True,
+                metadata={"unit": "um"},
+                resolution=(10, 10),
+            )
+
+            payload = extract_tiff_scale_metadata(path)
+
+        self.assertEqual(payload["status"], "ok")
+        self.assertAlmostEqual(payload["metadata_um_per_px"], 0.1, places=6)
+        self.assertAlmostEqual(payload["dx"], 0.1, places=6)
+        self.assertAlmostEqual(payload["dy"], 0.1, places=6)

--- a/cytocv/core/tests/test_upload_length_scale.py
+++ b/cytocv/core/tests/test_upload_length_scale.py
@@ -1,8 +1,13 @@
 ﻿"""Unit tests for upload-length conversion helpers."""
 
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from django.test import SimpleTestCase
 from unittest.mock import patch
+
+import numpy as np
+import tifffile
 
 from core.cell_analysis import CENDot
 from core.metadata_processing.dv_scale_parser import extract_dv_scale_metadata
@@ -340,3 +345,20 @@ class DVScaleMetadataParserTests(SimpleTestCase):
         payload = extract_dv_scale_metadata("dummy.dv")
         self.assertEqual(payload["status"], "invalid")
         self.assertIsNone(payload["metadata_um_per_px"])
+
+    def test_extract_tiff_scale_metadata_from_resolution_tags(self):
+        with TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "scaled.tif"
+            tifffile.imwrite(
+                path,
+                np.ones((4, 5, 6), dtype=np.uint16),
+                resolution=(10000, 10000),
+                resolutionunit="CENTIMETER",
+            )
+
+            payload = extract_dv_scale_metadata(path)
+
+        self.assertEqual(payload["status"], "ok")
+        self.assertAlmostEqual(payload["metadata_um_per_px"], 1.0, places=6)
+        self.assertAlmostEqual(payload["dx"], 1.0, places=6)
+        self.assertAlmostEqual(payload["dy"], 1.0, places=6)

--- a/cytocv/core/tests/test_upload_preparation.py
+++ b/cytocv/core/tests/test_upload_preparation.py
@@ -15,7 +15,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from core.config import DEFAULT_CHANNEL_CONFIG
-from core.metadata_processing.error_handling import DVValidationResult
+from core.metadata_processing.error_handling import SourceImageValidationResult
 from core.models import AnalysisJob, UploadedImage, UploadPreparationJob
 from core.services.analysis_jobs import enqueue_analysis_job
 from core.services.upload_preparation import (
@@ -68,8 +68,8 @@ class UploadPreparationTestCase(TestCase):
         )
 
     @staticmethod
-    def _valid_result() -> DVValidationResult:
-        return DVValidationResult(
+    def _valid_result() -> SourceImageValidationResult:
+        return SourceImageValidationResult(
             is_valid=True,
             layer_count=4,
             missing_channels=set(),
@@ -77,8 +77,8 @@ class UploadPreparationTestCase(TestCase):
         )
 
     @staticmethod
-    def _invalid_result(message: str = "not a recognized DV file") -> DVValidationResult:
-        return DVValidationResult(
+    def _invalid_result(message: str = "not a recognized supported image file") -> SourceImageValidationResult:
+        return SourceImageValidationResult(
             is_valid=False,
             layer_count=None,
             missing_channels=set(),
@@ -109,7 +109,7 @@ class UploadPreparationTestCase(TestCase):
             )
 
             with patch(
-                "core.services.upload_preparation.validate_dv_file",
+                "core.services.upload_preparation.validate_source_image_file",
                 return_value=self._valid_result(),
             ), patch(
                 "core.services.upload_preparation.extract_dv_scale_metadata",
@@ -148,7 +148,7 @@ class UploadPreparationTestCase(TestCase):
             )
 
             with patch(
-                "core.services.upload_preparation.validate_dv_file",
+                "core.services.upload_preparation.validate_source_image_file",
                 return_value=self._invalid_result(),
             ):
                 run_upload_preparation_job(job)
@@ -173,7 +173,7 @@ class UploadPreparationTestCase(TestCase):
                 return self._invalid_result() if "invalid_restored" in str(path) else self._valid_result()
 
             with patch(
-                "core.services.upload_preparation.validate_dv_file",
+                "core.services.upload_preparation.validate_source_image_file",
                 side_effect=validate_side_effect,
             ), patch(
                 "core.services.upload_preparation.extract_dv_scale_metadata",
@@ -204,7 +204,7 @@ class UploadPreparationTestCase(TestCase):
             )
 
             with patch(
-                "core.services.upload_preparation.validate_dv_file",
+                "core.services.upload_preparation.validate_source_image_file",
                 return_value=self._valid_result(),
             ), patch(
                 "core.services.upload_preparation.extract_dv_scale_metadata",
@@ -233,6 +233,31 @@ class UploadPreparationTestCase(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertFalse(UploadedImage.objects.exists())
+
+    def test_upload_batch_endpoint_accepts_tiff_files(self):
+        with temporary_media_root():
+            response = self.client.post(
+                reverse("experiment_upload_batch"),
+                {"files": [SimpleUploadedFile("sample.tiff", b"tiff")]},
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(UploadedImage.objects.count(), 1)
+        uploaded = UploadedImage.objects.get()
+        self.assertTrue(str(uploaded.file_location.name).endswith(".tiff"))
+
+    def test_legacy_experiment_post_accepts_tif_file(self):
+        with temporary_media_root():
+            response = self.client.post(
+                reverse("experiment"),
+                {"files": [SimpleUploadedFile("queued.tif", b"tiff")]},
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(UploadedImage.objects.count(), 1)
+        self.assertEqual(UploadPreparationJob.objects.count(), 1)
 
     def test_upload_preparation_status_forbids_other_user(self):
         job = enqueue_upload_preparation_job(
@@ -358,7 +383,7 @@ class UploadPreparationTestCase(TestCase):
             uploaded = self._create_uploaded_image(media_root, name="sync_ready")
 
             with patch(
-                "core.services.upload_preparation.validate_dv_file",
+                "core.services.upload_preparation.validate_source_image_file",
                 return_value=self._valid_result(),
             ), patch(
                 "core.services.upload_preparation.extract_dv_scale_metadata",
@@ -394,7 +419,7 @@ class UploadPreparationTestCase(TestCase):
             uploaded = self._create_uploaded_image(media_root, name="sync_invalid")
 
             with patch(
-                "core.services.upload_preparation.validate_dv_file",
+                "core.services.upload_preparation.validate_source_image_file",
                 return_value=self._invalid_result(),
             ):
                 response = self.client.post(

--- a/cytocv/core/views/experiment.py
+++ b/cytocv/core/views/experiment.py
@@ -33,6 +33,10 @@ from core.scale import (
     normalize_length_unit,
     parse_microns_per_pixel,
 )
+from core.image_sources import (
+    SUPPORTED_IMAGE_EXTENSIONS_LABEL,
+    is_supported_image_filename,
+)
 from core.services.biorientation_config import (
     DEFAULT_BIORIENTATION_COLLINEARITY_THRESHOLD_PX,
 )
@@ -777,11 +781,15 @@ def experiment(request):
         _persist_experiment_session(request, session_values)
 
         invalid_names = [
-            file.name for file in files if Path(str(file.name)).suffix.lower() != ".dv"
+            file.name for file in files if not is_supported_image_filename(file.name)
         ]
         if invalid_names:
             return JsonResponse(
-                {"errors": ["Only DeltaVision .dv files can be uploaded."]},
+                {
+                    "errors": [
+                        f"Only supported image files ({SUPPORTED_IMAGE_EXTENSIONS_LABEL}) can be uploaded."
+                    ]
+                },
                 status=400,
             )
 
@@ -947,7 +955,7 @@ def save_experiment_workflow_defaults(request):
 
 @require_POST
 def upload_file_batch(request):
-    """Save a small batch of DV files and return queued upload UUIDs."""
+    """Save a small batch of source image files and return queued upload UUIDs."""
 
     files = request.FILES.getlist("files")
     if not files:
@@ -968,11 +976,15 @@ def upload_file_batch(request):
     created_uuids: list[str] = []
     uploaded_items: list[dict[str, str]] = []
     invalid_names = [
-        file.name for file in files if Path(str(file.name)).suffix.lower() != ".dv"
+        file.name for file in files if not is_supported_image_filename(file.name)
     ]
     if invalid_names:
         return JsonResponse(
-            {"errors": ["Only DeltaVision .dv files can be uploaded."]},
+            {
+                "errors": [
+                    f"Only supported image files ({SUPPORTED_IMAGE_EXTENSIONS_LABEL}) can be uploaded."
+                ]
+            },
             status=400,
         )
 

--- a/cytocv/core/views/home.py
+++ b/cytocv/core/views/home.py
@@ -345,7 +345,7 @@ ABOUT_TECHNICAL_PAGE = {
     "page_title": "Technical Overview",
     "show_doc_overview": False,
     "page_intro": (
-        "CytoCV is organized as a web application that moves from DeltaVision upload "
+        "CytoCV is organized as a web application that moves from supported source-image upload "
         "through export, with supporting documentation for workflow stages, major "
         "dependencies, outputs, and repository references."
     ),
@@ -385,7 +385,7 @@ ABOUT_TECHNICAL_PAGE = {
             "eyebrow": "Pipeline",
             "title": "End-to-end workflow from upload to export",
             "paragraphs": (
-                "A typical run begins with DeltaVision `.dv` upload, channel validation, preview generation, and scale extraction. After that, the workflow advances through preprocess review, segmentation, per-cell measurement, display review, and export.",
+                "A typical run begins with supported `.dv`, `.tif`, or `.tiff` upload, channel validation, preview generation, and scale extraction. After that, the workflow advances through preprocess review, segmentation, per-cell measurement, display review, and export.",
                 "Each stage keeps the run configuration, channel interpretation, and produced outputs connected so researchers can review what happened at each point in the pipeline instead of only seeing a final spreadsheet.",
             ),
             "highlights": (
@@ -709,11 +709,11 @@ RESEARCH_SECTIONS = (
         "summary": (
             "CytoCV is documented as a web-based analysis system for DeltaVision microscopy "
             "of yeast cells. The active implementation combines authenticated web "
-            "workflows, DeltaVision-specific metadata parsing, Mask R-CNN-based segmentation, "
+            "workflows, source-image metadata parsing, Mask R-CNN-based segmentation, "
             "plugin-scoped per-cell quantification, and retention-aware result management."
         ),
         "highlights": (
-            "DeltaVision .dv ingestion stays connected to channel interpretation, scale context, and measurement output.",
+            "Supported source-image ingestion stays connected to channel interpretation, scale context, and measurement output.",
             "The computational path moves from upload and preview generation into DIC-driven segmentation and per-cell quantification.",
             "The platform is described as a domain-specific research workflow rather than a generic microscopy framework.",
         ),

--- a/cytocv/core/views/pre_process.py
+++ b/cytocv/core/views/pre_process.py
@@ -56,8 +56,11 @@ from .utils import (
     prune_experiment_session_state,
     sync_transient_run_session_state,
 )
-from core.channel_roles import CHANNEL_ROLE_ORDER, channel_display_label
+from core.channel_roles import CHANNEL_ROLE_ORDER, channel_display_label, normalize_channel_role
+from core.config import DEFAULT_CHANNEL_CONFIG
+from core.image_sources import TIFF_IMAGE_EXTENSIONS, source_image_extension
 from core.metadata_processing.dv_channel_parser import extract_channel_config
+from core.metadata_processing.tiff_channel_parser import extract_tiff_metadata_channel_config
 from core.mrcnn.my_inference import predict_images
 from core.mrcnn.preprocess_images import preprocess_images
 
@@ -88,6 +91,53 @@ PROCESSING_STORAGE_FULL_MESSAGE = (
     "Files could not be saved because storage is full. Free up space and try again."
 )
 logger = logging.getLogger(__name__)
+
+
+def _normalize_channel_config(config: dict[str, object]) -> dict[str, int]:
+    normalized: dict[str, int] = {}
+    for channel, index in (config or {}).items():
+        role = normalize_channel_role(channel)
+        if role is None:
+            continue
+        try:
+            normalized[role] = int(index)
+        except (TypeError, ValueError):
+            continue
+    return normalized
+
+
+def _write_channel_config(path: Path, config: dict[str, int]) -> None:
+    path.write_text(json.dumps(config), encoding="utf-8")
+
+
+def _refresh_default_tiff_channel_config(
+    uploaded: UploadedImage,
+    config_path: Path,
+    config: dict[str, object],
+) -> dict[str, int]:
+    """Refresh old default TIFF configs when complete metadata is available."""
+
+    normalized_config = _normalize_channel_config(config)
+    if normalized_config != DEFAULT_CHANNEL_CONFIG:
+        return normalized_config
+
+    source_path = Path(MEDIA_ROOT) / str(uploaded.file_location)
+    if source_image_extension(source_path) not in TIFF_IMAGE_EXTENSIONS:
+        return normalized_config
+
+    metadata_config = extract_tiff_metadata_channel_config(source_path)
+    if metadata_config is None or metadata_config == normalized_config:
+        return normalized_config
+
+    _write_channel_config(config_path, metadata_config)
+    return metadata_config
+
+
+def _channel_labels_from_config(config: dict[str, int]) -> list[str]:
+    return [
+        channel_display_label(channel)
+        for channel, _ in sorted(config.items(), key=lambda item: item[1])
+    ]
 PROGRESS_BATCH_SESSION_KEY = "authorized_progress_batches"
 
 
@@ -387,18 +437,14 @@ def pre_process(request, uuids):
         cfg_path = Path(MEDIA_ROOT) / uid / 'channel_config.json'
         if cfg_path.exists():
             cfg = json.loads(cfg_path.read_text())
-            detected_channels = [
-                channel_display_label(ch) for ch, _ in sorted(cfg.items(), key=lambda t: t[1])
-            ]
+            cfg = _refresh_default_tiff_channel_config(uploaded, cfg_path, cfg)
+            detected_channels = _channel_labels_from_config(cfg)
         else:
-            # fallback: parse header of first .dv file
-            dv_files = list((Path(MEDIA_ROOT) / uid).glob('*.dv'))
-            if dv_files:
-                cfg = extract_channel_config(str(dv_files[0]))
-                detected_channels = [
-                    channel_display_label(ch)
-                    for ch, _ in sorted(cfg.items(), key=lambda t: t[1])
-                ]
+            # fallback: parse the stored source image file
+            source_path = Path(MEDIA_ROOT) / str(uploaded.file_location)
+            if source_path.exists():
+                cfg = extract_channel_config(str(source_path))
+                detected_channels = _channel_labels_from_config(cfg)
             else:
                 detected_channels = []
 
@@ -924,20 +970,30 @@ def cancel_progress(request, uuids):
 @require_POST
 @csrf_exempt
 def update_channel_order(request, uuid):
-    """
-    POST {order: ["DIC","channel_blue","channel_red","channel_green"]}
-    → overwrite channel_config.json in MEDIA_ROOT/<uuid>/
-    """
+    """Persist a user-selected channel order for one uploaded source image."""
+
     try:
         data = json.loads(request.body)
         new_order = data.get('order', [])
-        expected = set(CHANNEL_ROLE_ORDER)
-        if set(new_order) != expected:
+        if not isinstance(new_order, list):
             return JsonResponse({'error': 'Invalid channel order.'}, status=400)
 
-        # new: 0–3 mapping to match your layer filenames
-        mapping = {ch: i for i, ch in enumerate(new_order)}
+        normalized_order = [
+            normalize_channel_role(channel)
+            for channel in new_order
+        ]
+        expected = set(CHANNEL_ROLE_ORDER)
+        if (
+            any(channel is None for channel in normalized_order)
+            or len(normalized_order) != len(CHANNEL_ROLE_ORDER)
+            or set(normalized_order) != expected
+        ):
+            return JsonResponse({'error': 'Invalid channel order.'}, status=400)
 
+        mapping = {
+            str(channel): index
+            for index, channel in enumerate(normalized_order)
+        }
 
         cfg_path = Path(MEDIA_ROOT) / uuid / 'channel_config.json'
         if not cfg_path.exists():
@@ -946,8 +1002,7 @@ def update_channel_order(request, uuid):
                 status=404,
             )
 
-        # SAVE: overwrite the JSON file with new mapping
-        cfg_path.write_text(json.dumps(mapping))
+        _write_channel_config(cfg_path, mapping)
         return JsonResponse({'status': 'ok'})
 
     except Exception:

--- a/cytocv/core/views/segment_image.py
+++ b/cytocv/core/views/segment_image.py
@@ -32,7 +32,6 @@ import numpy as np
 import skimage
 from PIL import Image
 from cv2_rolling_ball import subtract_background_rolling_ball
-from mrc import DVFile
 from scipy.spatial.distance import euclidean
 from skimage import io
 
@@ -62,6 +61,7 @@ from core.config import (
     input_dir,
     output_dir,
 )
+from core.image_sources import load_image_stack
 from core.models import CellStatistics, Contour, SegmentedImage, UploadedImage, get_guest_user
 from core.image_processing import (
     ensure_3channel_bgr,
@@ -673,18 +673,15 @@ def segment_image(request, uuids):
         uploaded_image = get_object_or_404(UploadedImage, pk=uuid, **owner_filter)
         DV_Name = uploaded_image.name
         DV_path = _resolve_uploaded_dv_path(uploaded_image)
+        source_image_name = Path(str(uploaded_image.file_location.name or "")).name or f"{DV_Name}.dv"
         channel_config = get_channel_config_for_uuid(uuid)
         layer_channel_lookup = _build_layer_channel_lookup(channel_config)
         image_dict = dict()
         image_dict[DV_Name] = list()
 
-        # Need to grab the original DV file
+        # Need to grab the original source image file
         # Load the original raw image and rescale its intensity values
-        f = DVFile(DV_path)
-        try:
-            im = f.asarray()
-        finally:
-            f.close()
+        im = load_image_stack(DV_path)
         if im.ndim == 2:
             im = np.expand_dims(im, axis=0)
 
@@ -766,20 +763,15 @@ def segment_image(request, uuids):
             lines_to_draw = dict()
             if resolve_cells_using_spc110:
 
-                # Open the red channel from the DV stack.
+                # Open the red channel from the source image stack.
 
                 # basename = image_name.split('_R3D_REF')[0]
                 # red_dir = input_dir + basename + '_PRJ_TIFFS/'
                 # red_image_name = basename + '_PRJ' + '_w625' + '.tif'
                 # red_image = np.array(Image.open(red_dir + red_image_name))
 
-                # Which file are we trying to find here?
-                f = DVFile(DV_path)
-                try:
-                    red_index = channel_config.get(CHANNEL_ROLE_RED)
-                    red_image = f.asarray()[red_index]
-                finally:
-                    f.close()
+                red_index = channel_config.get(CHANNEL_ROLE_RED)
+                red_image = im[red_index]
 
                 red_image = np.round(red_image * 255).astype(np.uint8)
 
@@ -977,11 +969,6 @@ def segment_image(request, uuids):
         #if os.path.isdir(to_open):
         #    continue
         #image = np.array(Image.open(to_open))
-        f = DVFile(DV_path)
-        try:
-            im = f.asarray()
-        finally:
-            f.close()
         if im.ndim == 2:
             im = np.expand_dims(im, axis=0)
 
@@ -1087,11 +1074,7 @@ def segment_image(request, uuids):
             if is_storage_full_error(exc):
                 return storage_full_response(exc)
             raise
-        f = DVFile(DV_path)
-        try:
-            image_stack = f.asarray()
-        finally:
-            f.close()
+        image_stack = im
         cell_image_cache: dict[int, dict[str, np.ndarray]] = defaultdict(dict)
         cell_measurement_image_cache: dict[int, dict[str, np.ndarray]] = defaultdict(dict)
 
@@ -1564,7 +1547,7 @@ def segment_image(request, uuids):
 
                     # Store file path information
                     'dv_file_path': str(DV_path),
-                    'image_name': DV_Name + '.dv',
+                    'image_name': source_image_name,
                 }
             )
 

--- a/cytocv/templates/about.html
+++ b/cytocv/templates/about.html
@@ -272,7 +272,7 @@
                 <h2 class="about-card-title">What CytoCV Is</h2>
             </div>
             <div class="about-copy">
-                <p>CytoCV is a browser-based analysis workflow for DeltaVision <code>.dv</code> microscopy of yeast cells. It is designed to keep image files, channel interpretation, scale context, and measurement outputs connected in one place.</p>
+                <p>CytoCV is a browser-based analysis workflow for supported <code>.dv</code>, <code>.tif</code>, and <code>.tiff</code> microscopy files of yeast cells. It is designed to keep image files, channel interpretation, scale context, and measurement outputs connected in one place.</p>
                 <p>The platform supports a modern default analysis path centered on structural segmentation plus red and green fluorescence measurements, while keeping older Blue-based workflows available as legacy paths when they are needed.</p>
             </div>
             <ul class="about-channel-list" aria-label="Channel roles">
@@ -324,7 +324,7 @@
                 <h2 class="about-card-title">How the Workflow Works</h2>
             </div>
             <div class="about-copy">
-                <p>Researchers upload DeltaVision <code>.dv</code> files, and CytoCV validates the channels required for the selected workflow before analysis proceeds. Preview images are generated first so the file can be checked before segmentation and measurement begin.</p>
+                <p>Researchers upload supported <code>.dv</code>, <code>.tif</code>, or <code>.tiff</code> files, and CytoCV validates the channels required for the selected workflow before analysis proceeds. Preview images are generated first so the file can be checked before segmentation and measurement begin.</p>
                 <p>The platform then uses <code>DIC</code>, a structural brightfield-like channel, as the input for Mask R-CNN-based cell segmentation. After cells are segmented, CytoCV computes software-generated per-cell measurements and presents the results for review and export.</p>
             </div>
             <p class="about-output-label">Workflow outputs</p>
@@ -370,13 +370,13 @@
                 <h2 class="about-card-title">What Image Inputs CytoCV Expects</h2>
             </div>
             <div class="about-copy">
-                <p>CytoCV is built for DeltaVision <code>.dv</code> microscopy files from yeast imaging workflows. The platform expects image stacks that preserve the channel context needed for validation, preview generation, segmentation, and downstream measurement.</p>
+                <p>CytoCV is built for single-file microscopy stacks from yeast imaging workflows. The platform accepts <code>.dv</code>, <code>.tif</code>, and <code>.tiff</code> files that preserve the channel context needed for validation, preview generation, segmentation, and downstream measurement.</p>
                 <p>In the current workflow, <code>DIC</code> provides the structural input for cell segmentation, while <code>Red</code> and <code>Green</code> channels provide the main fluorescence measurements. <code>Blue</code> remains relevant for older legacy analyses when that path is needed. Biology-facing names such as DAPI, mCherry, and GFP commonly map to the logical Blue, Red, and Green roles.</p>
             </div>
             <ul class="about-detail-list" aria-label="Image input expectations">
                 <li>
                     <strong>File format</strong>
-                    <span>DeltaVision <code>.dv</code> image stacks are the expected upload format.</span>
+                    <span><code>.dv</code>, <code>.tif</code>, and <code>.tiff</code> image stacks are supported upload formats.</span>
                 </li>
                 <li>
                     <strong>Structural input</strong>

--- a/cytocv/templates/form/experiment.html
+++ b/cytocv/templates/form/experiment.html
@@ -1973,7 +1973,7 @@
                         <div class="toggle-row subtoggle" id="layerCheckRow">
                             <div class="toggle-text">
                                 <span class="toggle-label-row">
-                                    <span class="toggle-label">Enforce 4-Image DV Files</span>
+                                    <span class="toggle-label">Enforce 4-Layer Files</span>
                                     <button
                                         type="button"
                                         class="info-dot compact advanced-info-dot"
@@ -2076,7 +2076,7 @@
         <div class="buttons-container">
             <label class="upload-btn">
                 Upload Files
-                <input type="file" id="fileInput" accept=".dv" multiple>
+                <input type="file" id="fileInput" accept=".dv,.tif,.tiff" multiple>
             </label>
             <label class="upload-btn">
                 Upload Folders
@@ -2597,13 +2597,13 @@
         ]),
         optionalChecksInfoDot: buildInfoSections([
             'Controls the optional metadata and file validation checks below. When off, saved optional channel and layer requirements are paused, but channels required by selected statistics are still enforced.',
-            'Enforce 4-Image DV Files: requires exactly four DV layers before preprocessing.',
+            'Enforce 4-Layer Files: requires exactly four image layers before preprocessing.',
             'Require All Channels: requires DIC, Blue, Red, and Green for every upload.',
             'Manual channel toggles: require individual channels even when selected statistics do not need them.',
             'Required channels: DIC is always required; optional checks can also require Blue, Red, and Green.',
         ]),
         layerCheckInfoDot: buildInfoSections([
-            'Requires each DV file to have exactly four image layers before preprocessing. Use this to catch incomplete acquisitions or files exported with missing layers.',
+            'Requires each source image file to have exactly four image layers before preprocessing. Use this to catch incomplete acquisitions or files exported with missing layers.',
             'Required channels: not channel-specific.',
         ]),
         wavelengthCheckInfoDot: buildInfoSections([
@@ -6325,6 +6325,14 @@
         });
     }
 
+    const SUPPORTED_UPLOAD_EXTENSIONS = ['.dv', '.tif', '.tiff'];
+    const SUPPORTED_UPLOAD_EXTENSIONS_LABEL = '.dv, .tif, .tiff';
+
+    function isSupportedUploadFileName(fileName) {
+        const normalizedName = String(fileName || '').toLowerCase();
+        return SUPPORTED_UPLOAD_EXTENSIONS.some(extension => normalizedName.endsWith(extension));
+    }
+
     function openFolderIssueModal({ validCount, duplicateFiles, invalidFiles }) {
         const backdrop = document.getElementById('folderIssueBackdrop');
         const panel = backdrop ? backdrop.querySelector('.folder-issue-modal') : null;
@@ -6342,23 +6350,23 @@
 
         if (validCount > 0) {
             const plural = validCount === 1 ? '' : 's';
-            body.textContent = `Some files in this folder cannot be added. Add ${validCount} valid .dv file${plural} to the queue?`;
+            body.textContent = `Some files in this folder cannot be added. Add ${validCount} supported image file${plural} to the queue?`;
         } else {
-            body.textContent = 'No new DeltaVision .dv files are available to add from this folder.';
+            body.textContent = 'No new supported image files are available to add from this folder.';
         }
 
         list.innerHTML = '';
         if (duplicateCount > 0) {
             const plural = duplicateCount === 1 ? '' : 's';
             const item = document.createElement('li');
-            item.textContent = `${duplicateCount} duplicate .dv file${plural} already in queue`;
+            item.textContent = `${duplicateCount} duplicate supported image file${plural} already in queue`;
             list.appendChild(item);
         }
         if (invalidCount > 0) {
             const item = document.createElement('li');
             item.textContent = invalidCount === 1
-                ? '1 file is not .dv'
-                : `${invalidCount} files are not .dv`;
+                ? `1 file is not a supported image file (${SUPPORTED_UPLOAD_EXTENSIONS_LABEL})`
+                : `${invalidCount} files are not supported image files (${SUPPORTED_UPLOAD_EXTENSIONS_LABEL})`;
             list.appendChild(item);
         }
 
@@ -6416,7 +6424,7 @@
         files.forEach(file => {
             const fileName = file.name;
 
-            if (!file.name.endsWith('.dv')) {
+            if (!isSupportedUploadFileName(file.name)) {
                 invalidFiles.push(file.name);
                 return;
             }
@@ -6451,7 +6459,7 @@
             const queueIssues = [];
             if (invalidFiles.length > 0) {
                 queueIssues.push(
-                    `Unsupported files detected (only DeltaVision .dv files are allowed): ${formatFileListForError(invalidFiles)}`
+                    `Unsupported files detected (only supported image files (${SUPPORTED_UPLOAD_EXTENSIONS_LABEL}) are allowed): ${formatFileListForError(invalidFiles)}`
                 );
             }
             if (duplicateFiles.length > 0) {
@@ -6725,7 +6733,7 @@
             const queuedCount = getQueuedCount();
             if (queuedCount === 0) {
                 showErrors([
-                    'No files selected. Upload at least one DeltaVision .dv file before preprocessing.',
+                    'No files selected. Upload at least one supported image file before preprocessing.',
                 ]);
                 return;
             }

--- a/cytocv/templates/home.html
+++ b/cytocv/templates/home.html
@@ -1,9 +1,9 @@
 ﻿{% extends 'base.html' %}
 {% block title %}CytoCV{% endblock title %}
 {% load static %}
-{% block meta_description %}CytoCV is a web-based analysis platform for DeltaVision .dv microscopy of yeast cells, supporting validation, segmentation, per-cell measurement, and review.{% endblock meta_description %}
-{% block og_description %}CytoCV is a web-based analysis platform for DeltaVision .dv microscopy of yeast cells, supporting validation, segmentation, per-cell measurement, and review.{% endblock og_description %}
-{% block twitter_description %}CytoCV is a web-based analysis platform for DeltaVision .dv microscopy of yeast cells, supporting validation, segmentation, per-cell measurement, and review.{% endblock twitter_description %}
+{% block meta_description %}CytoCV is a web-based analysis platform for supported .dv, .tif, and .tiff microscopy files of yeast cells, supporting validation, segmentation, per-cell measurement, and review.{% endblock meta_description %}
+{% block og_description %}CytoCV is a web-based analysis platform for supported .dv, .tif, and .tiff microscopy files of yeast cells, supporting validation, segmentation, per-cell measurement, and review.{% endblock og_description %}
+{% block twitter_description %}CytoCV is a web-based analysis platform for supported .dv, .tif, and .tiff microscopy files of yeast cells, supporting validation, segmentation, per-cell measurement, and review.{% endblock twitter_description %}
 
 {% block head %}
     <style>
@@ -677,7 +677,7 @@
                         <div>
                             <p class="section-eyebrow">Developed at the University of Washington Bothell in collaboration with researchers from the Miller Lab at the University of Utah School of Medicine</p>
                             <h1>CytoCV: Automated Cell Image Analysis for Research Workflows</h1>
-                            <p>CytoCV helps researchers upload DeltaVision <code>.dv</code> microscopy stacks, segment individual yeast cells, and review software-generated cell-level measurements through a browser-based workflow. It brings validation, preprocessing, segmentation, review, and export together so experiments are easier to analyze and compare.</p>
+                            <p>CytoCV helps researchers upload supported <code>.dv</code>, <code>.tif</code>, and <code>.tiff</code> microscopy stacks, segment individual yeast cells, and review software-generated cell-level measurements through a browser-based workflow. It brings validation, preprocessing, segmentation, review, and export together so experiments are easier to analyze and compare.</p>
                             <div class="hero-affiliation" aria-label="Institutional affiliation details">
                                 <div class="hero-affiliation-brand" aria-hidden="true">
                                     <img src="{% static uwb_white_logo_static_path %}?v=20260429" alt="{{ uwb_logo_alt }}" class="hero-affiliation-logo">

--- a/cytocv/templates/workflow_defaults.html
+++ b/cytocv/templates/workflow_defaults.html
@@ -1968,7 +1968,7 @@ main.main > section.panel > form.panel > .card {
             <div class="row{% if not preferences.experiment_defaults.module_enabled %} disabled{% endif %}" id="advancedLayerCheckRow">
               <div class="row-copy">
                 <span class="row-label-line">
-                  <label for="enforce_layer_count">Enforce 4-Image DV Files</label>
+                            <label for="enforce_layer_count">Enforce 4-Layer Files</label>
                 </span>
                 <p class="module-help">Require exactly four layers before preprocessing.</p>
                 <p class="reqtxt">Requires: not channel-specific.</p>


### PR DESCRIPTION
This pull request introduces a major refactor to support both DV and TIFF microscopy image files throughout the codebase, generalizing image handling and metadata extraction. The changes unify logic for loading image stacks, reading channel and scale metadata, and validation, so that TIFF files are now treated as first-class supported sources alongside DV files. Many DV-specific functions and classes are now generalized to "source image" and TIFF-specific parsing logic is added.

The most important changes are:

**Generalization of image handling and validation:**
* Introduced `cytocv/core/image_sources.py`, which provides unified loading, normalization, and validation utilities for both DV and TIFF files, including functions like `load_image_stack`, `get_image_layer_count`, and `is_recognized_image_file`.
* Refactored validation logic: replaced DV-specific validation classes and functions with generalized `SourceImageValidationOptions`, `SourceImageValidationResult`, and `validate_source_image_file` in `source_image_validation.py` [[1]](diffhunk://#diff-b7b43a71b7a665cebc0fa1120c3c3224c13aaa77913846e859c8dc7643e720f0L48-R49) [[2]](diffhunk://#diff-b7b43a71b7a665cebc0fa1120c3c3224c13aaa77913846e859c8dc7643e720f0L57-R59) [[3]](diffhunk://#diff-b7b43a71b7a665cebc0fa1120c3c3224c13aaa77913846e859c8dc7643e720f0L67-R68) [[4]](diffhunk://#diff-b7b43a71b7a665cebc0fa1120c3c3224c13aaa77913846e859c8dc7643e720f0L76-R138).

**TIFF support in metadata extraction:**
* Added `tiff_channel_parser.py` for extracting TIFF channel configurations, including label parsing, channel role mapping, and fallback to defaults.
* Updated DV channel and scale parsers to delegate to TIFF-specific logic when appropriate, allowing seamless support for TIFF files in channel and scale metadata extraction [[1]](diffhunk://#diff-6158bdd3e7085ebac0f9cc5dd976d1791d428470b7675604221ead3bacf44862L84-R103) [[2]](diffhunk://#diff-cbbc926b416969380425775eb7a0f5d07826c3cce87f1d81baf118f92cb72237R12-R17) [[3]](diffhunk://#diff-cbbc926b416969380425775eb7a0f5d07826c3cce87f1d81baf118f92cb72237R43-R51).

**API and interface changes:**
* Updated function and parameter names, docstrings, and error messages throughout to use "source image" instead of "DV file", reflecting the broader support [[1]](diffhunk://#diff-d6b51e934b039f441691536e232355aae7f463adb649d0cb64167a6ec1875015L48-R48) [[2]](diffhunk://#diff-6158bdd3e7085ebac0f9cc5dd976d1791d428470b7675604221ead3bacf44862L134-R158) [[3]](diffhunk://#diff-b7b43a71b7a665cebc0fa1120c3c3224c13aaa77913846e859c8dc7643e720f0L202-R213).
* Updated imports and internal references to use new generalized modules and functions [[1]](diffhunk://#diff-6158bdd3e7085ebac0f9cc5dd976d1791d428470b7675604221ead3bacf44862R11-R18) [[2]](diffhunk://#diff-8ba1077e6a274c514b9aed9d308746583e159c4398dde8d409471f4539d01228L1-R7).

These changes lay the groundwork for supporting a wider range of microscopy images, improving maintainability and user experience.