### PR TITLE
Enhance upload preparation status polling mechanism

### DIFF
--- a/cytocv/core/services/upload_preparation.py
+++ b/cytocv/core/services/upload_preparation.py
@@ -214,6 +214,7 @@ def run_upload_preparation_job(job: UploadPreparationJob) -> UploadPreparationJo
                     "fileIndex": index,
                     "fileTotal": requested_total,
                     "fileName": _display_file_name(uploaded, run_uuid),
+                    "message": "Checking file format, layer count, and required channels.",
                 },
             )
             if uploaded is None:

--- a/cytocv/core/tests/test_upload_preparation.py
+++ b/cytocv/core/tests/test_upload_preparation.py
@@ -186,6 +186,10 @@ class UploadPreparationTestCase(TestCase):
                 ],
             )
             self.assertEqual(
+                phase_calls[1][1]["message"],
+                "Checking file format, layer count, and required channels.",
+            )
+            self.assertEqual(
                 phase_calls[2][1]["message"],
                 "Reading scale calibration and channel assignments.",
             )

--- a/cytocv/templates/form/experiment.html
+++ b/cytocv/templates/form/experiment.html
@@ -7281,6 +7281,8 @@
     }
 
     const UPLOAD_PREPARATION_TIMEOUT_MS = 1800000;
+    const UPLOAD_PREPARATION_POLL_INITIAL_DELAY_MS = 50;
+    const UPLOAD_PREPARATION_POLL_MAX_DELAY_MS = 500;
     const UPLOAD_CONTROL_SELECTOR = '.upload-btn, .submit-btn, .settings-btn, .settings-close, .advanced-btn, .back-btn, .workflow-default-btn, .upload-page-back-btn, .folder-issue-btn, input[type="file"], input[type="checkbox"], input[type="number"], .remove-btn';
 
     function getUploadSubmitParts() {
@@ -7421,7 +7423,7 @@
 
     async function pollUploadPreparationJob(jobUuid, { signal, deadline, submitBtn, btnText }) {
         const wait = (ms) => new Promise((resolve) => window.setTimeout(resolve, ms));
-        let delay = 800;
+        let delay = UPLOAD_PREPARATION_POLL_INITIAL_DELAY_MS;
         while (Date.now() < deadline) {
             const statusResponse = await fetch(`/api/experiment/upload-prep/${encodeURIComponent(jobUuid)}/`, {
                 cache: 'no-store',
@@ -7440,7 +7442,7 @@
                 return;
             }
             await wait(delay);
-            delay = Math.min(2000, Math.round(delay * 1.25));
+            delay = Math.min(UPLOAD_PREPARATION_POLL_MAX_DELAY_MS, Math.round(delay * 1.15));
         }
         throw new DOMException('Upload timed out.', 'AbortError');
     }


### PR DESCRIPTION
This pull request introduces improvements to the upload preparation process, focusing on clearer user feedback and more responsive polling during file uploads. The main changes include adding a new status message to the backend and tests, and adjusting the frontend polling logic for faster and smoother status updates.

**Backend improvements:**

* Added a new status message, "Checking file format, layer count, and required channels.", to the upload preparation job status updates in `upload_preparation.py` to provide clearer feedback during the file checking phase.
* Updated the corresponding test in `test_upload_preparation.py` to assert the presence of the new status message, ensuring test coverage for the new feedback.

**Frontend polling enhancements:**

* Introduced `UPLOAD_PREPARATION_POLL_INITIAL_DELAY_MS` and `UPLOAD_PREPARATION_POLL_MAX_DELAY_MS` constants in `experiment.html` to control the polling interval for upload preparation status, allowing for a more responsive UI.
* Changed the polling logic in `pollUploadPreparationJob` to start with a shorter delay and increase it more gradually, capping at a lower maximum delay for smoother and faster status updates. [[1]](diffhunk://#diff-3d324e96c0072d465b4d4d33d19ff3ab041f4927bae3eba23f96fbbb234761aaL7424-R7426) [[2]](diffhunk://#diff-3d324e96c0072d465b4d4d33d19ff3ab041f4927bae3eba23f96fbbb234761aaL7443-R7445)