### PR TITLE
Clarify TIFF channel handling in documentation

### DIFF
--- a/docs/developer/data-flow-and-artifacts.md
+++ b/docs/developer/data-flow-and-artifacts.md
@@ -6,12 +6,14 @@ This document tracks how files and persisted state move through the system from 
 
 ## Upload Intake
 
-Input enters through the `experiment` view as a browser-uploaded `.dv` file.
+Input enters through the `experiment` view as one or more browser-uploaded source image files. Supported source extensions are `.dv`, `.tif`, and `.tiff`.
 
 Primary persisted outputs at request-time intake:
 
-- one `UploadedImage` row
-- one source DV file under the run UUID namespace
+- one `UploadedImage` row per uploaded source file
+- one source file under each run UUID namespace
+
+Each selected source file becomes an independent run. The upload flow does not combine separate per-wavelength TIFF files into one stack by matching filenames.
 
 Upload preparation then runs through `UploadPreparationJob`. In `sync` mode the
 request thread executes that job inline; in `worker` mode the background worker
@@ -22,6 +24,11 @@ Upload-prep outputs are:
 - one `channel_config.json`
 - preview PNG assets
 - `scale_info` metadata saved on `UploadedImage`
+
+Channel configuration is derived by source format:
+
+- `.dv`: DV header metadata is read first, then legacy XML-like header snippets are used as fallback.
+- `.tif` and `.tiff`: ImageJ `Labels` metadata is read when available. Complete and unambiguous softWoRx-style labels such as `*_w625.tif`, `*_w525.tif`, `*_w435.tif`, and `*_R3D_REF.tif` map to Red, Green, Blue, and DIC respectively. Missing or ambiguous TIFF labels fall back to the default channel order.
 
 The worker deletes invalid newly uploaded files, skips invalid restored files, and preserves safe user-facing validation errors on the job.
 

--- a/docs/reference/file-format-and-artifact-spec.md
+++ b/docs/reference/file-format-and-artifact-spec.md
@@ -6,18 +6,63 @@ This document defines the key input assumptions and generated artifact patterns 
 
 ## Input File Assumptions
 
-Primary input format:
+Supported input formats:
 
 - DeltaVision `.dv`
+- TIFF `.tif`
+- TIFF `.tiff`
 
 Current workflow assumptions:
 
-- the upload can be interpreted as a channel stack
+- each uploaded file is interpreted as one independent run-level channel stack
 - CytoCV supports four logical channel roles: `DIC`, `Blue`, `Red`, and `Green`
 - only `DIC` is universally required
 - additional required channels are derived from the selected plugin set and optional validation settings
 - channel order can be remapped through `channel_config.json`
 - exact four-layer enforcement occurs only when `enforce_layer_count` is enabled
+
+CytoCV does not group multiple separate TIFF files into one multi-channel run based on filename similarity. When a user selects several source files, each file is saved, validated, previewed, processed, and displayed as its own run with its own UUID and `channel_config.json`.
+
+## TIFF Channel Detection
+
+TIFF uploads are expected to be stack files when more than one channel is needed. The stack can be a multi-page or otherwise channel-axis TIFF that `tifffile` can normalize into a channel-first image stack.
+
+TIFF channel order is resolved in this order:
+
+1. Read ImageJ metadata labels from `Labels` or `labels`.
+2. If the labels form a complete, unambiguous four-channel set, build `channel_config.json` from those labels.
+3. If metadata labels are missing, incomplete, duplicated, or ambiguous, fall back to the default channel order.
+
+The recognized TIFF label patterns are:
+
+- Red: a wavelength token near `w625`, within 12 nm of 625
+- Green: a wavelength token near `w525`, within 12 nm of 525
+- Blue: a wavelength token near `w435`, within 12 nm of 435
+- DIC: labels containing `DIC`, `brightfield`, `transmission`, `r3dref`, `_ref`, or ending in `ref.tif`
+
+The wavelength token matcher accepts `w625`, `w_625`, `w-625`, and `w 625` when the token is separated from surrounding letters or digits. Example softWoRx/ImageJ label metadata that maps successfully:
+
+```text
+sample_PRJ_w625.tif
+sample_PRJ_w435.tif
+sample_PRJ_w525.tif
+sample_R3D_REF.tif
+```
+
+In that example, the source upload is still one TIFF stack. The filenames above are metadata labels inside the TIFF, not separate files that CytoCV assembles.
+
+Default fallback order is:
+
+```json
+{
+  "channel_red": 3,
+  "channel_green": 2,
+  "channel_blue": 1,
+  "DIC": 0
+}
+```
+
+Because required-channel validation checks the mapped channel index against the actual layer count, a one-layer TIFF with fallback mapping only provides `DIC` for validation purposes. It will fail workflows that require Red, Green, or Blue unless those channels are present in the stack and mapped by metadata or manual channel configuration.
 
 ## Channel Roles
 
@@ -62,9 +107,9 @@ Full four-role example:
 ```json
 {
   "DIC": 0,
-  "Blue": 1,
-  "Red": 2,
-  "Green": 3
+  "channel_blue": 1,
+  "channel_red": 2,
+  "channel_green": 3
 }
 ```
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -14,7 +14,7 @@ This page is for people running CytoCV locally for development, evaluation, or m
 - the project dependencies from `requirements.txt`
 - a configured `.env` file at the repository root
 - the required Mask R-CNN weights file under `cytocv/core/weights`
-- at least one supported DeltaVision `.dv` file
+- at least one supported `.dv`, `.tif`, or `.tiff` source image file
 
 ## Browser Support
 
