### PR TITLE
Refactor backend imports, CI, and documentation updates

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -100,6 +100,19 @@ jobs:
         working-directory: cytocv
         run: python manage.py collectstatic --dry-run --noinput
 
+      - name: Frontend contract tests
+        working-directory: cytocv
+        run: |
+          python manage.py test \
+            core.tests.test_frontend_template_contracts \
+            core.tests.test_frontend_static_contracts \
+            core.tests.test_frontend_json_contracts \
+            core.tests.test_frontend_js_contracts \
+            core.tests.test_frontend_workflow_contracts \
+            core.tests.test_frontend_viewer_contracts \
+            core.tests.test_frontend_export_contracts \
+            core.tests.test_core_app
+
       - name: Core tests
         working-directory: cytocv
         run: python manage.py test core

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,117 @@
+name: Backend CI
+
+"on":
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+      - nicolasmgioanni
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend-tests:
+    name: backend-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      CYTOCV_SECRET_KEY: ci-insecure-secret-key
+      CYTOCV_DEBUG: "1"
+      CYTOCV_ALLOWED_HOSTS: localhost,127.0.0.1,testserver
+      CYTOCV_ANALYSIS_EXECUTION_MODE: sync
+      CYTOCV_DB_BACKEND: sqlite
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: .python-version
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install OpenCV runtime libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libgl1 libglib2.0-0
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements.txt
+
+      - name: Check whitespace in changed files
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            if git cat-file -e "$base^{commit}" 2>/dev/null; then
+              git diff --check "$base"...HEAD
+            else
+              git diff --check
+            fi
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            before="${{ github.event.before }}"
+            if [[ -n "$before" && "$before" != "0000000000000000000000000000000000000000" ]] && git cat-file -e "$before^{commit}" 2>/dev/null; then
+              git diff --check "$before" HEAD
+            else
+              git diff --check
+            fi
+          else
+            git diff --check
+          fi
+
+      - name: Print Python version
+        working-directory: cytocv
+        run: python --version
+
+      - name: Print pip version
+        working-directory: cytocv
+        run: python -m pip --version
+
+      - name: Print Django version
+        working-directory: cytocv
+        run: python -c "import django; print('Django', django.get_version())"
+
+      - name: Django system check
+        working-directory: cytocv
+        run: python manage.py check
+
+      - name: Migration dry-run
+        working-directory: cytocv
+        run: python manage.py makemigrations --check --dry-run
+
+      - name: Static collection dry-run
+        working-directory: cytocv
+        run: python manage.py collectstatic --dry-run --noinput
+
+      - name: Core tests
+        working-directory: cytocv
+        run: python manage.py test core
+
+      - name: Account tests
+        working-directory: cytocv
+        run: python manage.py test accounts
+
+      - name: Full test suite
+        working-directory: cytocv
+        run: python manage.py test
+
+      - name: Final repository status
+        if: always()
+        run: git status --short

--- a/cytocv/accounts/views/profile.py
+++ b/cytocv/accounts/views/profile.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import json
-import math
 import re
 import shutil
 from pathlib import Path
 from typing import Any
-from uuid import UUID
 
 from django.contrib import messages
 from django.contrib.auth import logout