@@ -36,6 +36,8 @@ Only `DIC` is universally required because the segmentation and CNN preprocessin
 - manual required channels are added only when the validation module is enabled
 - exact four-layer enforcement occurs only when `enforce_layer_count` is enabled
 - all-four-role enforcement occurs only when `enforce_wavelengths` is enabled
+
+Supported TIFF files are treated as stack files. If you upload several TIFF files at once, CytoCV processes them as several independent runs; it does not combine separate Red, Green, Blue, and DIC TIFF files by filename. For TIFF channel detection, CytoCV uses ImageJ label metadata when it is present and complete. softWoRx-style labels containing `w625`, `w525`, `w435`, and `R3D_REF` map to Red, Green, Blue, and DIC. If those labels are unavailable or ambiguous, CytoCV uses its default channel order.
 
 ## Local Startup Procedure
 
@@ -65,7 +67,7 @@ python manage.py runserver
 ## First Successful Run
 
 1. Open the `Experiment` page.
-2. Upload one or more `.dv` files.
+2. Upload one or more supported `.dv`, `.tif`, or `.tiff` files.
 3. Leave the default modern workflow enabled unless you are intentionally testing a reduced plugin set or a legacy Blue workflow. The default set includes `PunctaDistance`, `CENDot`, `Biorientation`, `GreenRedIntensity`, and `NuclearCellPairIntensity`.
 4. Confirm that the file provides `DIC` plus any channels required by the selected plugin set.
 5. Review scale settings and, if needed, advanced validation toggles.

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -13,23 +13,26 @@ This guide lists common user-visible failures and the expected corrective action
 
 ### Symptom
 
-The upload page reports invalid DV files or rejects files immediately.
+The upload page reports invalid source image files or rejects files immediately.
 
 ### Likely Causes
 
-- the file does not parse as a valid DeltaVision stack
+- the file does not parse as a valid supported `.dv`, `.tif`, or `.tiff` stack
 - the file does not satisfy enforced layer-count requirements
 - required wavelengths are missing
 - a selected plugin requires a channel that is not present
+- separate single-channel TIFFs were uploaded with the expectation that CytoCV would combine them into one multi-channel file
 
 ### Corrective Action
 
-- verify the file is a supported `.dv` file
+- verify the file is a supported `.dv`, `.tif`, or `.tiff` file
 - verify the current plugin selection
 - disable unneeded validation controls
 - confirm that `DIC` is present
 - confirm that any plugin-required channels are present
 - if all-wavelength enforcement is enabled, confirm that all four logical channel roles are present
+- for TIFF workflows, use a TIFF stack that contains the needed channels; CytoCV does not assemble separate wavelength TIFF files into one run by filename
+- if TIFF channel order looks wrong, check for ImageJ labels such as `w625`, `w525`, `w435`, and `R3D_REF`, or adjust the channel mapping before analysis
 
 ### Symptom
 


### PR DESCRIPTION
This pull request updates the documentation to clarify and expand support for TIFF (`.tif`, `.tiff`) image files in addition to DeltaVision (`.dv`) files. It details how CytoCV handles uploads, channel detection, and the limitations regarding multi-file TIFF uploads. The changes also provide guidance for users and developers on expected behaviors and troubleshooting.

**Expanded file format support and upload behavior:**

- CytoCV now supports `.dv`, `.tif`, and `.tiff` files as source image inputs; each uploaded file is treated as an independent run, and separate TIFF files are not combined into a single stack by filename. [[1]](diffhunk://#diff-1cd818760d82b9d798fbec7391068ccb3aa6b1ab016295be62cbdad5e951927eL9-R16) [[2]](diffhunk://#diff-17a9742b82d96407a7daec2735a8a721643937a101eaab642dcff8effe90023cL9-R66) [[3]](diffhunk://#diff-816862240c6f5d4959307b5248230cc3c4cb3df5895b2309c4d8883619cec7d4L17-R17) [[4]](diffhunk://#diff-816862240c6f5d4959307b5248230cc3c4cb3df5895b2309c4d8883619cec7d4L68-R70)

**TIFF channel detection and mapping:**

- Documentation now explains how channel roles are detected in TIFF files: ImageJ metadata labels are used when present and complete, with specific mappings for softWoRx-style labels (`w625`, `w525`, `w435`, `R3D_REF`). If labels are missing or ambiguous, a default channel order is used. [[1]](diffhunk://#diff-1cd818760d82b9d798fbec7391068ccb3aa6b1ab016295be62cbdad5e951927eR28-R32) [[2]](diffhunk://#diff-17a9742b82d96407a7daec2735a8a721643937a101eaab642dcff8effe90023cL9-R66)
- The mapping of channel roles in JSON examples and descriptions has been updated for clarity and accuracy.

**User-facing documentation and troubleshooting:**

- The Getting Started and Troubleshooting guides have been updated to reflect TIFF support, clarify upload expectations, and provide actionable advice for TIFF-specific issues (e.g., not combining single-channel TIFFs, checking label metadata). [[1]](diffhunk://#diff-816862240c6f5d4959307b5248230cc3c4cb3df5895b2309c4d8883619cec7d4R40-R41) [[2]](diffhunk://#diff-7df4e9bd6252879fc1abecc457c9b3b4e772dcfc42b3be3593381e8c2e211671L16-R35)

These changes ensure that both users and developers understand the expanded file format support, the specifics of TIFF channel detection, and how to resolve common issues with uploads and channel mapping.