@@ -59,7 +57,6 @@ from core.services.biorientation_config import (
 from core.services.cell_statistics_payload import serialize_cell_statistics_payload
 from core.services.combined_stat_export import (
     CombinedStatisticsExportError,
-    StatisticsExportFile,
     build_combined_statistics_export_response,
 )
 from core.services.export_filenames import (
@@ -72,7 +69,6 @@ from core.services.overlay_rendering import (
 )
 from core.services.puncta_line_mode import (
     DEFAULT_PUNCTA_LINE_MODE,
-    VALID_PUNCTA_LINE_MODES,
     normalize_puncta_line_mode,
 )
 from core.services.dot_split import (
@@ -91,6 +87,18 @@ from core.services.stat_export_selection import (
     export_exclude_columns,
     export_metric_scope,
     export_selection_config,
+)
+from core.services.stat_export_requests import (
+    build_statistics_export_sources,
+    normalize_uuid_list,
+)
+from core.services.result_view_payloads import (
+    NUCLEAR_CELL_PAIR_MODES,
+    RESULT_CHANNEL_ORDER,
+    channel_config_payload,
+    detected_channel_labels,
+    resolve_cell_table_modes,
+    sanitize_for_json,
 )
 from core.scale import (
     get_scale_context_payload,
@@ -112,7 +120,6 @@ from core.tables import CellTable
 from cytocv.settings import MEDIA_ROOT, MEDIA_URL
 from core.services.artifact_paths import normalize_media_field_path
 
-NUCLEAR_CELL_PAIR_MODES = {"green_nucleus", "red_nucleus"}
 LENGTH_UNITS = {"px", "um"}
 
 
@@ -528,23 +535,6 @@ def _build_required_channel_rows(
     return rows, requirement_summary
 
 
-def _normalize_uuid_list(raw_values: Any) -> list[str]:
-    if not isinstance(raw_values, list):
-        return []
-    normalized: list[str] = []
-    seen: set[str] = set()
-    for value in raw_values:
-        try:
-            value_uuid = str(UUID(str(value)))
-        except (TypeError, ValueError, AttributeError):
-            return []
-        if value_uuid in seen:
-            continue
-        seen.add(value_uuid)
-        normalized.append(value_uuid)
-    return normalized
-
-
 def _recalculate_user_storage_usage(user: Any) -> None:
     refresh_user_storage_usage(user)
 
@@ -581,8 +571,7 @@ def _build_cell_table_for_uuid(
     stats_qs = CellStatistics.objects.filter(segmented_image=segmented_image).order_by(
         "cell_id"
     )
-    intensity_mode = _resolve_nuclear_cell_pair_mode(stats_qs)
-    puncta_line_mode = _resolve_puncta_line_mode(stats_qs)
+    intensity_mode, puncta_line_mode = resolve_cell_table_modes(stats_qs)
     return CellTable(
         stats_qs,
         intensity_mode=intensity_mode,
@@ -612,41 +601,10 @@ def _dashboard_available_export_uuid_set(user: Any) -> set[str]:
     }
 
 
-def _resolve_nuclear_cell_pair_mode(stats_iterable: Any) -> str | None:
-    modes = set()
-    for stat in stats_iterable:
-        props = stat.properties or {}
-        mode = props.get("nuclear_cell_pair_mode", props.get("nuclear_cellular_mode"))
-        if mode in NUCLEAR_CELL_PAIR_MODES:
-            modes.add(mode)
-    return modes.pop() if len(modes) == 1 else None
-
-
-def _resolve_puncta_line_mode(stats_iterable: Any) -> str | None:
-    modes = set()
-    for stat in stats_iterable:
-        props = stat.properties or {}
-        mode = props.get("puncta_line_mode")
-        if mode in VALID_PUNCTA_LINE_MODES:
-            modes.add(mode)
-    return modes.pop() if len(modes) == 1 else None
-
-
 def _serialize_cell_statistics(
     cell_stat: CellStatistics | None,
 ) -> dict[str, Any] | None:
     return serialize_cell_statistics_payload(cell_stat)
-
-
-def _sanitize_for_json(value: Any) -> Any:
-    """Convert nested values to strict JSON-safe equivalents."""
-    if isinstance(value, float):
-        return value if math.isfinite(value) else None
-    if isinstance(value, dict):
-        return {str(key): _sanitize_for_json(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple, set)):
-        return [_sanitize_for_json(item) for item in value]
-    return value
 
 
 def _media_url_for_file(path: Path) -> str:
@@ -750,12 +708,7 @@ def _build_dashboard_payload(user: Any) -> dict[str, Any]:
     first_table_uuid: str = ""
     cell_table = None
 
-    channel_order = [
-        CHANNEL_ROLE_DIC,
-        CHANNEL_ROLE_BLUE,
-        CHANNEL_ROLE_RED,
-        CHANNEL_ROLE_GREEN,
-    ]
+    channel_order = RESULT_CHANNEL_ORDER
     for segmented_image in segmented_images:
         uuid = str(segmented_image.UUID)
         uploaded = uploaded_map.get(uuid)
@@ -770,10 +723,7 @@ def _build_dashboard_payload(user: Any) -> dict[str, Any]:
             segmented_dir
         )
         output_frames = _scan_output_frames(output_dir)
-        detected_channels = [
-            channel_display_label(channel)
-            for channel, _ in sorted(channel_config.items(), key=lambda entry: entry[1])
-        ]
+        detected_channels = detected_channel_labels(channel_config)
         scale_payload = get_scale_sidebar_payload(
             uploaded.scale_info,
             manual_default=default_manual_scale,
@@ -788,8 +738,9 @@ def _build_dashboard_payload(user: Any) -> dict[str, Any]:
         stats_by_id = {cell.cell_id: cell for cell in stats_qs}
         if stats_by_id and cell_table is None:
             first_table_uuid = uuid
-            intensity_mode = _resolve_nuclear_cell_pair_mode(stats_by_id.values())
-            puncta_line_mode = _resolve_puncta_line_mode(stats_by_id.values())
+            intensity_mode, puncta_line_mode = resolve_cell_table_modes(
+                stats_by_id.values()
+            )
             cell_table = CellTable(
                 stats_qs,
                 intensity_mode=intensity_mode,
@@ -918,10 +869,7 @@ def _build_dashboard_payload(user: Any) -> dict[str, Any]:
             "CellPairImages": cell_images,
             "Image_Name": image_name,
             "ScaleContext": scale_context,
-            "ChannelConfig": {
-                channel_slug(channel_name): channel_index
-                for channel_name, channel_index in channel_config.items()
-            },
+            "ChannelConfig": channel_config_payload(channel_config),
             "Statistics": statistics,
             "NoCellsWarning": no_cells_warning,
         }
@@ -954,7 +902,7 @@ def _build_dashboard_payload(user: Any) -> dict[str, Any]:
     )
     if file_capacity_projection_ready:
         max_files_at_current_average = saved_file_count + additional_files_possible
-    files_data_json = json.dumps(_sanitize_for_json(files_data), allow_nan=False)
+    files_data_json = json.dumps(sanitize_for_json(files_data), allow_nan=False)
 
     return {
         "file_list": file_list,
@@ -1134,7 +1082,7 @@ def dashboard_bulk_delete_view(request: HttpRequest) -> HttpResponse:
             status=400,
         )
 
-    requested_uuids = _normalize_uuid_list(payload.get("uuids", []))
+    requested_uuids = normalize_uuid_list(payload.get("uuids", []))
     if not requested_uuids:
         return JsonResponse(
             {"error": "Select at least one saved file to continue."},
@@ -1180,7 +1128,7 @@ def dashboard_bulk_export_view(request: HttpRequest) -> HttpResponse:
             status=400,
         )
 
-    requested_uuids = _normalize_uuid_list(payload.get("uuids", []))
+    requested_uuids = normalize_uuid_list(payload.get("uuids", []))
     if not requested_uuids:
         return JsonResponse(
             {"error": "Select at least one saved file to continue."},
@@ -1215,15 +1163,11 @@ def dashboard_bulk_export_view(request: HttpRequest) -> HttpResponse:
     default_manual_scale = preferences.get("experiment_defaults", {}).get(
         "microns_per_pixel", 0.1
     )
-    sources = [
-        StatisticsExportFile(
-            uuid=uuid,
-            file_name=uploaded_map[uuid].name,
-            segmented_image=segmented_map[uuid],
-            scale_info=uploaded_map[uuid].scale_info,
-        )
-        for uuid in requested_uuids
-    ]
+    sources = build_statistics_export_sources(
+        requested_uuids,
+        uploaded_map=uploaded_map,
+        segmented_map=segmented_map,
+    )
     try:
         return build_combined_statistics_export_response(
             sources,

--- a/cytocv/core/management/commands/run_analysis_worker.py
+++ b/cytocv/core/management/commands/run_analysis_worker.py
@@ -9,7 +9,6 @@ from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from core.models import AnalysisJob
 from core.services.analysis_context import AnalysisBatchContext, normalize_analysis_config_snapshot
 from core.services.analysis_exceptions import AnalysisCancelled
 from core.services.analysis_jobs import (

--- a/cytocv/core/services/overlay_rendering.py
+++ b/cytocv/core/services/overlay_rendering.py
@@ -18,8 +18,6 @@ from core.channel_roles import (
     CHANNEL_ROLE_DIC,
     CHANNEL_ROLE_GREEN,
     CHANNEL_ROLE_RED,
-    channel_display_label,
-    channel_role_from_slug,
     channel_slug,
     normalize_channel_role,
 )

--- a/cytocv/core/services/progress_request_helpers.py
+++ b/cytocv/core/services/progress_request_helpers.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import re
+
+from django.http import JsonResponse
+
+from core.models import SegmentedImage, UploadedImage, get_guest_user
+from core.services.analysis_context import build_batch_key
+from core.services.analysis_jobs import get_latest_analysis_job
+from core.services.analysis_progress_contract import (
+    PROGRESS_PHASE_FAILED,
+    PROGRESS_STATUS_FAILED,
+)
+
+PROGRESS_BATCH_SESSION_KEY = "authorized_progress_batches"
+
+
+class ProgressRequestError(Exception):
+    """Controlled progress request error carrying an HTTP status code."""
+
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+def current_owner_filter(request) -> dict:
+    if request.user.is_authenticated:
+        return {"user": request.user}
+    return {"user_id": get_guest_user()}
+
+
+def get_authorized_progress_batches(request) -> set[str]:
+    return {
+        str(value)
+        for value in request.session.get(PROGRESS_BATCH_SESSION_KEY, [])
+        if str(value)
+    }
+
+
+def track_progress_batch(request, batch_key: str) -> None:
+    tracked = get_authorized_progress_batches(request)
+    if batch_key in tracked:
+        return
+    tracked.add(batch_key)
+    request.session[PROGRESS_BATCH_SESSION_KEY] = sorted(tracked)
+    request.session.modified = True
+
+
+def release_progress_batch(request, batch_key: str) -> None:
+    tracked = get_authorized_progress_batches(request)
+    if batch_key not in tracked:
+        return
+    tracked.remove(batch_key)
+    request.session[PROGRESS_BATCH_SESSION_KEY] = sorted(tracked)
+    request.session.modified = True
+
+
+def resolve_owned_progress_batch(request, raw_uuids: str) -> tuple[str, list[str]]:
+    if not raw_uuids or not re.fullmatch(r"[0-9a-fA-F,-]+", raw_uuids):
+        raise ProgressRequestError("Invalid analysis batch.", status_code=400)
+    try:
+        batch_key = build_batch_key(raw_uuids)
+    except (TypeError, ValueError):
+        raise ProgressRequestError("Invalid analysis batch.", status_code=400)
+    uuid_list = [value for value in batch_key.split(",") if value]
+    if not uuid_list:
+        raise ProgressRequestError("Invalid analysis batch.", status_code=400)
+
+    owner_filter = current_owner_filter(request)
+    owned_uploads = {
+        str(value)
+        for value in UploadedImage.objects.filter(
+            uuid__in=uuid_list,
+            **owner_filter,
+        ).values_list("uuid", flat=True)
+    }
+    owned_segmented = {
+        str(value)
+        for value in SegmentedImage.objects.filter(
+            UUID__in=uuid_list,
+            user=request.user,
+        ).values_list("UUID", flat=True)
+    }
+    owned_uuids = owned_uploads | owned_segmented
+    if set(uuid_list).issubset(owned_uuids):
+        return batch_key, uuid_list
+
+    if batch_key in get_authorized_progress_batches(request):
+        return batch_key, uuid_list
+
+    if get_latest_analysis_job(user_id=request.user.id, batch_key=batch_key) is not None:
+        return batch_key, uuid_list
+
+    raise ProgressRequestError("Forbidden", status_code=403)
+
+
+def progress_read_error_response(message: str, *, status_code: int) -> JsonResponse:
+    return JsonResponse(
+        {
+            "phase": PROGRESS_PHASE_FAILED,
+            "status": PROGRESS_STATUS_FAILED,
+            "failure_summary": message,
+            "redirect": None,
+        },
+        status=status_code,
+    )
+
+
+def progress_write_error_response(message: str, *, status_code: int) -> JsonResponse:
+    return JsonResponse({"status": "error", "message": message}, status=status_code)

--- a/cytocv/core/services/result_view_payloads.py
+++ b/cytocv/core/services/result_view_payloads.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from core.channel_roles import (
+    CHANNEL_ROLE_BLUE,
+    CHANNEL_ROLE_DIC,
+    CHANNEL_ROLE_GREEN,
+    CHANNEL_ROLE_RED,
+    channel_display_label,
+    channel_slug,
+)
+from core.services.puncta_line_mode import VALID_PUNCTA_LINE_MODES
+
+RESULT_CHANNEL_ORDER = [
+    CHANNEL_ROLE_DIC,
+    CHANNEL_ROLE_BLUE,
+    CHANNEL_ROLE_RED,
+    CHANNEL_ROLE_GREEN,
+]
+NUCLEAR_CELL_PAIR_MODES = {"green_nucleus", "red_nucleus"}
+
+
+def resolve_nuclear_cell_pair_mode(stats_iterable: Any) -> str | None:
+    modes = set()
+    for stat in stats_iterable:
+        props = stat.properties or {}
+        mode = props.get("nuclear_cell_pair_mode", props.get("nuclear_cellular_mode"))
+        if mode in NUCLEAR_CELL_PAIR_MODES:
+            modes.add(mode)
+    return modes.pop() if len(modes) == 1 else None
+
+
+def resolve_puncta_line_mode(stats_iterable: Any) -> str | None:
+    modes = set()
+    for stat in stats_iterable:
+        props = stat.properties or {}
+        mode = props.get("puncta_line_mode")
+        if mode in VALID_PUNCTA_LINE_MODES:
+            modes.add(mode)
+    return modes.pop() if len(modes) == 1 else None
+
+
+def resolve_cell_table_modes(stats_iterable: Any) -> tuple[str | None, str | None]:
+    return (
+        resolve_nuclear_cell_pair_mode(stats_iterable),
+        resolve_puncta_line_mode(stats_iterable),
+    )
+
+
+def sanitize_for_json(value: Any) -> Any:
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {str(key): sanitize_for_json(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [sanitize_for_json(item) for item in value]
+    return value
+
+
+def detected_channel_labels(channel_config: dict[str, int]) -> list[str]:
+    return [
+        channel_display_label(channel_name)
+        for channel_name, _ in sorted(channel_config.items(), key=lambda entry: entry[1])
+    ]
+
+
+def channel_config_payload(channel_config: dict[str, int]) -> dict[str, int]:
+    return {
+        channel_slug(channel_name): channel_index
+        for channel_name, channel_index in channel_config.items()
+    }

--- a/cytocv/core/services/scale_request_payloads.py
+++ b/cytocv/core/services/scale_request_payloads.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import math
+from uuid import UUID
+
+
+def parse_file_scale_map_payload(
+    raw_payload: str,
+    active_uuid_set: set[str],
+) -> tuple[dict[str, float], str | None, int]:
+    if not raw_payload:
+        return {}, None, 200
+    try:
+        payload = json.loads(raw_payload)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {}, "Invalid per-file scale payload.", 400
+    if not isinstance(payload, dict):
+        return {}, "Per-file scale payload must be a JSON object.", 400
+
+    parsed: dict[str, float] = {}
+    for raw_uuid, raw_value in payload.items():
+        try:
+            normalized_uuid = str(UUID(str(raw_uuid)))
+        except (TypeError, ValueError, AttributeError):
+            return {}, "Per-file scale payload contains an invalid UUID.", 400
+        if normalized_uuid not in active_uuid_set:
+            return {}, "Per-file scale payload contains unavailable files.", 403
+
+        value = raw_value
+        if isinstance(raw_value, dict):
+            value = raw_value.get("effective_um_per_px")
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return {}, "Per-file scale values must be numeric.", 400
+        if not math.isfinite(numeric) or numeric <= 0:
+            return {}, "Per-file scale values must be greater than 0.", 400
+        parsed[normalized_uuid] = numeric
+    return parsed, None, 200
+
+
+def parse_file_scale_revert_payload(
+    raw_payload: str,
+    active_uuid_set: set[str],
+) -> tuple[set[str], str | None, int]:
+    if not raw_payload:
+        return set(), None, 200
+    try:
+        payload = json.loads(raw_payload)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return set(), "Invalid scale revert payload.", 400
+    if not isinstance(payload, list):
+        return set(), "Scale revert payload must be a JSON array.", 400
+
+    parsed: set[str] = set()
+    for raw_uuid in payload:
+        try:
+            normalized_uuid = str(UUID(str(raw_uuid)))
+        except (TypeError, ValueError, AttributeError):
+            return set(), "Scale revert payload contains an invalid UUID.", 400
+        if normalized_uuid not in active_uuid_set:
+            return set(), "Scale revert payload contains unavailable files.", 403
+        parsed.add(normalized_uuid)
+    return parsed, None, 200

--- a/cytocv/core/services/segmentation_pipeline.py
+++ b/cytocv/core/services/segmentation_pipeline.py
@@ -22,9 +22,7 @@ from django.conf import settings
 from django.db import transaction
 
 from core.channel_roles import (
-    CHANNEL_ROLE_BLUE,
     CHANNEL_ROLE_DIC,
-    CHANNEL_ROLE_GREEN,
     CHANNEL_ROLE_RED,
 )
 from core.config import DEFAULT_CHANNEL_CONFIG, DEFAULT_PROCESS_CONFIG, input_dir
@@ -45,8 +43,6 @@ from core.services.artifact_storage import (
     StorageQuotaExceeded,
     assert_user_can_save_runs,
     cleanup_transient_processing_artifacts,
-    delete_uploaded_run_by_uuid,
-    is_storage_full_error,
     log_storage_capacity_failure,
     refresh_user_storage_usage,
     save_png_array,

--- a/cytocv/core/services/stat_export_requests.py
+++ b/cytocv/core/services/stat_export_requests.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from core.services.combined_stat_export import StatisticsExportFile
+
+
+def normalize_uuid_list(raw_values: Any) -> list[str]:
+    if not isinstance(raw_values, list):
+        return []
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in raw_values:
+        try:
+            value_uuid = str(UUID(str(value)))
+        except (TypeError, ValueError, AttributeError):
+            return []
+        if value_uuid in seen:
+            continue
+        seen.add(value_uuid)
+        normalized.append(value_uuid)
+    return normalized
+
+
+def build_statistics_export_sources(
+    ordered_uuids: list[str],
+    *,
+    uploaded_map: dict[str, Any],
+    segmented_map: dict[str, Any],
+) -> list[StatisticsExportFile]:
+    return [
+        StatisticsExportFile(
+            uuid=uuid,
+            file_name=uploaded_map[uuid].name,
+            segmented_image=segmented_map[uuid],
+            scale_info=uploaded_map[uuid].scale_info,
+        )
+        for uuid in ordered_uuids
+    ]

--- a/cytocv/core/services/upload_preparation_payloads.py
+++ b/cytocv/core/services/upload_preparation_payloads.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from core.models import UploadPreparationJob
+from core.services.analysis_progress import normalize_progress_detail
+
+
+def upload_job_detail(job: UploadPreparationJob) -> dict[str, object]:
+    return normalize_progress_detail(job.progress_detail)
+
+
+def build_upload_preparation_payload(
+    job: UploadPreparationJob,
+    *,
+    stale_state: tuple[str, str, str] | None = None,
+    redirect_url: str | None = None,
+) -> dict[str, object]:
+    status = stale_state[0] if stale_state is not None else job.status
+    phase = stale_state[1] if stale_state is not None else job.current_phase
+    failure_summary = stale_state[2] if stale_state is not None else job.failure_summary
+    errors = [str(line) for line in job.error_lines or [] if str(line)]
+    if failure_summary and not errors and status == UploadPreparationJob.Status.FAILED:
+        errors = [failure_summary]
+
+    return {
+        "job_uuid": str(job.job_uuid),
+        "status": status,
+        "phase": phase,
+        "detail": upload_job_detail(job),
+        "errors": errors,
+        "failure_summary": failure_summary,
+        "redirect": redirect_url,
+    }
+
+
+def build_upload_preparation_cancel_payload(
+    job: UploadPreparationJob,
+) -> dict[str, object]:
+    return {
+        "status": job.status,
+        "phase": job.current_phase,
+        "detail": upload_job_detail(job),
+    }

--- a/cytocv/core/static/css/pages/dashboard.css
+++ b/cytocv/core/static/css/pages/dashboard.css
@@ -287,14 +287,7 @@ body {
 .quota-fill {
     height: 100%;
     background: var(--accent);
-    width: {
-        {
-            storage_percentage|floatformat:2
-        }
-
-    }
-
-    %;
+    width: var(--quota-fill-width, 0%);
 }
 
 .delete-modal-backdrop {

--- a/cytocv/core/static/js/pages/dashboard-viewer.js
+++ b/cytocv/core/static/js/pages/dashboard-viewer.js
@@ -4,6 +4,14 @@
         const dashboardPageConfig = readJsonConfig('dashboardPageConfig');
         window.CytoCVDashboardPageConfig = dashboardPageConfig;
 
+        function applyQuotaFillWidths() {
+            document.querySelectorAll('.quota-fill[data-quota-fill-width]').forEach((element) => {
+                const quotaFillWidth = element.dataset.quotaFillWidth;
+                element.style.setProperty('--quota-fill-width', `${quotaFillWidth}%`);
+            });
+        }
+        applyQuotaFillWidths();
+
         function getCsrfToken() {
             const match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]*)/);
             return match ? decodeURIComponent(match[1]) : '';

--- a/cytocv/core/tests/test_analysis_async.py
+++ b/cytocv/core/tests/test_analysis_async.py
@@ -22,7 +22,10 @@ from core.services.analysis_context import AnalysisBatchContext
 from core.services.analysis_jobs import AnalysisJobLimitExceeded, enqueue_analysis_job
 from core.services.analysis_pipeline import run_preprocess_and_inference_batch
 from core.services.analysis_progress_contract import (
+    PROGRESS_PHASE_FAILED,
+    PROGRESS_STATUS_FAILED,
     SAFE_ANALYSIS_FAILURE_SUMMARY,
+    SAFE_PROGRESS_ERROR_MESSAGE,
     SAFE_PROGRESS_WRITE_ERROR_MESSAGE,
 )
 from core.services.analysis_progress import (
@@ -469,6 +472,21 @@ class AnalysisAsyncTestCase(TestCase):
             )
 
             self.assertEqual(response.status_code, 403)
+
+    @override_settings(ANALYSIS_EXECUTION_MODE="worker")
+    def test_progress_endpoint_rejects_invalid_batch_with_safe_payload(self):
+        response = self.client.get(reverse("analysis_progress", args=["not-a-batch"]))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                "phase": PROGRESS_PHASE_FAILED,
+                "status": PROGRESS_STATUS_FAILED,
+                "failure_summary": SAFE_PROGRESS_ERROR_MESSAGE,
+                "redirect": None,
+            },
+        )
 
     @override_settings(ANALYSIS_EXECUTION_MODE="worker")
     def test_cancel_progress_forbids_other_user_batch(self):

--- a/cytocv/core/tests/test_artifact_path_contracts.py
+++ b/cytocv/core/tests/test_artifact_path_contracts.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from uuid import UUID
+
+from django.conf import settings
+from django.test import SimpleTestCase, override_settings
+
+from core.models import UploadedImage
+from core.services.artifact_paths import (
+    output_frame_url,
+    segmented_cell_image_url,
+)
+from core.services.artifact_storage import (
+    output_media_path,
+    preprocess_media_path,
+    preview_media_path,
+    run_media_path,
+    segmented_media_path,
+)
+from core.services.neck_split import manifest_path, sidecar_path
+from core.services.overlay_rendering import (
+    overlay_cache_image_path,
+    overlay_render_config_path,
+)
+
+
+class ArtifactPathContractTests(SimpleTestCase):
+    def test_run_artifact_paths_keep_current_layout(self):
+        run_uuid = UUID("cef22bb0-b838-47f3-ab96-387cfb559b0b")
+        image_stem = "sample"
+        cell_id = 3
+
+        with TemporaryDirectory() as temp_dir:
+            media_root = Path(temp_dir) / "media"
+            with override_settings(MEDIA_ROOT=media_root, MEDIA_URL="/media/"):
+                uploaded = SimpleNamespace(uuid=run_uuid, name=image_stem)
+
+                self.assertEqual(
+                    UploadedImage.upload_to(uploaded, f"{image_stem}.dv"),
+                    f"{run_uuid}/{image_stem}.dv",
+                )
+                self.assertEqual(
+                    run_media_path(str(run_uuid)),
+                    media_root.resolve() / str(run_uuid),
+                )
+                self.assertEqual(
+                    run_media_path(str(run_uuid)) / "channel_config.json",
+                    media_root.resolve() / str(run_uuid) / "channel_config.json",
+                )
+                self.assertEqual(
+                    preview_media_path(str(run_uuid)) / "preview-layer2.png",
+                    media_root.resolve() / str(run_uuid) / "preview_images" / "preview-layer2.png",
+                )
+                self.assertEqual(
+                    preprocess_media_path(str(run_uuid)) / f"{image_stem}.png",
+                    media_root.resolve() / str(run_uuid) / "preprocessed_images" / f"{image_stem}.png",
+                )
+                self.assertEqual(
+                    output_media_path(str(run_uuid)) / "mask.tif",
+                    media_root.resolve() / str(run_uuid) / "output" / "mask.tif",
+                )
+                self.assertEqual(
+                    output_media_path(str(run_uuid)) / "cellpairs.tif",
+                    media_root.resolve() / str(run_uuid) / "output" / "cellpairs.tif",
+                )
+                self.assertEqual(
+                    output_media_path(str(run_uuid)) / f"{image_stem}_frame_2.png",
+                    media_root.resolve() / str(run_uuid) / "output" / f"{image_stem}_frame_2.png",
+                )
+                self.assertEqual(
+                    output_frame_url(uuid=run_uuid, image_name=f"{image_stem}.dv", frame_index=2),
+                    f"{settings.MEDIA_URL}{run_uuid}/output/{image_stem}_frame_2.png",
+                )
+                self.assertEqual(
+                    manifest_path(media_root / str(run_uuid)),
+                    media_root / str(run_uuid) / "output" / "pair-geometry.json",
+                )
+                self.assertEqual(
+                    sidecar_path(media_root / str(run_uuid), f"{image_stem}.dv", cell_id),
+                    media_root / str(run_uuid) / "output" / f"{image_stem}-{cell_id}.neck_split",
+                )
+                self.assertEqual(
+                    output_media_path(str(run_uuid)) / f"{image_stem}-{cell_id}.outline",
+                    media_root.resolve() / str(run_uuid) / "output" / f"{image_stem}-{cell_id}.outline",
+                )
+
+    def test_segmented_and_overlay_paths_keep_current_layout(self):
+        run_uuid = UUID("cef22bb0-b838-47f3-ab96-387cfb559b0b")
+        image_stem = "sample"
+        cell_id = 3
+        channel_index = 2
+
+        with TemporaryDirectory() as temp_dir:
+            media_root = Path(temp_dir) / "media"
+            with override_settings(MEDIA_ROOT=media_root, MEDIA_URL="/media/"):
+                self.assertEqual(
+                    segmented_media_path(str(run_uuid)) / f"cell_{cell_id}.png",
+                    media_root.resolve() / str(run_uuid) / "segmented" / f"cell_{cell_id}.png",
+                )
+                self.assertEqual(
+                    segmented_media_path(str(run_uuid)) / f"{image_stem}-{channel_index}-{cell_id}.png",
+                    media_root.resolve()
+                    / str(run_uuid)
+                    / "segmented"
+                    / f"{image_stem}-{channel_index}-{cell_id}.png",
+                )
+                self.assertEqual(
+                    segmented_media_path(str(run_uuid)) / f"{image_stem}-{channel_index}-{cell_id}-no_outline.png",
+                    media_root.resolve()
+                    / str(run_uuid)
+                    / "segmented"
+                    / f"{image_stem}-{channel_index}-{cell_id}-no_outline.png",
+                )
+                self.assertEqual(
+                    segmented_cell_image_url(
+                        uuid=run_uuid,
+                        image_name=f"{image_stem}.dv",
+                        channel_index=channel_index,
+                        cell_id=cell_id,
+                    ),
+                    f"{settings.MEDIA_URL}{run_uuid}/segmented/{image_stem}-{channel_index}-{cell_id}.png",
+                )
+                self.assertEqual(
+                    segmented_cell_image_url(
+                        uuid=run_uuid,
+                        image_name=f"{image_stem}.dv",
+                        channel_index=channel_index,
+                        cell_id=cell_id,
+                        outline=False,
+                    ),
+                    f"{settings.MEDIA_URL}{run_uuid}/segmented/{image_stem}-{channel_index}-{cell_id}-no_outline.png",
+                )
+                self.assertEqual(
+                    overlay_render_config_path(str(run_uuid)),
+                    media_root / str(run_uuid) / "segmented" / "overlay-render-config.json",
+                )
+                for channel in ("red", "green", "blue"):
+                    with self.subTest(channel=channel):
+                        self.assertEqual(
+                            overlay_cache_image_path(str(run_uuid), cell_id, channel),
+                            media_root
+                            / str(run_uuid)
+                            / "segmented"
+                            / "overlay-cache-v4"
+                            / f"cell-{cell_id}-{channel}.png",
+                        )

--- a/cytocv/core/tests/test_artifact_storage.py
+++ b/cytocv/core/tests/test_artifact_storage.py
@@ -566,6 +566,11 @@ class UploadQuotaProjectionViewTests(ArtifactStorageTestCase):
         self.assertContains(response, "1 out of 3 files saved.")
         self.assertContains(
             response,
+            'style="--quota-fill-width: 33.33%;"',
+            html=False,
+        )
+        self.assertContains(
+            response,
             "2 additional files can be saved before quota at your current average file size.",
         )
 

--- a/cytocv/core/tests/test_artifact_storage.py
+++ b/cytocv/core/tests/test_artifact_storage.py
@@ -202,6 +202,15 @@ class PreviewArtifactTests(ArtifactStorageTestCase):
             preview_dir = media_root / str(uploaded.uuid) / PREVIEW_FOLDER_NAME
             self.assertEqual(len(preview_rows), 4)
             self.assertEqual(DVLayerTifPreview.objects.filter(uploaded_image_uuid=uploaded).count(), 4)
+            self.assertEqual(
+                [row.file_location.name.replace("\\", "/") for row in preview_rows],
+                [
+                    f"{uploaded.uuid}/{PREVIEW_FOLDER_NAME}/preview-layer0.png",
+                    f"{uploaded.uuid}/{PREVIEW_FOLDER_NAME}/preview-layer1.png",
+                    f"{uploaded.uuid}/{PREVIEW_FOLDER_NAME}/preview-layer2.png",
+                    f"{uploaded.uuid}/{PREVIEW_FOLDER_NAME}/preview-layer3.png",
+                ],
+            )
             self.assertEqual(sorted(path.suffix for path in preview_dir.iterdir()), [".png", ".png", ".png", ".png"])
             self.assertFalse(any(preview_dir.glob("*.tif")))
             self.assertFalse(any(preview_dir.glob("*.jpg")))
@@ -246,7 +255,10 @@ class PreprocessEncodingTests(ArtifactStorageTestCase):
                 )
 
             self.assertIsNotNone(artifact)
-            self.assertTrue(str(artifact.preprocessed_path).endswith(".png"))
+            self.assertEqual(
+                artifact.preprocessed_path,
+                media_root / str(uploaded.uuid) / PRE_PROCESS_FOLDER_NAME / "preprocess_png.png",
+            )
             self.assertTrue(artifact.preprocessed_path.exists())
             self.assertFalse((media_root / str(uploaded.uuid) / "preprocessed_images_list.csv").exists())
             self.assertFalse(any((media_root / str(uploaded.uuid) / PRE_PROCESS_FOLDER_NAME).glob("*.tif")))
@@ -566,9 +578,10 @@ class UploadQuotaProjectionViewTests(ArtifactStorageTestCase):
         self.assertContains(response, "1 out of 3 files saved.")
         self.assertContains(
             response,
-            'style="--quota-fill-width: 33.33%;"',
+            'data-quota-fill-width="33.33"',
             html=False,
         )
+        self.assertNotContains(response, "style=", html=False)
         self.assertContains(
             response,
             "2 additional files can be saved before quota at your current average file size.",

--- a/cytocv/core/tests/test_core_app.py
+++ b/cytocv/core/tests/test_core_app.py
@@ -69,6 +69,17 @@ class RouteSurfaceRefactorTests(TestCase):
         "https://www.washington.edu/online/terms",
         "https://www.uwb.edu/accessibility/",
     )
+    FILES_DATA_REQUIRED_KEYS = {
+        "MainImagePath",
+        "MainImagePaths",
+        "NumberOfCells",
+        "CellPairImages",
+        "Image_Name",
+        "ScaleContext",
+        "ChannelConfig",
+        "Statistics",
+        "NoCellsWarning",
+    }
 
     def setUp(self):
         user_model = get_user_model()
@@ -127,6 +138,12 @@ class RouteSurfaceRefactorTests(TestCase):
             response,
             "/static/assets/uwb/web-white-left-school-signature-uw-bothell.png",
             html=False,
+        )
+
+    def _assert_files_data_payload_contract(self, payload):
+        self.assertTrue(
+            self.FILES_DATA_REQUIRED_KEYS.issubset(payload.keys()),
+            sorted(self.FILES_DATA_REQUIRED_KEYS.difference(payload.keys())),
         )
 
     def test_static_frontend_javascript_does_not_embed_template_syntax(self):
@@ -1155,6 +1172,7 @@ class RouteSurfaceRefactorTests(TestCase):
         self.assertEqual(response.status_code, 200)
         files_data = json.loads(response.context["files_data"])
         payload = files_data[uuid_value]
+        self._assert_files_data_payload_contract(payload)
         self.assertEqual(
             set(payload["MainImagePaths"].keys()),
             {"dic", "blue", "red", "green"},
@@ -1191,6 +1209,7 @@ class RouteSurfaceRefactorTests(TestCase):
         self.assertEqual(response.status_code, 200)
         files_data = json.loads(response.context["files_data_json"])
         payload = files_data[uuid_value]
+        self._assert_files_data_payload_contract(payload)
         self.assertEqual(
             set(payload["MainImagePaths"].keys()),
             {"dic", "blue", "red", "green"},

--- a/cytocv/core/tests/test_frontend_export_contracts.py
+++ b/cytocv/core/tests/test_frontend_export_contracts.py
@@ -108,3 +108,58 @@ class FrontendExportContractTests(TestCase):
         self.assertIn("attachment;", response["Content-Disposition"])
         self.assertIn("cytocv_", response["Content-Disposition"])
         self.assertIn("Red In Red Intensity 1", response.content.decode("utf-8"))
+
+    def test_display_export_preserves_visible_subset_order(self):
+        user = login_user(self, "frontend-display-export-order@example.com")
+        first_uuid = create_display_file(uploaded_owner=user, filename="display_export_first")
+        second_uuid = create_display_file(uploaded_owner=user, filename="display_export_second")
+        add_cell_stat(first_uuid)
+        add_cell_stat(second_uuid)
+
+        response = self.client.post(
+            reverse("display_export_files"),
+            data=json.dumps(
+                {
+                    "visible_uuids": [second_uuid, first_uuid],
+                    "uuids": [first_uuid, second_uuid],
+                    "_export": "csv",
+                    "_columns": ["red_intensity_1"],
+                    "_unit": "px",
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode("utf-8")
+        self.assertLess(
+            content.index("display_export_second"),
+            content.index("display_export_first"),
+        )
+
+    def test_dashboard_export_preserves_selected_uuid_order(self):
+        user = login_user(self, "frontend-dashboard-export-order@example.com")
+        first_uuid = create_display_file(uploaded_owner=user, filename="dashboard_export_first")
+        second_uuid = create_display_file(uploaded_owner=user, filename="dashboard_export_second")
+        add_cell_stat(first_uuid)
+        add_cell_stat(second_uuid)
+
+        response = self.client.post(
+            reverse("dashboard_bulk_export"),
+            data=json.dumps(
+                {
+                    "uuids": [second_uuid, first_uuid],
+                    "_export": "csv",
+                    "_columns": ["red_intensity_1"],
+                    "_unit": "px",
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode("utf-8")
+        self.assertLess(
+            content.index("dashboard_export_second"),
+            content.index("dashboard_export_first"),
+        )

--- a/cytocv/core/tests/test_frontend_js_contracts.py
+++ b/cytocv/core/tests/test_frontend_js_contracts.py
@@ -54,6 +54,13 @@ class FrontendJavaScriptStaticContractTests(SimpleTestCase):
             with self.subTest(helper=helper_name):
                 self.assertIn(helper_name, source)
 
+    def test_dashboard_quota_fill_width_is_applied_from_data_attribute(self):
+        source = static_text("js/pages/dashboard-viewer.js")
+        self.assertIn(".quota-fill[data-quota-fill-width]", source)
+        self.assertIn("dataset.quotaFillWidth", source)
+        self.assertIn("--quota-fill-width", source)
+        self.assertIn("`${quotaFillWidth}%`", source)
+
 
 class FrontendJavaScriptRenderedOrderTests(TestCase):
     def test_dashboard_and_display_load_shared_globals_before_consumers(self):

--- a/cytocv/core/tests/test_frontend_json_contracts.py
+++ b/cytocv/core/tests/test_frontend_json_contracts.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from .frontend_contract_helpers import (
+    add_cell_stat,
     assert_json_script_keys,
     create_display_file,
     create_preprocess_file,
@@ -85,12 +86,45 @@ class FrontendJsonContractTests(TestCase):
             uploaded_owner=user,
             segmented_owner_id=guest_user_id(),
             filename="json_transient",
+            num_cells=1,
         )
+        add_cell_stat(saved_uuid, cell_id=1)
+        add_cell_stat(transient_uuid, cell_id=1)
         set_transient_uuids(self.client, [transient_uuid])
 
         display_response = self.client.get(reverse("display", args=[transient_uuid]))
         display_content = response_text(display_response)
-        self.assertIsInstance(parse_json_script(display_content, "displayFilesData"), dict)
+        display_files = parse_json_script(display_content, "displayFilesData")
+        self.assertIsInstance(display_files, dict)
+        display_file = display_files[transient_uuid]
+        expected_file_keys = {
+            "MainImagePath",
+            "MainImagePaths",
+            "NumberOfCells",
+            "CellPairImages",
+            "Image_Name",
+            "ScaleContext",
+            "ChannelConfig",
+            "Statistics",
+            "NoCellsWarning",
+        }
+        self.assertEqual(set(display_file.keys()), expected_file_keys)
+        self.assertEqual(display_file["NumberOfCells"], 1)
+        self.assertEqual(list(display_file["CellPairImages"].keys()), ["1"])
+        self.assertEqual(
+            display_file["CellPairImages"]["1"],
+            [
+                f"/media/{transient_uuid}/segmented/json_transient-0-1.png",
+                f"/media/{transient_uuid}/segmented/json_transient-0-1-no_outline.png",
+                f"/media/{transient_uuid}/segmented/json_transient-1-1.png",
+                f"/media/{transient_uuid}/segmented/json_transient-1-1-no_outline.png",
+                f"/media/{transient_uuid}/segmented/json_transient-3-1.png",
+                f"/media/{transient_uuid}/segmented/json_transient-3-1-no_outline.png",
+                f"/media/{transient_uuid}/segmented/json_transient-2-1.png",
+                f"/media/{transient_uuid}/segmented/json_transient-2-1-no_outline.png",
+            ],
+        )
+        self.assertEqual(list(display_file["Statistics"].keys()), ["1"])
         display_config = assert_json_script_keys(
             self,
             display_content,
@@ -109,7 +143,14 @@ class FrontendJsonContractTests(TestCase):
 
         dashboard_response = self.client.get(reverse("dashboard") + f"?file_uuid={saved_uuid}")
         dashboard_content = response_text(dashboard_response)
-        self.assertIsInstance(parse_json_script(dashboard_content, "dashboardFilesData"), dict)
+        dashboard_files = parse_json_script(dashboard_content, "dashboardFilesData")
+        self.assertIsInstance(dashboard_files, dict)
+        dashboard_file = dashboard_files[saved_uuid]
+        self.assertEqual(set(dashboard_file.keys()), expected_file_keys)
+        self.assertEqual(dashboard_file["NumberOfCells"], 1)
+        self.assertEqual(list(dashboard_file["CellPairImages"].keys()), ["1"])
+        self.assertEqual(len(dashboard_file["CellPairImages"]["1"]), 8)
+        self.assertEqual(list(dashboard_file["Statistics"].keys()), ["1"])
         dashboard_config = assert_json_script_keys(
             self,
             dashboard_content,

--- a/cytocv/core/tests/test_image_sources.py
+++ b/cytocv/core/tests/test_image_sources.py
@@ -8,6 +8,8 @@ import tifffile
 from django.test import SimpleTestCase
 
 from core.image_sources import (
+    SUPPORTED_IMAGE_EXTENSIONS,
+    SUPPORTED_IMAGE_EXTENSIONS_LABEL,
     get_image_layer_count,
     is_recognized_image_file,
     is_supported_image_filename,
@@ -16,6 +18,10 @@ from core.image_sources import (
 
 
 class ImageSourceTests(SimpleTestCase):
+    def test_supported_source_extension_constants_are_exact(self):
+        self.assertEqual(SUPPORTED_IMAGE_EXTENSIONS, frozenset({".dv", ".tif", ".tiff"}))
+        self.assertEqual(SUPPORTED_IMAGE_EXTENSIONS_LABEL, ".dv, .tif, .tiff")
+
     def test_supported_source_extensions_are_case_insensitive(self):
         self.assertTrue(is_supported_image_filename("sample.dv"))
         self.assertTrue(is_supported_image_filename("sample.TIF"))

--- a/cytocv/core/tests/test_scale_request_payloads.py
+++ b/cytocv/core/tests/test_scale_request_payloads.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+from django.test import SimpleTestCase
+
+from core.services.scale_request_payloads import (
+    parse_file_scale_map_payload,
+    parse_file_scale_revert_payload,
+)
+
+
+class ScaleRequestPayloadTests(SimpleTestCase):
+    def test_scale_map_payload_preserves_empty_contract(self):
+        parsed, error, status = parse_file_scale_map_payload(
+            "",
+            active_uuid_set=set(),
+        )
+
+        self.assertEqual(parsed, {})
+        self.assertIsNone(error)
+        self.assertEqual(status, 200)
+
+    def test_scale_map_payload_preserves_error_contracts(self):
+        active_uuid = str(uuid4())
+        unavailable_uuid = str(uuid4())
+
+        cases = (
+            (
+                "{bad-json",
+                "Invalid per-file scale payload.",
+                400,
+            ),
+            (
+                json.dumps(["not", "an", "object"]),
+                "Per-file scale payload must be a JSON object.",
+                400,
+            ),
+            (
+                json.dumps({"not-a-uuid": 1.0}),
+                "Per-file scale payload contains an invalid UUID.",
+                400,
+            ),
+            (
+                json.dumps({unavailable_uuid: 1.0}),
+                "Per-file scale payload contains unavailable files.",
+                403,
+            ),
+            (
+                json.dumps({active_uuid: "not-numeric"}),
+                "Per-file scale values must be numeric.",
+                400,
+            ),
+            (
+                json.dumps({active_uuid: 0}),
+                "Per-file scale values must be greater than 0.",
+                400,
+            ),
+        )
+
+        for raw_payload, expected_error, expected_status in cases:
+            with self.subTest(raw_payload=raw_payload):
+                parsed, error, status = parse_file_scale_map_payload(
+                    raw_payload,
+                    active_uuid_set={active_uuid},
+                )
+
+                self.assertEqual(parsed, {})
+                self.assertEqual(error, expected_error)
+                self.assertEqual(status, expected_status)
+
+    def test_scale_map_payload_preserves_valid_override_contract(self):
+        active_uuid = str(uuid4())
+
+        parsed, error, status = parse_file_scale_map_payload(
+            json.dumps({active_uuid.upper(): {"effective_um_per_px": "0.25"}}),
+            active_uuid_set={active_uuid},
+        )
+
+        self.assertEqual(parsed, {active_uuid: 0.25})
+        self.assertIsNone(error)
+        self.assertEqual(status, 200)
+
+    def test_scale_revert_payload_preserves_empty_contract(self):
+        parsed, error, status = parse_file_scale_revert_payload(
+            "",
+            active_uuid_set=set(),
+        )
+
+        self.assertEqual(parsed, set())
+        self.assertIsNone(error)
+        self.assertEqual(status, 200)
+
+    def test_scale_revert_payload_preserves_error_contracts(self):
+        active_uuid = str(uuid4())
+        unavailable_uuid = str(uuid4())
+
+        cases = (
+            (
+                "{bad-json",
+                "Invalid scale revert payload.",
+                400,
+            ),
+            (
+                json.dumps({"not": "an array"}),
+                "Scale revert payload must be a JSON array.",
+                400,
+            ),
+            (
+                json.dumps(["not-a-uuid"]),
+                "Scale revert payload contains an invalid UUID.",
+                400,
+            ),
+            (
+                json.dumps([unavailable_uuid]),
+                "Scale revert payload contains unavailable files.",
+                403,
+            ),
+        )
+
+        for raw_payload, expected_error, expected_status in cases:
+            with self.subTest(raw_payload=raw_payload):
+                parsed, error, status = parse_file_scale_revert_payload(
+                    raw_payload,
+                    active_uuid_set={active_uuid},
+                )
+
+                self.assertEqual(parsed, set())
+                self.assertEqual(error, expected_error)
+                self.assertEqual(status, expected_status)
+
+    def test_scale_revert_payload_preserves_valid_revert_contract(self):
+        active_uuid = str(uuid4())
+
+        parsed, error, status = parse_file_scale_revert_payload(
+            json.dumps([active_uuid.upper()]),
+            active_uuid_set={active_uuid},
+        )
+
+        self.assertEqual(parsed, {active_uuid})
+        self.assertIsNone(error)
+        self.assertEqual(status, 200)

--- a/cytocv/core/tests/test_upload_preparation.py
+++ b/cytocv/core/tests/test_upload_preparation.py
@@ -413,6 +413,20 @@ class UploadPreparationTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
         payload = response.json()
+        self.assertEqual(
+            list(payload.keys()),
+            [
+                "job_uuid",
+                "status",
+                "phase",
+                "detail",
+                "errors",
+                "failure_summary",
+                "redirect",
+            ],
+        )
+        self.assertEqual(payload["job_uuid"], str(job.job_uuid))
+        self.assertEqual(payload["status"], UploadPreparationJob.Status.RUNNING)
         self.assertEqual(payload["phase"], "Extracting Image Metadata")
         self.assertEqual(
             payload["detail"],
@@ -423,6 +437,9 @@ class UploadPreparationTestCase(TestCase):
                 "fileTotal": 4,
             },
         )
+        self.assertEqual(payload["errors"], [])
+        self.assertEqual(payload["failure_summary"], "")
+        self.assertIsNone(payload["redirect"])
 
     def test_upload_preparation_cancel_terminal_job_returns_status_phase_detail(self):
         job = enqueue_upload_preparation_job(

--- a/cytocv/core/tests/test_upload_preparation.py
+++ b/cytocv/core/tests/test_upload_preparation.py
@@ -424,6 +424,83 @@ class UploadPreparationTestCase(TestCase):
             },
         )
 
+    def test_upload_preparation_cancel_terminal_job_returns_status_phase_detail(self):
+        job = enqueue_upload_preparation_job(
+            user_id=self.user.id,
+            new_run_uuids=[],
+            restored_run_uuids=[],
+            config_snapshot=self._config_snapshot(),
+        )
+        UploadPreparationJob.objects.filter(pk=job.pk).update(
+            status=UploadPreparationJob.Status.SUCCEEDED,
+            current_phase="Completed",
+            progress_detail={
+                "fileName": "../complete.dv",
+                "message": "Upload preparation complete.",
+                "fileIndex": 1,
+                "fileTotal": 1,
+                "unsafe": "ignored",
+            },
+            finished_at=timezone.now(),
+        )
+
+        response = self.client.post(
+            reverse("experiment_upload_prepare_cancel", args=[str(job.job_uuid)])
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(list(payload.keys()), ["status", "phase", "detail"])
+        self.assertEqual(payload["status"], UploadPreparationJob.Status.SUCCEEDED)
+        self.assertEqual(payload["phase"], "Completed")
+        self.assertEqual(
+            payload["detail"],
+            {
+                "fileName": "complete.dv",
+                "message": "Upload preparation complete.",
+                "fileIndex": 1,
+                "fileTotal": 1,
+            },
+        )
+
+    def test_upload_preparation_cancel_queued_job_returns_cancelled_payload(self):
+        with temporary_media_root() as media_root:
+            uploaded = self._create_uploaded_image(media_root, name="queued_cancel")
+            run_dir = media_root / str(uploaded.uuid)
+            job = enqueue_upload_preparation_job(
+                user_id=self.user.id,
+                new_run_uuids=[str(uploaded.uuid)],
+                restored_run_uuids=[],
+                config_snapshot=self._config_snapshot(),
+            )
+            session = self.client.session
+            session["recent_upload_preparation_job_uuids"] = [str(job.job_uuid)]
+            session.save()
+
+            response = self.client.post(
+                reverse("experiment_upload_prepare_cancel", args=[str(job.job_uuid)])
+            )
+
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(list(payload.keys()), ["status", "phase", "detail"])
+            self.assertEqual(
+                payload,
+                {
+                    "status": UploadPreparationJob.Status.CANCELLED,
+                    "phase": "Cancelled",
+                    "detail": {},
+                },
+            )
+            job.refresh_from_db()
+            self.assertEqual(job.status, UploadPreparationJob.Status.CANCELLED)
+            self.assertFalse(UploadedImage.objects.filter(uuid=uploaded.uuid).exists())
+            self.assertFalse(run_dir.exists())
+            self.assertNotIn(
+                "recent_upload_preparation_job_uuids",
+                self.client.session,
+            )
+
     def test_upload_preparation_enqueue_forbids_other_user_uuid_and_cleans_new(self):
         with temporary_media_root() as media_root:
             new_upload = self._create_uploaded_image(media_root, name="new_upload")

--- a/cytocv/core/views/display.py
+++ b/cytocv/core/views/display.py
@@ -69,7 +69,7 @@ from core.scale import (
     normalize_spatial_stats_unit,
 )
 from core.tables import CellTable
-from cytocv.settings import MEDIA_ROOT, MEDIA_URL
+from cytocv.settings import MEDIA_ROOT
 from django_tables2.export.export import TableExport
 
 

--- a/cytocv/core/views/display.py
+++ b/cytocv/core/views/display.py
@@ -1,8 +1,6 @@
 import json
-import math
 import re
 from pathlib import Path
-from uuid import UUID
 
 from django.db import transaction
 from django.http import (
@@ -21,9 +19,7 @@ from core.channel_roles import (
     CHANNEL_ROLE_DIC,
     CHANNEL_ROLE_GREEN,
     CHANNEL_ROLE_RED,
-    channel_display_label,
     channel_role_from_slug,
-    channel_slug,
 )
 from core.config import get_channel_config_for_uuid
 from core.models import (
@@ -43,7 +39,6 @@ from core.services.cell_deletion import delete_multiple_cells, delete_single_cel
 from core.services.cell_statistics_payload import serialize_cell_statistics_payload
 from core.services.combined_stat_export import (
     CombinedStatisticsExportError,
-    StatisticsExportFile,
     build_combined_statistics_export_response,
 )
 from core.services.export_filenames import (
@@ -56,12 +51,22 @@ from core.services.artifact_paths import (
 )
 from core.services.main_image_urls import build_main_image_paths
 from core.services.overlay_rendering import build_overlay_image_url, overlay_image_available
-from core.services.puncta_line_mode import VALID_PUNCTA_LINE_MODES
+from core.services.result_view_payloads import (
+    RESULT_CHANNEL_ORDER,
+    channel_config_payload,
+    detected_channel_labels,
+    resolve_cell_table_modes,
+    sanitize_for_json,
+)
 from core.services.stat_export_selection import (
     ExportColumnSelectionError,
     export_exclude_columns,
     export_metric_scope,
     export_selection_config,
+)
+from core.services.stat_export_requests import (
+    build_statistics_export_sources,
+    normalize_uuid_list,
 )
 from core.scale import (
     get_scale_context_payload,
@@ -71,37 +76,6 @@ from core.scale import (
 from core.tables import CellTable
 from cytocv.settings import MEDIA_ROOT
 from django_tables2.export.export import TableExport
-
-
-def _resolve_nuclear_cell_pair_mode(stats_iterable):
-    modes = set()
-    for stat in stats_iterable:
-        props = stat.properties or {}
-        mode = props.get("nuclear_cell_pair_mode", props.get("nuclear_cellular_mode"))
-        if mode in {"green_nucleus", "red_nucleus"}:
-            modes.add(mode)
-    return modes.pop() if len(modes) == 1 else None
-
-
-def _resolve_puncta_line_mode(stats_iterable):
-    modes = set()
-    for stat in stats_iterable:
-        props = stat.properties or {}
-        mode = props.get("puncta_line_mode")
-        if mode in VALID_PUNCTA_LINE_MODES:
-            modes.add(mode)
-    return modes.pop() if len(modes) == 1 else None
-
-
-def _sanitize_for_json(value):
-    """Convert nested values to strict JSON-safe equivalents."""
-    if isinstance(value, float):
-        return value if math.isfinite(value) else None
-    if isinstance(value, dict):
-        return {str(key): _sanitize_for_json(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple, set)):
-        return [_sanitize_for_json(item) for item in value]
-    return value
 
 
 def _scan_output_frames(uuid: str):
@@ -125,23 +99,6 @@ def _current_transient_uuid_set(request):
         for value in request.session.get("transient_experiment_uuids", [])
         if str(value)
     }
-
-
-def _normalize_uuid_list(raw_values):
-    if not isinstance(raw_values, list):
-        return []
-    normalized = []
-    seen = set()
-    for value in raw_values:
-        try:
-            value_uuid = str(UUID(str(value)))
-        except (TypeError, ValueError, AttributeError):
-            return []
-        if value_uuid in seen:
-            continue
-        seen.add(value_uuid)
-        normalized.append(value_uuid)
-    return normalized
 
 
 MANUAL_SAVE_STORAGE_FULL_MESSAGE = (
@@ -202,12 +159,7 @@ def display(request, uuids):
     # List to store file information for sidebar navigation
     file_list = []
     cell_table = None
-    channel_order = [
-        CHANNEL_ROLE_DIC,
-        CHANNEL_ROLE_BLUE,
-        CHANNEL_ROLE_RED,
-        CHANNEL_ROLE_GREEN,
-    ]
+    channel_order = RESULT_CHANNEL_ORDER
 
     preferences = get_user_preferences(request.user)
     show_saved_file_channels = bool(preferences.get("show_saved_file_channels", True))
@@ -245,10 +197,7 @@ def display(request, uuids):
             # get your channel-to-index mapping
             channel_config = get_channel_config_for_uuid(uuid)
             # Sort by saved index so the sidebar mirrors the detected file order.
-            detected = [
-                channel_display_label(channel_name)
-                for channel_name, _ in sorted(channel_config.items(), key=lambda t: t[1])
-            ]
+            detected = detected_channel_labels(channel_config)
 
             # Append file info for the sidebar, INCLUDING the channel pills
             scale_payload = get_scale_sidebar_payload(
@@ -299,8 +248,9 @@ def display(request, uuids):
             stats_by_id = {cell.cell_id: cell for cell in cell_stats_qs}
             if stats_by_id and first_table_uuid is None:
                 first_table_uuid = uuid
-                table_mode = _resolve_nuclear_cell_pair_mode(stats_by_id.values())
-                puncta_line_mode = _resolve_puncta_line_mode(stats_by_id.values())
+                table_mode, puncta_line_mode = resolve_cell_table_modes(
+                    stats_by_id.values()
+                )
                 cell_table = CellTable(
                     cell_stats_qs,
                     intensity_mode=table_mode,
@@ -401,10 +351,7 @@ def display(request, uuids):
                 'CellPairImages': images,
                 'Image_Name': image_name,
                 'ScaleContext': scale_context,
-                'ChannelConfig': {
-                    channel_slug(channel_name): channel_index
-                    for channel_name, channel_index in channel_config.items()
-                },
+                'ChannelConfig': channel_config_payload(channel_config),
                 'Statistics': statistics,
                 'NoCellsWarning': no_cells_warning,
             }
@@ -424,7 +371,7 @@ def display(request, uuids):
         )
 
     # Convert the files_data to JSON to be used in the template
-    json_files_data = json.dumps(_sanitize_for_json(all_files_data), allow_nan=False)
+    json_files_data = json.dumps(sanitize_for_json(all_files_data), allow_nan=False)
 
     return render(request, "display.html", {
         'files_data': json_files_data,  # Pass all file data to the template
@@ -454,7 +401,7 @@ def save_display_files(request):
             status=400,
         )
 
-    requested_uuids = _normalize_uuid_list(payload.get("uuids", []))
+    requested_uuids = normalize_uuid_list(payload.get("uuids", []))
     if not requested_uuids:
         return JsonResponse({"error": "Select at least one file to continue."}, status=400)
 
@@ -555,7 +502,7 @@ def unsave_display_files(request):
             status=400,
         )
 
-    requested_uuids = _normalize_uuid_list(payload.get("uuids", []))
+    requested_uuids = normalize_uuid_list(payload.get("uuids", []))
     if not requested_uuids:
         return JsonResponse({"error": "Select at least one file to continue."}, status=400)
 
@@ -644,8 +591,8 @@ def sync_display_file_selection(request):
             status=400,
         )
 
-    visible_uuids = _normalize_uuid_list(payload.get("visible_uuids", []))
-    selected_uuids = _normalize_uuid_list(payload.get("selected_uuids", []))
+    visible_uuids = normalize_uuid_list(payload.get("visible_uuids", []))
+    selected_uuids = normalize_uuid_list(payload.get("selected_uuids", []))
     if not visible_uuids:
         return JsonResponse({"error": "Select at least one file to continue."}, status=400)
 
@@ -761,8 +708,8 @@ def export_display_files(request):
             status=400,
         )
 
-    visible_uuids = _normalize_uuid_list(payload.get("visible_uuids", []))
-    requested_uuids = _normalize_uuid_list(payload.get("uuids", []))
+    visible_uuids = normalize_uuid_list(payload.get("visible_uuids", []))
+    requested_uuids = normalize_uuid_list(payload.get("uuids", []))
     if not requested_uuids:
         return JsonResponse({"error": "Select at least one file to continue."}, status=400)
     if not visible_uuids:
@@ -800,7 +747,6 @@ def export_display_files(request):
             status=403,
         )
 
-    sources = []
     for uuid in ordered_uuids:
         uploaded = uploaded_map[uuid]
         segmented = segmented_map[uuid]
@@ -809,14 +755,11 @@ def export_display_files(request):
                 {"error": "One or more selected files are no longer available. Refresh and try again."},
                 status=403,
             )
-        sources.append(
-            StatisticsExportFile(
-                uuid=uuid,
-                file_name=uploaded.name,
-                segmented_image=segmented,
-                scale_info=uploaded.scale_info,
-            )
-        )
+    sources = build_statistics_export_sources(
+        ordered_uuids,
+        uploaded_map=uploaded_map,
+        segmented_map=segmented_map,
+    )
 
     preferences = get_user_preferences(request.user)
     default_manual_scale = (

--- a/cytocv/core/views/experiment.py
+++ b/cytocv/core/views/experiment.py
@@ -180,6 +180,16 @@ def _build_upload_preparation_payload(
     }
 
 
+def _build_upload_preparation_cancel_payload(
+    job: UploadPreparationJob,
+) -> dict[str, object]:
+    return {
+        "status": job.status,
+        "phase": job.current_phase,
+        "detail": _upload_job_detail(job),
+    }
+
+
 def _resolve_upload_preparation_resume_payload(request) -> dict[str, object] | None:
     """Return the newest resumable upload-preparation payload for this session."""
 
@@ -1257,13 +1267,7 @@ def cancel_upload_preparation(request, job_uuid):
         UploadPreparationJob.Status.FAILED,
         UploadPreparationJob.Status.CANCELLED,
     }:
-        return JsonResponse(
-            {
-                "status": job.status,
-                "phase": job.current_phase,
-                "detail": _upload_job_detail(job),
-            }
-        )
+        return JsonResponse(_build_upload_preparation_cancel_payload(job))
 
     if job.status == UploadPreparationJob.Status.QUEUED:
         for run_uuid in job.new_run_uuids:
@@ -1278,10 +1282,4 @@ def cancel_upload_preparation(request, job_uuid):
         _forget_upload_preparation_job(request, str(job.job_uuid))
     else:
         job = request_upload_preparation_cancellation(job)
-    return JsonResponse(
-        {
-            "status": job.status,
-            "phase": job.current_phase,
-            "detail": _upload_job_detail(job),
-        }
-    )
+    return JsonResponse(_build_upload_preparation_cancel_payload(job))

--- a/cytocv/core/views/experiment.py
+++ b/cytocv/core/views/experiment.py
@@ -67,7 +67,6 @@ from core.services.artifact_storage import (
     sweep_user_run_artifacts,
 )
 from core.services.analysis_context import normalize_execution_mode
-from core.services.analysis_progress import normalize_progress_detail
 from core.services.upload_preparation import run_upload_preparation_job
 from core.services.upload_preparation_jobs import (
     ACTIVE_UPLOAD_PREPARATION_STATUSES,
@@ -79,6 +78,10 @@ from core.services.upload_preparation_jobs import (
     reap_stale_upload_preparation_jobs,
     request_upload_preparation_cancellation,
     start_inline_upload_preparation_job,
+)
+from core.services.upload_preparation_payloads import (
+    build_upload_preparation_cancel_payload,
+    build_upload_preparation_payload,
 )
 
 NUCLEAR_CELL_PAIR_MODES = {"green_nucleus", "red_nucleus"}
@@ -98,10 +101,6 @@ def _parse_bool(value, default=False):
     if isinstance(value, bool):
         return value
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _upload_job_detail(job: UploadPreparationJob) -> dict[str, object]:
-    return normalize_progress_detail(job.progress_detail)
 
 
 def _recent_upload_preparation_job_uuids(request) -> list[str]:
@@ -147,47 +146,33 @@ def _forget_upload_preparation_job(request, job_uuid: str) -> None:
     _set_recent_upload_preparation_job_uuids(request, next_values)
 
 
-def _build_upload_preparation_payload(
+def _upload_preparation_redirect_for_request(
+    request,
+    job: UploadPreparationJob,
+    status: str,
+) -> str | None:
+    if status != UploadPreparationJob.Status.SUCCEEDED or not job.valid_run_uuids:
+        return None
+
+    valid_uuids = [str(value) for value in job.valid_run_uuids if str(value)]
+    request.session["last_experiment_uuids"] = valid_uuids
+    request.session.modified = True
+    return reverse("pre_process", kwargs={"uuids": ",".join(valid_uuids)})
+
+
+def _build_upload_preparation_payload_for_request(
     request,
     job: UploadPreparationJob,
     *,
     stale_state: tuple[str, str, str] | None = None,
 ) -> dict[str, object]:
-    """Serialize one upload-preparation job for APIs and resume bootstrapping."""
-
     status = stale_state[0] if stale_state is not None else job.status
-    phase = stale_state[1] if stale_state is not None else job.current_phase
-    failure_summary = stale_state[2] if stale_state is not None else job.failure_summary
-    errors = [str(line) for line in job.error_lines or [] if str(line)]
-    if failure_summary and not errors and status == UploadPreparationJob.Status.FAILED:
-        errors = [failure_summary]
-
-    redirect_url = None
-    if status == UploadPreparationJob.Status.SUCCEEDED and job.valid_run_uuids:
-        valid_uuids = [str(value) for value in job.valid_run_uuids if str(value)]
-        request.session["last_experiment_uuids"] = valid_uuids
-        request.session.modified = True
-        redirect_url = reverse("pre_process", kwargs={"uuids": ",".join(valid_uuids)})
-
-    return {
-        "job_uuid": str(job.job_uuid),
-        "status": status,
-        "phase": phase,
-        "detail": _upload_job_detail(job),
-        "errors": errors,
-        "failure_summary": failure_summary,
-        "redirect": redirect_url,
-    }
-
-
-def _build_upload_preparation_cancel_payload(
-    job: UploadPreparationJob,
-) -> dict[str, object]:
-    return {
-        "status": job.status,
-        "phase": job.current_phase,
-        "detail": _upload_job_detail(job),
-    }
+    redirect_url = _upload_preparation_redirect_for_request(request, job, status)
+    return build_upload_preparation_payload(
+        job,
+        stale_state=stale_state,
+        redirect_url=redirect_url,
+    )
 
 
 def _resolve_upload_preparation_resume_payload(request) -> dict[str, object] | None:
@@ -211,7 +196,7 @@ def _resolve_upload_preparation_resume_payload(request) -> dict[str, object] | N
     for job_uuid in reversed(existing_job_uuids):
         job = jobs_by_uuid[job_uuid]
         stale_state = get_stale_upload_preparation_terminal_state(job)
-        selected_payload = _build_upload_preparation_payload(
+        selected_payload = _build_upload_preparation_payload_for_request(
             request,
             job,
             stale_state=stale_state,
@@ -981,7 +966,7 @@ def experiment(request):
             config_snapshot=config_snapshot,
         )
         _track_active_upload_preparation_job(request, job)
-        payload = _build_upload_preparation_payload(request, job)
+        payload = _build_upload_preparation_payload_for_request(request, job)
         if is_ajax:
             return JsonResponse(payload)
         if job.status == UploadPreparationJob.Status.SUCCEEDED and payload.get(
@@ -1218,7 +1203,7 @@ def enqueue_upload_preparation(request):
         config_snapshot=config_snapshot,
     )
     _track_active_upload_preparation_job(request, job)
-    return JsonResponse(_build_upload_preparation_payload(request, job))
+    return JsonResponse(_build_upload_preparation_payload_for_request(request, job))
 
 
 @require_GET
@@ -1235,7 +1220,7 @@ def upload_preparation_status(request, job_uuid):
             {"errors": ["That upload session is no longer available."]}, status=404
         )
     stale_state = get_stale_upload_preparation_terminal_state(job)
-    payload = _build_upload_preparation_payload(
+    payload = _build_upload_preparation_payload_for_request(
         request,
         job,
         stale_state=stale_state,
@@ -1267,7 +1252,7 @@ def cancel_upload_preparation(request, job_uuid):
         UploadPreparationJob.Status.FAILED,
         UploadPreparationJob.Status.CANCELLED,
     }:
-        return JsonResponse(_build_upload_preparation_cancel_payload(job))
+        return JsonResponse(build_upload_preparation_cancel_payload(job))
 
     if job.status == UploadPreparationJob.Status.QUEUED:
         for run_uuid in job.new_run_uuids:
@@ -1282,4 +1267,4 @@ def cancel_upload_preparation(request, job_uuid):
         _forget_upload_preparation_job(request, str(job.job_uuid))
     else:
         job = request_upload_preparation_cancellation(job)
-    return JsonResponse(_build_upload_preparation_cancel_payload(job))
+    return JsonResponse(build_upload_preparation_cancel_payload(job))

--- a/cytocv/core/views/pre_process.py
+++ b/cytocv/core/views/pre_process.py
@@ -32,7 +32,6 @@ from core.services.analysis_progress_contract import (
     PROGRESS_PHASE_FAILED,
     PROGRESS_STATUS_FAILED,
     PROGRESS_STATUS_SUCCEEDED,
-    SAFE_ANALYSIS_FAILURE_SUMMARY,
     SAFE_PROGRESS_ERROR_MESSAGE,
     SAFE_PROGRESS_WRITE_ERROR_MESSAGE,
     TERMINAL_PROGRESS_STATUSES,
@@ -60,7 +59,6 @@ from core.services.signal_quantification import (
     resolve_signal_quantification_selection,
 )
 from .utils import (
-    tif_to_jpg,
     prune_experiment_session_state,
     sync_transient_run_session_state,
 )

--- a/cytocv/core/views/pre_process.py
+++ b/cytocv/core/views/pre_process.py
@@ -5,14 +5,12 @@ from django.template.response import TemplateResponse
 from django.views.decorators.http import require_POST, require_GET
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
 from django.urls import reverse
-import math
 from uuid import UUID
 import logging
 
-from core.models import SegmentedImage, UploadedImage, get_guest_user
+from core.models import UploadedImage
 from core.services.analysis_context import (
     build_analysis_batch_context,
-    build_batch_key,
     normalize_execution_mode,
 )
 from core.services.analysis_exceptions import AnalysisCancelled
@@ -20,7 +18,6 @@ from core.services.analysis_jobs import (
     AnalysisJobLimitExceeded,
     enqueue_analysis_job,
     get_active_analysis_job,
-    get_latest_analysis_job,
     reap_stale_analysis_jobs,
 )
 from core.services.analysis_pipeline import run_analysis_batch
@@ -29,8 +26,6 @@ from core.services.analysis_progress import (
     get_progress_snapshot,
 )
 from core.services.analysis_progress_contract import (
-    PROGRESS_PHASE_FAILED,
-    PROGRESS_STATUS_FAILED,
     PROGRESS_STATUS_SUCCEEDED,
     SAFE_PROGRESS_ERROR_MESSAGE,
     SAFE_PROGRESS_WRITE_ERROR_MESSAGE,
@@ -58,6 +53,19 @@ from core.services.nuclear_cell_pair_contour_mode import (
 from core.services.signal_quantification import (
     resolve_signal_quantification_selection,
 )
+from core.services.progress_request_helpers import (
+    ProgressRequestError,
+    current_owner_filter as _current_owner_filter,
+    progress_read_error_response as _progress_read_error_response,
+    progress_write_error_response as _progress_write_error_response,
+    release_progress_batch as _release_progress_batch,
+    resolve_owned_progress_batch as _resolve_owned_progress_batch,
+    track_progress_batch as _track_progress_batch,
+)
+from core.services.scale_request_payloads import (
+    parse_file_scale_map_payload,
+    parse_file_scale_revert_payload,
+)
 from .utils import (
     prune_experiment_session_state,
     sync_transient_run_session_state,
@@ -83,7 +91,6 @@ from core.mrcnn.preprocess_images import preprocess_images
 from cytocv.settings import MEDIA_ROOT
 from pathlib import Path
 import json
-import re
 
 from accounts.preferences import get_user_preferences
 from core.scale import (
@@ -160,18 +167,6 @@ def _channel_labels_from_config(config: dict[str, int]) -> list[str]:
     ]
 
 
-PROGRESS_BATCH_SESSION_KEY = "authorized_progress_batches"
-
-
-class ProgressRequestError(Exception):
-    """Controlled progress request error carrying an HTTP status code."""
-
-    def __init__(self, message: str, *, status_code: int) -> None:
-        super().__init__(message)
-        self.message = message
-        self.status_code = status_code
-
-
 def _parse_bool(value, default: bool = False) -> bool:
     """Parse common truthy/falsy request/session values."""
 
@@ -180,14 +175,6 @@ def _parse_bool(value, default: bool = False) -> bool:
     if isinstance(value, bool):
         return value
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _current_owner_filter(request) -> dict:
-    """Return queryset filter args for the current upload owner."""
-
-    if request.user.is_authenticated:
-        return {"user": request.user}
-    return {"user_id": get_guest_user()}
 
 
 def _delete_cancelled_runs(request, uuid_values: list[str]) -> None:
@@ -204,166 +191,6 @@ def _delete_cancelled_runs(request, uuid_values: list[str]) -> None:
     for run_uuid in owned_uuids:
         delete_uploaded_run_by_uuid(run_uuid)
     prune_experiment_session_state(request, owned_uuids)
-
-
-def _get_authorized_progress_batches(request) -> set[str]:
-    """Return session-tracked progress batches authorized for the current user."""
-
-    return {
-        str(value)
-        for value in request.session.get(PROGRESS_BATCH_SESSION_KEY, [])
-        if str(value)
-    }
-
-
-def _track_progress_batch(request, batch_key: str) -> None:
-    """Persist a session-scoped allowlist for in-flight progress lookups."""
-
-    tracked = _get_authorized_progress_batches(request)
-    if batch_key in tracked:
-        return
-    tracked.add(batch_key)
-    request.session[PROGRESS_BATCH_SESSION_KEY] = sorted(tracked)
-    request.session.modified = True
-
-
-def _release_progress_batch(request, batch_key: str) -> None:
-    """Remove a finished batch from the session-scoped progress allowlist."""
-
-    tracked = _get_authorized_progress_batches(request)
-    if batch_key not in tracked:
-        return
-    tracked.remove(batch_key)
-    request.session[PROGRESS_BATCH_SESSION_KEY] = sorted(tracked)
-    request.session.modified = True
-
-
-def _resolve_owned_progress_batch(request, raw_uuids: str) -> tuple[str, list[str]]:
-    """Return the canonical owned batch key for progress routes."""
-
-    if not raw_uuids or not re.fullmatch(r"[0-9a-fA-F,-]+", raw_uuids):
-        raise ProgressRequestError("Invalid analysis batch.", status_code=400)
-    try:
-        batch_key = build_batch_key(raw_uuids)
-    except (TypeError, ValueError):
-        raise ProgressRequestError("Invalid analysis batch.", status_code=400)
-    uuid_list = [value for value in batch_key.split(",") if value]
-    if not uuid_list:
-        raise ProgressRequestError("Invalid analysis batch.", status_code=400)
-
-    owner_filter = _current_owner_filter(request)
-    owned_uploads = {
-        str(value)
-        for value in UploadedImage.objects.filter(
-            uuid__in=uuid_list,
-            **owner_filter,
-        ).values_list("uuid", flat=True)
-    }
-    owned_segmented = {
-        str(value)
-        for value in SegmentedImage.objects.filter(
-            UUID__in=uuid_list,
-            user=request.user,
-        ).values_list("UUID", flat=True)
-    }
-    owned_uuids = owned_uploads | owned_segmented
-    if set(uuid_list).issubset(owned_uuids):
-        return batch_key, uuid_list
-
-    if batch_key in _get_authorized_progress_batches(request):
-        return batch_key, uuid_list
-
-    if (
-        get_latest_analysis_job(user_id=request.user.id, batch_key=batch_key)
-        is not None
-    ):
-        return batch_key, uuid_list
-
-    raise ProgressRequestError("Forbidden", status_code=403)
-
-
-def _progress_read_error_response(message: str, *, status_code: int) -> JsonResponse:
-    """Return a controlled progress-read error payload."""
-
-    return JsonResponse(
-        {
-            "phase": PROGRESS_PHASE_FAILED,
-            "status": PROGRESS_STATUS_FAILED,
-            "failure_summary": message,
-            "redirect": None,
-        },
-        status=status_code,
-    )
-
-
-def _progress_write_error_response(message: str, *, status_code: int) -> JsonResponse:
-    """Return a controlled progress-write error payload."""
-
-    return JsonResponse({"status": "error", "message": message}, status=status_code)
-
-
-def _parse_file_scale_map_payload(
-    raw_payload: str,
-    active_uuid_set: set[str],
-) -> tuple[dict[str, float], str | None, int]:
-    """Parse and validate per-file scale payload from preprocess form."""
-
-    if not raw_payload:
-        return {}, None, 200
-    try:
-        payload = json.loads(raw_payload)
-    except (TypeError, ValueError, json.JSONDecodeError):
-        return {}, "Invalid per-file scale payload.", 400
-    if not isinstance(payload, dict):
-        return {}, "Per-file scale payload must be a JSON object.", 400
-
-    parsed: dict[str, float] = {}
-    for raw_uuid, raw_value in payload.items():
-        try:
-            normalized_uuid = str(UUID(str(raw_uuid)))
-        except (TypeError, ValueError, AttributeError):
-            return {}, "Per-file scale payload contains an invalid UUID.", 400
-        if normalized_uuid not in active_uuid_set:
-            return {}, "Per-file scale payload contains unavailable files.", 403
-
-        value = raw_value
-        if isinstance(raw_value, dict):
-            value = raw_value.get("effective_um_per_px")
-        try:
-            numeric = float(value)
-        except (TypeError, ValueError):
-            return {}, "Per-file scale values must be numeric.", 400
-        if not math.isfinite(numeric) or numeric <= 0:
-            return {}, "Per-file scale values must be greater than 0.", 400
-        parsed[normalized_uuid] = numeric
-    return parsed, None, 200
-
-
-def _parse_file_scale_revert_payload(
-    raw_payload: str,
-    active_uuid_set: set[str],
-) -> tuple[set[str], str | None, int]:
-    """Parse and validate file UUIDs that should revert to auto scale resolution."""
-
-    if not raw_payload:
-        return set(), None, 200
-    try:
-        payload = json.loads(raw_payload)
-    except (TypeError, ValueError, json.JSONDecodeError):
-        return set(), "Invalid scale revert payload.", 400
-    if not isinstance(payload, list):
-        return set(), "Scale revert payload must be a JSON array.", 400
-
-    parsed: set[str] = set()
-    for raw_uuid in payload:
-        try:
-            normalized_uuid = str(UUID(str(raw_uuid)))
-        except (TypeError, ValueError, AttributeError):
-            return set(), "Scale revert payload contains an invalid UUID.", 400
-        if normalized_uuid not in active_uuid_set:
-            return set(), "Scale revert payload contains unavailable files.", 403
-        parsed.add(normalized_uuid)
-    return parsed, None, 200
 
 
 @require_GET
@@ -520,7 +347,7 @@ def pre_process(request, uuids):
                 active_uuid_set.add(str(UUID(str(value))))
             except (TypeError, ValueError, AttributeError):
                 active_uuid_set.add(str(value))
-        scale_map, scale_error, scale_status = _parse_file_scale_map_payload(
+        scale_map, scale_error, scale_status = parse_file_scale_map_payload(
             request.POST.get("file_scale_map", ""),
             active_uuid_set=active_uuid_set,
         )
@@ -528,7 +355,7 @@ def pre_process(request, uuids):
             if request.headers.get("X-Requested-With") == "XMLHttpRequest":
                 return JsonResponse({"error": scale_error}, status=scale_status)
             return HttpResponse(scale_error, status=scale_status)
-        revert_uuid_set, revert_error, revert_status = _parse_file_scale_revert_payload(
+        revert_uuid_set, revert_error, revert_status = parse_file_scale_revert_payload(
             request.POST.get("file_scale_revert_uuids", ""),
             active_uuid_set=active_uuid_set,
         )

--- a/cytocv/core/views/segment_image.py
+++ b/cytocv/core/views/segment_image.py
@@ -8,8 +8,6 @@ import os
 import time
 from collections import defaultdict
 from pathlib import Path
-import json
-import hashlib
 
 # ==========================================================
 # Matplotlib backend (must run BEFORE importing pyplot/etc.)
@@ -33,8 +31,6 @@ import numpy as np
 import skimage
 from PIL import Image
 from cv2_rolling_ball import subtract_background_rolling_ball
-from scipy.spatial.distance import euclidean
-from skimage import io
 
 # =========================
 # Django imports
@@ -48,7 +44,7 @@ from django.shortcuts import get_object_or_404, redirect
 # =========================
 # Local application imports
 # =========================
-from cytocv.settings import MEDIA_ROOT, MEDIA_URL
+from cytocv.settings import MEDIA_ROOT
 from .utils import (
     write_progress,
     is_cancelled,
@@ -70,7 +66,6 @@ from core.config import (
 from core.image_sources import load_image_stack
 from core.models import (
     CellStatistics,
-    Contour,
     SegmentedImage,
     UploadedImage,
     get_guest_user,

--- a/cytocv/core/views/utils.py
+++ b/cytocv/core/views/utils.py
@@ -1,12 +1,10 @@
 import cv2
-import logging
 from pathlib import Path
 from cytocv.settings import MEDIA_ROOT
 from core.models import SegmentedImage, get_guest_user
 from core.services.analysis_progress import (
     clear_cancelled as clear_cancelled_flag,
     is_cancelled as is_cancelled_flag,
-    progress_path,
     read_file_progress,
     set_cancelled as set_cancelled_flag,
     write_file_progress,
@@ -28,9 +26,6 @@ def tif_to_jpg(tif_path :Path, output_dir :Path) -> Path:
     jpg_path = Path(output_dir / temp)
     cv2.imwrite(str(jpg_path), read,[int(cv2.IMWRITE_JPEG_QUALITY), 100])
     return jpg_path
-
-
-logger = logging.getLogger(__name__)
 
 
 def write_progress(key: str, phase: str, status: str | None = None, failure_summary: str = "") -> None:

--- a/cytocv/templates/dashboard.html
+++ b/cytocv/templates/dashboard.html
@@ -105,7 +105,7 @@
                     <p class="storage-text">{{ used_storage_mb|floatformat:2 }} MB out of {{ total_storage_gb|floatformat:2 }} GB</p>
                 </div>
                 <div class="quota-track">
-                    <div class="quota-fill"></div>
+                    <div class="quota-fill" style="--quota-fill-width: {{ storage_percentage|floatformat:2 }}%;"></div>
                 </div>
                 <p class="storage-summary">{{ saved_file_count }} out of {{ max_files_at_current_average }} files saved.</p>
                 {% if file_capacity_projection_ready %}

--- a/cytocv/templates/dashboard.html
+++ b/cytocv/templates/dashboard.html
@@ -105,7 +105,7 @@
                     <p class="storage-text">{{ used_storage_mb|floatformat:2 }} MB out of {{ total_storage_gb|floatformat:2 }} GB</p>
                 </div>
                 <div class="quota-track">
-                    <div class="quota-fill" style="--quota-fill-width: {{ storage_percentage|floatformat:2 }}%;"></div>
+                    <div class="quota-fill" data-quota-fill-width="{{ storage_percentage|floatformat:2 }}"></div>
                 </div>
                 <p class="storage-summary">{{ saved_file_count }} out of {{ max_files_at_current_average }} files saved.</p>
                 {% if file_capacity_projection_ready %}

--- a/docs/developer/testing-guide.md
+++ b/docs/developer/testing-guide.md
@@ -65,8 +65,15 @@ GitHub Actions runs the backend safety gate in `.github/workflows/backend-ci.yml
 The workflow uses Python 3.11.5 from `.python-version`, installs
 `requirements.txt`, and runs `manage.py check`,
 `manage.py makemigrations --check --dry-run`,
-`manage.py collectstatic --dry-run --noinput`, `manage.py test core`,
-`manage.py test accounts`, and the full `manage.py test` suite.
+`manage.py collectstatic --dry-run --noinput`, explicit Django frontend-contract
+tests, `manage.py test core`, `manage.py test accounts`, and the full
+`manage.py test` suite.
+
+There is no separate Node frontend toolchain or frontend build CI. The
+frontend safety rail in CI is contract coverage for Django-rendered templates,
+static CSS/JS references, JSON config blocks, JavaScript globals, viewer hooks,
+workflow responses, and export hooks. It is not browser E2E coverage and does
+not run an npm build.
 
 Coverage reporting, lint/format gates, typechecking, browser E2E, Docker build,
 and deployment validation are intentionally deferred until the baseline CI is

--- a/docs/developer/testing-guide.md
+++ b/docs/developer/testing-guide.md
@@ -11,7 +11,7 @@ The active Django test suite is split across:
 - `cytocv/core/tests/`
 - `cytocv/accounts/tests_*.py`
 
-The current baseline is 745 tests: 674 under `core` and 71 under `accounts`.
+The current baseline is 747 tests: 676 under `core` and 71 under `accounts`.
 The suite includes upload preparation, TIFF/DV parsing, artifact storage,
 progress and worker behavior, scientific-stat calculations, exports, frontend
 contracts, account preferences, email alias behavior, and quota policy.
@@ -54,6 +54,19 @@ python manage.py test
 ```
 
 When working on a narrower area, run the relevant subset first and then rerun the full suite before finalizing.
+
+## Backend CI
+
+GitHub Actions runs the backend safety gate in `.github/workflows/backend-ci.yml`.
+The workflow uses Python 3.11.5 from `.python-version`, installs
+`requirements.txt`, and runs `manage.py check`,
+`manage.py makemigrations --check --dry-run`,
+`manage.py collectstatic --dry-run --noinput`, `manage.py test core`,
+`manage.py test accounts`, and the full `manage.py test` suite.
+
+Coverage reporting, lint/format gates, typechecking, browser E2E, Docker build,
+and deployment validation are intentionally deferred until the baseline CI is
+stable.
 
 For frontend template/static changes, run:
 

--- a/docs/developer/testing-guide.md
+++ b/docs/developer/testing-guide.md
@@ -11,7 +11,7 @@ The active Django test suite is split across:
 - `cytocv/core/tests/`
 - `cytocv/accounts/tests_*.py`
 
-The current baseline is 747 tests: 676 under `core` and 71 under `accounts`.
+The current baseline is 751 tests: 680 under `core` and 71 under `accounts`.
 The suite includes upload preparation, TIFF/DV parsing, artifact storage,
 progress and worker behavior, scientific-stat calculations, exports, frontend
 contracts, account preferences, email alias behavior, and quota policy.
@@ -26,6 +26,9 @@ contracts, account preferences, email alias behavior, and quota policy.
 - table rendering and export support
 - scale initialization and upload-time scale handling
 - plugin and stats validation behavior
+- exact artifact path contracts for generated media and overlay files
+- display/dashboard JSON payload keys used by the viewers
+- supported source image extension contracts
 - frontend rendered-template contracts, static asset references, JSON config blocks, shared JavaScript globals, and frontend-facing response shapes
 
 ## Frontend Contract Tests
@@ -34,6 +37,7 @@ The frontend is Django-rendered HTML plus static CSS/JS, so regression coverage 
 
 - Template contract tests verify major pages render the expected template, CSS/JS includes, DOM hooks, JSON config scripts, and no inline styles.
 - Static contract tests verify template `{% static %}` references resolve, CSS `url(...)` references exist, static JS contains no Django syntax, and debug/conflict markers are absent.
+- Dashboard quota fill width is rendered as a data attribute and applied by static JavaScript so templates keep the no-inline-style contract.
 - JSON contract tests parse frontend config scripts and assert stable IDs, required keys, and basic value types.
 - JavaScript contract tests verify owner files for public globals and run `node --check` when Node is available.
 - Viewer/workflow/export contract tests cover page-specific hooks and frontend-facing endpoint response shapes without duplicating deeper backend behavior tests.

--- a/docs/developer/testing-guide.md
+++ b/docs/developer/testing-guide.md
@@ -4,30 +4,17 @@
 
 This document explains the current automated test surface and the expected validation workflow for code changes.
 
-## Test Location
+## Test Locations
 
-The active test suite is under `cytocv/core/tests/`.
+The active Django test suite is split across:
 
-Current test modules:
+- `cytocv/core/tests/`
+- `cytocv/accounts/tests_*.py`
 
-- `test_accounts_preferences.py`
-- `test_artifact_storage.py`
-- `test_core_app.py`
-- `test_frontend_export_contracts.py`
-- `test_frontend_json_contracts.py`
-- `test_frontend_js_contracts.py`
-- `test_frontend_static_contracts.py`
-- `test_frontend_template_contracts.py`
-- `test_frontend_viewer_contracts.py`
-- `test_frontend_workflow_contracts.py`
-- `test_mrcnn_inference.py`
-- `test_nuclear_cell_pair_intensity.py`
-- `test_scale_upload_initialization.py`
-- `test_stats_cache.py`
-- `test_stats_validation.py`
-- `test_tables.py`
-- `test_upload_preparation.py`
-- `test_upload_length_scale.py`
+The current baseline is 745 tests: 674 under `core` and 71 under `accounts`.
+The suite includes upload preparation, TIFF/DV parsing, artifact storage,
+progress and worker behavior, scientific-stat calculations, exports, frontend
+contracts, account preferences, email alias behavior, and quota policy.
 
 ## What The Tests Cover
 
@@ -58,6 +45,11 @@ When adding a new frontend page, add a rendered-template contract for the page C
 From `cytocv/`:
 
 ```powershell
+python manage.py check
+python manage.py makemigrations --check --dry-run
+python manage.py collectstatic --dry-run --noinput
+python manage.py test core
+python manage.py test accounts
 python manage.py test
 ```
 

--- a/docs/ops/deployment-guide.md
+++ b/docs/ops/deployment-guide.md
@@ -50,6 +50,11 @@ The repository includes:
 - `start.sh`
 
 These artifacts support containerized deployment, but the final environment still depends on correct `.env` provisioning and accessible media storage.
+The current `start.sh` runs `makemigrations` for `accounts` and `core` before
+`migrate` and Gunicorn. Treat that as current runtime behavior when using this
+script; controlled production deployments should still review generated
+migration changes before rollout rather than relying on startup-time migration
+generation.
 
 Optional worker startup paths:
 

--- a/docs/ops/security-and-privacy.md
+++ b/docs/ops/security-and-privacy.md
@@ -51,6 +51,11 @@ Sensitive values that must remain outside source control:
 - reCAPTCHA secret key
 
 `.env` should never be committed.
+The repository should not contain live production values in `.env.production`
+or any other environment file. If such values were committed, rotate the
+affected credentials, scrub the file from active deployment workflows, and audit
+history as an operational incident. Do not quote secret values in tickets,
+docs, logs, or review comments.
 
 ## Ownership And Data Visibility
 

--- a/docs/reference/file-format-and-artifact-spec.md
+++ b/docs/reference/file-format-and-artifact-spec.md
@@ -77,17 +77,21 @@ Common artifacts under `MEDIA_ROOT/<uuid>/`:
 
 - source upload file
 - `channel_config.json`
-- preview PNG files
-- preprocess intermediates
+- `preview_images/preview-layer<n>.png`
+- `preprocessed_images/<source-stem>.png`
 - `output/mask.tif`
 
   Labeled segmentation mask written after mask postprocessing; enclosed interior holes are filled before downstream outlines, crops, and contour clipping use it.
 
+- `output/cellpairs.tif`
 - `output/*_frame_<n>.png`
+- `output/pair-geometry.json`
+- `output/<image>-<cell>.neck_split`
+- `output/<image>-<cell>.outline`
 - `segmented/cell_<n>.png`
 - `segmented/*-no_outline.png`
 - `segmented/overlay-render-config.json`
-- `segmented/overlay-cache-v1/*.png`
+- `segmented/overlay-cache-v4/*.png`
 - `segmented/*_debug.png`
 
 ## Channel Configuration File
@@ -133,8 +137,12 @@ Observed output naming patterns include:
 - binary cell masks: `cell_<n>.png`
 - channel-indexed outlined crops: `<image>-<channel_index>-<cell>.png`
 - channel-indexed no-outline crops: `<image>-<channel_index>-<cell>-no_outline.png`
+- cell-pair geometry manifest: `output/pair-geometry.json`
+- neck split sidecar: `output/<image>-<cell>.neck_split`
+- outline coordinates: `output/<image>-<cell>.outline`; legacy segmented
+  outline patterns are still checked by cleanup/deletion paths
 - exact overlay render snapshot: `overlay-render-config.json`
-- exact overlay cache entries: `overlay-cache-v1/cell-<cell>-<channel>.png`
+- exact overlay cache entries: `overlay-cache-v4/cell-<cell>-<channel>.png`
 - optional legacy debug overlays when raster export is enabled: `<image>-<cell>-Red_debug.png`, `<image>-<cell>-Green_debug.png`, `<image>-<cell>-Blue_debug.png`
 
 ## Export Output


### PR DESCRIPTION
This pull request refactors and modularizes several utility functions related to result payloads, statistics exports, and progress request handling. The main changes involve moving logic from `cytocv/accounts/views/profile.py` into new or existing service modules, improving code organization and reusability. Additionally, the CI workflow for the backend has been added.

**Backend CI workflow:**

* Added a new GitHub Actions workflow `.github/workflows/backend-ci.yml` to run backend tests, check code quality, and ensure CI consistency on `main`, `develop`, and user branches.

**Code modularization and refactoring:**

* Moved logic for resolving cell table modes, channel config payloads, detected channel labels, and JSON sanitization from `profile.py` to the new module `core/services/result_view_payloads.py`, replacing local implementations with imports. [[1]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acR91-R102) [[2]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL584-R574) [[3]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL615-L651) [[4]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL753-R711) [[5]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL773-R726) [[6]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL791-R743) [[7]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL921-R872) [[8]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL957-R905) [[9]](diffhunk://#diff-0bbe77eafe4ce4c54d71b931284dd34db9b299f5dd11c21aff650bb75d180466R1-R73)

* Moved and replaced the `_normalize_uuid_list` helper with `normalize_uuid_list` from `core/services/stat_export_requests.py` for improved normalization and deduplication of UUID lists. [[1]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL531-L547) [[2]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL1137-R1085) [[3]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL1183-R1131)

* Replaced manual construction of statistics export sources with the new `build_statistics_export_sources` function from `core/services/stat_export_requests.py`. [[1]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL62) [[2]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL1218-L1226)

**New helper module for progress requests:**

* Introduced `core/services/progress_request_helpers.py` containing utility functions and error handling for validating and tracking analysis progress requests, improving separation of concerns.

**Minor dependency and import cleanups:**

* Removed unused imports (`math`, `UUID`, `StatisticsExportFile`, `VALID_PUNCTA_LINE_MODES`, etc.) from `profile.py` and other modules. [[1]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL6-L11) [[2]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL62) [[3]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL75) [[4]](diffhunk://#diff-ec582f8cfdc4daaa11fa545f81a1cb2a65b6710b858f8d69b3a4dc0c8e2157acL115) [[5]](diffhunk://#diff-0f615c7d3d8cfc95b4bb77161398b71c6f3b95188cdf70648acac8d3b6557fc1L12) [[6]](diffhunk://#diff-fef90c7f659bbbec01c491c55a19fe49407cecef117e02858bb1d4ec7daff174L21-L22)

These changes improve code maintainability, clarity, and testability by centralizing commonly used logic and reducing duplication.