### PR TITLE
Align license documentation and finalize v2.0.0 release details

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,9 +3,28 @@ message: "If you use CytoCV in your research, please cite this software."
 title: "CytoCV"
 type: software
 version: "2.0.0"
+date-released: "2026-08-12"
+doi: "10.5281/zenodo.21901187"
 repository-code: "https://github.com/BrentLagesse/CytoCV"
+repository-artifact: "https://doi.org/10.5281/zenodo.21901187"
 url: "https://cytocv2.uwb.edu/"
 license: "AGPL-3.0-or-later"
+
+abstract: >-
+  CytoCV is a browser-accessible Django platform for reproducible analysis
+  of yeast fluorescence microscopy images. It supports DeltaVision and
+  stack TIFF inputs, DIC-guided Mask R-CNN segmentation, configurable
+  single-cell and cell-pair retention, plugin-based per-cell measurements,
+  visual review, and structured CSV/XLSX export.
+
+keywords:
+  - yeast microscopy
+  - fluorescence quantification
+  - bioimage analysis
+  - cell instance segmentation
+  - Django
+  - Mask R-CNN
+  - reproducible research
 
 authors:
   - family-names: "Gioanni"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ CytoCV is a Django-based analysis platform for DeltaVision (`.dv`) and stack TIF
 - [Runtime Requirements](#runtime-requirements)
 - [Security Notes](#security-notes)
 - [Historical Notes](#historical-notes)
+- [Citation](#citation)
 - [License](#license)
 
 ## Overview
@@ -34,7 +35,9 @@ The current workflow defaults enable these plugins:
 - `CENDot`
 - `Biorientation`
 - `GreenRedIntensity`
-- `NuclearCellPairIntensity`
+
+`NuclearCellPairIntensity` remains available as a selectable analysis module
+but is not enabled in the default plugin set.
 
 That default set requires `DIC`, `Red`, and `Green`. `Blue` remains supported for legacy measurements and for optional full-wavelength validation.
 These outputs are software-generated measurements intended to support review and downstream research analysis. They should not be treated as final biological conclusions on their own.
@@ -250,6 +253,19 @@ Detailed operational guidance is documented in:
 ## Historical Notes
 
 This tool derived from the python application found at https://github.com/BrentLagesse/YeastAnalysisTool.  That tool is no longer maintained, but is still available for historical development purposes.
+
+## Citation
+
+The archived CytoCV v2.0.0 software record is identified by:
+
+**DOI:** [10.5281/zenodo.21901187](https://doi.org/10.5281/zenodo.21901187)
+
+Citation metadata are also provided in
+[`CITATION.cff`](CITATION.cff).
+
+When reporting analyses, cite the exact CytoCV version used. Later releases may
+change interfaces, dependencies, outputs, or scientific workflow behavior and
+should be cited separately.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -29,17 +29,26 @@ CytoCV combines:
 - plugin-based per-cell quantification
 - database-backed review, retention, and export workflows
 
-The current workflow defaults enable these plugins:
+CytoCV exposes two primary Signal Quantification modes:
 
-- `PunctaDistance`
+- `PunctaDistance` (`Puncta Distance`), which is the default primary mode.
+- `NuclearCellPairIntensity` (`Nuclear, Cell-Pair Intensity`), which is a
+  fully supported selectable primary mode.
+
+The default puncta-oriented plugin selection also includes:
+
 - `CENDot`
 - `Biorientation`
 - `GreenRedIntensity`
 
-`NuclearCellPairIntensity` remains available as a selectable analysis module
-but is not enabled in the default plugin set.
+Mode selection determines which measurements and controls are active.
+Selecting `NuclearCellPairIntensity` activates the nuclear/cell-pair intensity
+workflow and its nucleus-contour configuration controls.
 
-That default set requires `DIC`, `Red`, and `Green`. `Blue` remains supported for legacy measurements and for optional full-wavelength validation.
+The current default puncta-oriented selection requires `DIC`, `Red`, and
+`Green`. The nuclear/cell-pair workflow also uses the channels required by its
+configured contour and measurement modes. `Blue` remains supported for
+backward-compatible measurements and optional full-wavelength validation.
 These outputs are software-generated measurements intended to support review and downstream research analysis. They should not be treated as final biological conclusions on their own.
 
 ## System Scope

--- a/cytocv/core/licensing.py
+++ b/cytocv/core/licensing.py
@@ -9,11 +9,12 @@ LICENSE_FULL_NAME = "GNU Affero General Public License v3.0 or later"
 LICENSE_SPDX_ID = "AGPL-3.0-or-later"
 LICENSE_OFFICIAL_URL = "https://www.gnu.org/licenses/agpl-3.0.html"
 LICENSE_SPDX_URL = "https://spdx.org/licenses/AGPL-3.0-or-later.html"
-SOURCE_CODE_URL = "https://github.com/BrentLagesse/CytoCV"
-
-# Release follow-up: after v2.0.0 is published, production source and license
-# links should target the immutable release tag or the exact deployed commit.
-LICENSE_REPOSITORY_URL = f"{SOURCE_CODE_URL}/blob/main/LICENSE"
+REPOSITORY_URL = "https://github.com/BrentLagesse/CytoCV"
+RELEASE_VERSION = "2.0.0"
+RELEASE_TAG = f"v{RELEASE_VERSION}"
+SOURCE_CODE_URL = f"{REPOSITORY_URL}/tree/{RELEASE_TAG}"
+LICENSE_REPOSITORY_URL = f"{REPOSITORY_URL}/blob/{RELEASE_TAG}/LICENSE"
+DOCUMENTATION_URL = f"{SOURCE_CODE_URL}/docs"
 
 
 def license_metadata(request: HttpRequest) -> dict[str, str]:

--- a/cytocv/core/tests/test_core_app.py
+++ b/cytocv/core/tests/test_core_app.py
@@ -21,6 +21,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from PIL import Image
 
+from core import licensing
 from core.cell_analysis import Analysis
 from core.config import DEFAULT_CHANNEL_CONFIG
 from core.image_processing import GrayImage
@@ -73,8 +74,14 @@ def temporary_media_root():
 
 
 class RouteSurfaceRefactorTests(TestCase):
-    SOURCE_CODE_URL = "https://github.com/BrentLagesse/CytoCV"
-    FULL_LICENSE_URL = f"{SOURCE_CODE_URL}/blob/main/LICENSE"
+    REPOSITORY_URL = "https://github.com/BrentLagesse/CytoCV"
+    RELEASE_VERSION = "2.0.0"
+    RELEASE_TAG = f"v{RELEASE_VERSION}"
+    SOURCE_CODE_URL = f"{REPOSITORY_URL}/tree/{RELEASE_TAG}"
+    GITHUB_BLOB_BASE_URL = f"{REPOSITORY_URL}/blob/{RELEASE_TAG}"
+    FULL_LICENSE_URL = f"{GITHUB_BLOB_BASE_URL}/LICENSE"
+    DOCUMENTATION_URL = f"{SOURCE_CODE_URL}/docs"
+    MALFORMED_RELEASE_URL = f"{SOURCE_CODE_URL}/blob/main"
     OFFICIAL_LICENSE_URL = "https://www.gnu.org/licenses/agpl-3.0.html"
     LICENSE_SPDX_URL = "https://spdx.org/licenses/AGPL-3.0-or-later.html"
     LEGACY_LICENSE_LABEL = " ".join(("CC", "BY-" + "NC-SA", "4.0"))
@@ -182,6 +189,9 @@ class RouteSurfaceRefactorTests(TestCase):
         self.assertNotContains(response, self.LEGACY_LICENSE_LABEL)
         self.assertNotContains(response, self.LEGACY_POLICY_TERM)
         self.assertNotContains(response, self.LEGACY_LICENSE_URL, html=False)
+
+    def _assert_release_links_are_well_formed(self, response):
+        self.assertNotContains(response, self.MALFORMED_RELEASE_URL, html=False)
 
     def _assert_files_data_payload_contract(self, payload):
         self.assertTrue(
@@ -618,6 +628,15 @@ class RouteSurfaceRefactorTests(TestCase):
         response = self.client.get(reverse("license"))
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(licensing.REPOSITORY_URL, self.REPOSITORY_URL)
+        self.assertEqual(licensing.RELEASE_VERSION, self.RELEASE_VERSION)
+        self.assertEqual(licensing.RELEASE_TAG, self.RELEASE_TAG)
+        self.assertEqual(licensing.SOURCE_CODE_URL, self.SOURCE_CODE_URL)
+        self.assertEqual(
+            licensing.LICENSE_REPOSITORY_URL,
+            self.FULL_LICENSE_URL,
+        )
+        self.assertEqual(licensing.DOCUMENTATION_URL, self.DOCUMENTATION_URL)
         self.assertEqual(
             response.context["license_full_name"],
             "GNU Affero General Public License v3.0 or later",
@@ -731,6 +750,7 @@ class RouteSurfaceRefactorTests(TestCase):
 
         home_response = self.client.get(reverse("home"))
         self.assertEqual(home_response.status_code, 200)
+        self._assert_release_links_are_well_formed(home_response)
         self.assertContains(home_response, reverse("experiment"))
         self.assertContains(home_response, reverse("about"))
         self.assertContains(home_response, reverse("collaborators"))
@@ -779,8 +799,12 @@ class RouteSurfaceRefactorTests(TestCase):
         self.assertContains(home_response, f"{reverse('about')}#results", html=False)
         self.assertContains(
             home_response,
-            "https://github.com/BrentLagesse/CytoCV/tree/main/docs",
+            self.DOCUMENTATION_URL,
             html=False,
+        )
+        self.assertEqual(
+            home_response.context["github_blob_base_url"],
+            self.GITHUB_BLOB_BASE_URL,
         )
         self.assertNotContains(home_response, "What CytoCV Is")
         self.assertNotContains(home_response, "Why Researchers Need It")
@@ -874,6 +898,7 @@ class RouteSurfaceRefactorTests(TestCase):
 
         technical_response = self.client.get(reverse("about_technical"))
         self.assertEqual(technical_response.status_code, 200)
+        self._assert_release_links_are_well_formed(technical_response)
         self.assertTemplateUsed(technical_response, "about_detail.html")
         self.assertContains(technical_response, 'id="aboutNavMenu"', html=False)
         self.assertContains(technical_response, 'data-about-current="technical"', html=False)
@@ -896,17 +921,17 @@ class RouteSurfaceRefactorTests(TestCase):
         self.assertContains(technical_response, 'href="#developer-docs"', html=False)
         self.assertContains(
             technical_response,
-            "https://github.com/BrentLagesse/CytoCV/blob/main/docs/developer/architecture-overview.md",
+            f"{self.GITHUB_BLOB_BASE_URL}/docs/developer/architecture-overview.md",
             html=False,
         )
         self.assertContains(
             technical_response,
-            "https://github.com/BrentLagesse/CytoCV/blob/main/docs/reference/data-model.md",
+            f"{self.GITHUB_BLOB_BASE_URL}/docs/reference/data-model.md",
             html=False,
         )
         self.assertContains(
             technical_response,
-            "https://github.com/BrentLagesse/CytoCV/blob/main/docs/research/pdfs/methods-and-system-description.pdf",
+            f"{self.GITHUB_BLOB_BASE_URL}/docs/research/pdfs/methods-and-system-description.pdf",
             html=False,
         )
         self.assertNotContains(technical_response, "docs/ops/deployment-guide.md", html=False)
@@ -915,6 +940,7 @@ class RouteSurfaceRefactorTests(TestCase):
 
         biology_response = self.client.get(reverse("about_biology"))
         self.assertEqual(biology_response.status_code, 200)
+        self._assert_release_links_are_well_formed(biology_response)
         self.assertTemplateUsed(biology_response, "about_detail.html")
         self.assertContains(biology_response, 'id="aboutNavMenu"', html=False)
         self.assertContains(biology_response, 'data-about-current="biological"', html=False)
@@ -937,17 +963,17 @@ class RouteSurfaceRefactorTests(TestCase):
         self.assertContains(biology_response, 'href="#biology-workflow-docs"', html=False)
         self.assertContains(
             biology_response,
-            "https://github.com/BrentLagesse/CytoCV/blob/main/docs/research/pdfs/figure-catalog.pdf",
+            f"{self.GITHUB_BLOB_BASE_URL}/docs/research/pdfs/figure-catalog.pdf",
             html=False,
         )
         self.assertContains(
             biology_response,
-            "https://github.com/BrentLagesse/CytoCV/blob/main/docs/user/output-guide.md",
+            f"{self.GITHUB_BLOB_BASE_URL}/docs/user/output-guide.md",
             html=False,
         )
         self.assertNotContains(
             biology_response,
-            "https://github.com/BrentLagesse/CytoCV/blob/main/docs/developer/architecture-overview.md",
+            f"{self.GITHUB_BLOB_BASE_URL}/docs/developer/architecture-overview.md",
             html=False,
         )
 
@@ -1063,6 +1089,7 @@ class RouteSurfaceRefactorTests(TestCase):
 
         license_response = self.client.get(reverse("license"))
         self.assertEqual(license_response.status_code, 200)
+        self._assert_release_links_are_well_formed(license_response)
         self.assertTemplateUsed(license_response, "license.html")
         self.assertContains(
             license_response,

--- a/cytocv/core/tests/test_docs_contracts.py
+++ b/cytocv/core/tests/test_docs_contracts.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from django.test import SimpleTestCase
+
+from core.services.signal_quantification import DEFAULT_SIGNAL_SELECTED_PLUGINS
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -15,6 +18,108 @@ def doc_text(relative_path: str) -> str:
 
 
 class DocumentationContractTests(SimpleTestCase):
+    def test_readme_default_plugins_match_runtime_defaults(self):
+        readme = doc_text("README.md")
+        default_section = readme.split(
+            "The current workflow defaults enable these plugins:",
+            maxsplit=1,
+        )[1].split(
+            "That default set requires",
+            maxsplit=1,
+        )[0]
+        documented_defaults = tuple(
+            re.findall(r"^- `([^`]+)`$", default_section, flags=re.MULTILINE)
+        )
+
+        self.assertEqual(documented_defaults, DEFAULT_SIGNAL_SELECTED_PLUGINS)
+        self.assertIn(
+            "`NuclearCellPairIntensity` remains available as a selectable "
+            "analysis module\nbut is not enabled in the default plugin set.",
+            readme,
+        )
+
+    def test_citation_metadata_and_readme_release_citation(self):
+        citation = doc_text("CITATION.cff")
+        readme = doc_text("README.md")
+        normalized_citation = " ".join(citation.split())
+        citation_section = readme.split("## Citation", maxsplit=1)[1].split(
+            "## License",
+            maxsplit=1,
+        )[0]
+
+        for expected in (
+            'version: "2.0.0"',
+            'date-released: "2026-08-12"',
+            'doi: "10.5281/zenodo.21901187"',
+            'repository-code: "https://github.com/BrentLagesse/CytoCV"',
+            'repository-artifact: "https://doi.org/10.5281/zenodo.21901187"',
+            'url: "https://cytocv2.uwb.edu/"',
+            'license: "AGPL-3.0-or-later"',
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, citation)
+
+        self.assertIn(
+            "[10.5281/zenodo.21901187](https://doi.org/10.5281/zenodo.21901187)",
+            citation_section,
+        )
+        self.assertIn("[`CITATION.cff`](CITATION.cff)", citation_section)
+        self.assertLess(readme.index("## Citation"), readme.index("## License"))
+        self.assertIn(
+            "CytoCV is a browser-accessible Django platform for reproducible "
+            "analysis of yeast fluorescence microscopy images. It supports "
+            "DeltaVision and stack TIFF inputs, DIC-guided Mask R-CNN "
+            "segmentation, configurable single-cell and cell-pair retention, "
+            "plugin-based per-cell measurements, visual review, and structured "
+            "CSV/XLSX export.",
+            normalized_citation,
+        )
+
+        keywords = (
+            "yeast microscopy",
+            "fluorescence quantification",
+            "bioimage analysis",
+            "cell instance segmentation",
+            "Django",
+            "Mask R-CNN",
+            "reproducible research",
+        )
+        keyword_positions = [citation.index(f"  - {keyword}") for keyword in keywords]
+        self.assertEqual(keyword_positions, sorted(keyword_positions))
+
+        for family_name, given_name in (
+            ("Gioanni", "Nicolas"),
+            ("Prasad", "Anoop"),
+            ("Parnell", "Emily"),
+            ("Miller", "Matthew P."),
+            ("Lagesse", "Brent"),
+        ):
+            with self.subTest(author=family_name):
+                self.assertIn(
+                    f'- family-names: "{family_name}"\n'
+                    f'    given-names: "{given_name}"',
+                    citation,
+                )
+
+    def test_license_docs_preserve_v2_release_and_commercial_position(self):
+        license_docs = doc_text("docs/license/README.md")
+
+        self.assertIn("AGPL-3.0-or-later", license_docs)
+        self.assertIn("Section 13 network-source requirement", license_docs)
+        self.assertIn("non-binding project preference", license_docs)
+        self.assertIn("The full `LICENSE` file controls.", license_docs)
+        self.assertIn("Releases through v1.8.2", license_docs)
+        self.assertIn(
+            "Beginning with v2.0.0, CytoCV releases are published under "
+            "`AGPL-3.0-or-later`.",
+            license_docs,
+        )
+        self.assertIn(
+            "https://github.com/BrentLagesse/CytoCV/tree/v2.0.0",
+            license_docs,
+        )
+        self.assertNotIn("COMMERCIAL USE IS PERMITTED", license_docs)
+
     def test_uw_names_and_marks_notice_is_separate_from_agpl(self):
         notice_path = PROJECT_ROOT / "TRADEMARKS.md"
         notice = doc_text("TRADEMARKS.md")

--- a/cytocv/core/tests/test_docs_contracts.py
+++ b/cytocv/core/tests/test_docs_contracts.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 from django.test import SimpleTestCase
 
-from core.services.signal_quantification import DEFAULT_SIGNAL_SELECTED_PLUGINS
+from core.services.signal_quantification import (
+    DEFAULT_SIGNAL_SELECTED_PLUGINS,
+    NUCLEAR_CELL_PAIR_PLUGIN,
+    PUNCTA_DISTANCE_PLUGIN,
+)
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -18,25 +22,89 @@ def doc_text(relative_path: str) -> str:
 
 
 class DocumentationContractTests(SimpleTestCase):
-    def test_readme_default_plugins_match_runtime_defaults(self):
+    def test_docs_distinguish_primary_modes_from_puncta_defaults(self):
         readme = doc_text("README.md")
-        default_section = readme.split(
-            "The current workflow defaults enable these plugins:",
-            maxsplit=1,
-        )[1].split(
-            "That default set requires",
+        workflow_guide = doc_text("docs/user/workflow-guide.md")
+        analysis_options = doc_text("docs/user/analysis-options.md")
+        getting_started = doc_text("docs/user/getting-started.md")
+        overview = readme.split("## Overview", maxsplit=1)[1].split(
+            "## System Scope",
             maxsplit=1,
         )[0]
-        documented_defaults = tuple(
-            re.findall(r"^- `([^`]+)`$", default_section, flags=re.MULTILINE)
+        companion_plugins = tuple(
+            re.findall(r"^- `([^`]+)`$", overview, flags=re.MULTILINE)
+        )
+        documented_default_plugins = (
+            PUNCTA_DISTANCE_PLUGIN,
+            *companion_plugins,
         )
 
-        self.assertEqual(documented_defaults, DEFAULT_SIGNAL_SELECTED_PLUGINS)
-        self.assertIn(
-            "`NuclearCellPairIntensity` remains available as a selectable "
-            "analysis module\nbut is not enabled in the default plugin set.",
-            readme,
+        self.assertEqual(
+            documented_default_plugins,
+            DEFAULT_SIGNAL_SELECTED_PLUGINS,
         )
+        self.assertNotIn(NUCLEAR_CELL_PAIR_PLUGIN, DEFAULT_SIGNAL_SELECTED_PLUGINS)
+        self.assertIn(
+            "CytoCV exposes two primary Signal Quantification modes:",
+            overview,
+        )
+        self.assertIn(
+            f"`{PUNCTA_DISTANCE_PLUGIN}` (`Puncta Distance`)",
+            overview,
+        )
+        self.assertIn(
+            f"`{NUCLEAR_CELL_PAIR_PLUGIN}` (`Nuclear, Cell-Pair Intensity`)",
+            overview,
+        )
+        self.assertIn("fully supported selectable primary mode", overview)
+        self.assertIn("default puncta-oriented plugin selection", overview)
+
+        self.assertIn(PUNCTA_DISTANCE_PLUGIN, workflow_guide)
+        self.assertIn(NUCLEAR_CELL_PAIR_PLUGIN, workflow_guide)
+        self.assertIn("default primary mode", workflow_guide)
+        self.assertIn("default puncta-oriented selection", workflow_guide)
+        self.assertIn("nucleus-contour and measurement controls", workflow_guide)
+
+        current_docs = {
+            "README.md": readme,
+            "docs/user/workflow-guide.md": workflow_guide,
+            "docs/user/analysis-options.md": analysis_options,
+            "docs/user/getting-started.md": getting_started,
+        }
+        for path, content in current_docs.items():
+            normalized_content = " ".join(content.split())
+            with self.subTest(path=path, mode=PUNCTA_DISTANCE_PLUGIN):
+                self.assertIn(PUNCTA_DISTANCE_PLUGIN, normalized_content)
+            with self.subTest(path=path, mode=NUCLEAR_CELL_PAIR_PLUGIN):
+                self.assertIn(NUCLEAR_CELL_PAIR_PLUGIN, normalized_content)
+            with self.subTest(path=path, default="puncta"):
+                self.assertRegex(
+                    normalized_content,
+                    rf"(?:default.{{0,80}}{PUNCTA_DISTANCE_PLUGIN}|"
+                    rf"{PUNCTA_DISTANCE_PLUGIN}.{{0,80}}default)",
+                )
+            with self.subTest(path=path, alternative="nuclear"):
+                self.assertRegex(
+                    normalized_content,
+                    rf"{NUCLEAR_CELL_PAIR_PLUGIN}.{{0,300}}"
+                    r"(?:fully supported|selectable|activates)",
+                )
+
+        prohibited_descriptions = (
+            " ".join(("not enabled in the", "default plugin set")),
+        )
+        prohibited_mode_pattern = re.compile(
+            rf"{NUCLEAR_CELL_PAIR_PLUGIN.lower()}\s+"
+            r"(?:is|was|has been)\s+"
+            r"(?:unavailable|removed|deprecated|legacy|not (?:offered|available))"
+        )
+        for path, content in current_docs.items():
+            normalized_content = " ".join(content.replace("`", "").split()).lower()
+            for prohibited in prohibited_descriptions:
+                with self.subTest(path=path, prohibited=prohibited):
+                    self.assertNotIn(prohibited.lower(), normalized_content)
+            with self.subTest(path=path, prohibited="mode status"):
+                self.assertIsNone(prohibited_mode_pattern.search(normalized_content))
 
     def test_citation_metadata_and_readme_release_citation(self):
         citation = doc_text("CITATION.cff")

--- a/cytocv/core/views/home.py
+++ b/cytocv/core/views/home.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from django.template.response import TemplateResponse
 
-from core.licensing import SOURCE_CODE_URL
+from core.licensing import DOCUMENTATION_URL, RELEASE_TAG, REPOSITORY_URL
 
 # These constants are intentionally kept in Python rather than templates so the
 # public pages can share repository links and institutional branding data.
@@ -12,7 +12,7 @@ UWB_STEM_URL = "https://www.uwb.edu/stem"
 UWB_STEM_FACT_SHEET_URL = "https://www.uwb.edu/wp-content/uploads/2026/02/School_of_STEM_Fact_Sheet.pdf"
 UWB_STEM_LOGO_STATIC_PATH = "assets/uwb/web-left-school-signature-uw-bothell.png"
 UWB_STEM_WHITE_LOGO_STATIC_PATH = "assets/uwb/web-white-left-school-signature-uw-bothell.png"
-GITHUB_BLOB_BASE_URL = f"{SOURCE_CODE_URL}/blob/main"
+GITHUB_BLOB_BASE_URL = f"{REPOSITORY_URL}/blob/{RELEASE_TAG}"
 
 HOME_AFFILIATION_LINES = (
     "University of Washington Bothell",
@@ -97,7 +97,7 @@ HOME_SECTION_CARDS = (
             "Find upload requirements, workflow guidance, output explanations, and "
             "troubleshooting notes."
         ),
-        "href": "https://github.com/BrentLagesse/CytoCV/tree/main/docs",
+        "href": DOCUMENTATION_URL,
         "link_label": "View Documentation",
         "external": True,
     },

--- a/docs/license/README.md
+++ b/docs/license/README.md
@@ -7,7 +7,7 @@ Authoritative references:
 - [Repository LICENSE file](../../LICENSE)
 - [SPDX license record](https://spdx.org/licenses/AGPL-3.0-or-later.html)
 - [Official GNU AGPL page](https://www.gnu.org/licenses/agpl-3.0.html)
-- [CytoCV source repository](https://github.com/BrentLagesse/CytoCV)
+- [CytoCV v2.0.0 source](https://github.com/BrentLagesse/CytoCV/tree/v2.0.0)
 
 ## Strong Copyleft Notice
 

--- a/docs/license/README.md
+++ b/docs/license/README.md
@@ -34,17 +34,9 @@ Consult the full license for the precise scope and conditions of this requiremen
 
 ## Project Position on Commercial Use
 
-> **COMMERCIAL USE IS PERMITTED**
->
-> Commercial use is permitted under the GNU Affero General Public License v3.0 or later.
->
-> Paid hosting, consulting, support, modification, redistribution, and sale of copies or related services are permitted, subject to the license terms.
+CytoCV was developed primarily to support academic research, reproducible science, and open collaboration. The maintainers strongly discourage commercial exploitation that extracts value from CytoCV without providing meaningful support to the project or research community.
 
-AGPL compliance is mandatory. Commercial activities do not remove the source-code obligations that apply to covered modified versions.
-
-Commercial exploitation without reciprocal support is strongly discouraged.
-
-CytoCV was developed primarily to support academic research, reproducible science, and open collaboration. The maintainers strongly discourage commercial exploitation that extracts value from CytoCV without providing meaningful support to the project or the research community.
+The license permits commercial use. This statement expresses a non-binding project preference and does not add, modify, or override any permission or requirement in `AGPL-3.0-or-later`. The full `LICENSE` file controls.
 
 Commercial users are strongly encouraged to:
 
@@ -52,11 +44,7 @@ Commercial users are strongly encouraged to:
 2. report defects, compatibility problems, and security issues;
 3. support ongoing maintenance, infrastructure, and documentation;
 4. preserve clear attribution to CytoCV and its contributors; and
-5. make all corresponding source required by the AGPL readily available.
-
-Contributing changes directly upstream is strongly encouraged, but it is not an additional license condition.
-
-This statement expresses a non-binding project preference. It does not add, modify, or override any restriction or permission in AGPL-3.0-or-later. The full LICENSE file controls.
+5. make the corresponding source required by the AGPL readily available.
 
 ## What Is Not Acceptable
 
@@ -86,4 +74,4 @@ This page is a plain-language summary and is not legal advice. The full [LICENSE
 
 ## License History
 
-Releases through v1.8.2 were published under **CC BY-NC-SA 4.0**. Those previously published versions remain available under the license terms under which they were originally released. The forthcoming v2.0.0 release adopts `AGPL-3.0-or-later`.
+Releases through v1.8.2 were published under **CC BY-NC-SA 4.0**. Those previously published versions remain available under the license terms under which they were originally released. Beginning with v2.0.0, CytoCV releases are published under `AGPL-3.0-or-later`.

--- a/docs/user/analysis-options.md
+++ b/docs/user/analysis-options.md
@@ -9,17 +9,23 @@ This guide explains the user-visible analysis controls that affect validation, s
 - access to the upload page or workflow defaults interface
 - familiarity with the logical channel roles `DIC`, `Blue`, `Red`, and `Green`
 
-## Default Plugin Configuration
+## Signal Quantification Modes And Default Selection
 
-The current workflow defaults select:
+Signal Quantification provides two primary modes:
 
-- `PunctaDistance`
+- `PunctaDistance` (`Puncta Distance`), the default primary mode
+- `NuclearCellPairIntensity` (`Nuclear, Cell-Pair Intensity`), a fully
+  supported selectable primary mode
+
+The default puncta-oriented selection also includes:
+
 - `CENDot`
 - `Biorientation`
 - `GreenRedIntensity`
-- `NuclearCellPairIntensity`
 
-These defaults require `DIC`, `Red`, and `Green`. They do not require `Blue`.
+The default puncta-oriented selection requires `DIC`, `Red`, and `Green`. It
+does not require `Blue`. Selecting the nuclear/cell-pair primary mode activates
+`NuclearCellPairIntensity` and its nucleus-contour and measurement controls.
 
 Legacy plugins remain available when legacy visibility is enabled:
 
@@ -60,13 +66,13 @@ If no plugins are selected and no validation overrides are enabled, the enforced
 
 ### Plugin-Specific Channel Requirements
 
-| Plugin | Required channels beyond `DIC` | Legacy | Included in modern defaults |
+| Plugin | Required channels beyond `DIC` | Legacy | Default puncta-oriented selection |
 | --- | --- | --- | --- |
 | `PunctaDistance` | `Red`, `Green` | No | Yes |
 | `CENDot` | `Red`, `Green` | No | Yes |
 | `Biorientation` | `Red`, `Green` | No | Yes |
 | `GreenRedIntensity` | `Red`, `Green` | No | Yes |
-| `NuclearCellPairIntensity` | `Red`, `Green` | No | Yes |
+| `NuclearCellPairIntensity` | `Red`, `Green` | No | No — selectable primary mode |
 | `NucleusIntensity` | `Blue`, `Green` | Yes | No |
 | `BlueNucleusIntensity` | `Blue` | Yes | No |
 | `RedBlueIntensity` | `Red`, `Blue` | Yes | No |

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -68,7 +68,7 @@ python manage.py runserver
 
 1. Open the `Experiment` page.
 2. Upload one or more supported `.dv`, `.tif`, or `.tiff` files.
-3. Leave the default modern workflow enabled unless you are intentionally testing a reduced plugin set or a legacy Blue workflow. The default set includes `PunctaDistance`, `CENDot`, `Biorientation`, `GreenRedIntensity`, and `NuclearCellPairIntensity`.
+3. Leave the default `PunctaDistance` primary mode and its puncta-oriented companion selection enabled unless another workflow is needed. `NuclearCellPairIntensity` remains a fully supported alternative primary mode and can be selected to run the nuclear/cell-pair intensity workflow.
 4. Confirm that the file provides `DIC` plus any channels required by the selected plugin set.
 5. Review scale settings and, if needed, advanced validation toggles.
 6. Continue to preprocessing.

--- a/docs/user/workflow-guide.md
+++ b/docs/user/workflow-guide.md
@@ -43,7 +43,21 @@ The upload step also captures the active analysis configuration. This includes:
 
 These selections are stored with the current workflow state and reused in later steps. Signed-in users can also save them as workflow defaults for future runs.
 
-The current workflow defaults select `PunctaDistance`, `CENDot`, `Biorientation`, `GreenRedIntensity`, and `NuclearCellPairIntensity`. That default set requires `DIC`, `Red`, and `Green`. Mother/daughter parentage is computed automatically from DIC geometry and consumed by `CENDot`. `Blue` becomes required only when a legacy plugin or all-wavelength enforcement is active.
+Signal Quantification provides two primary modes:
+`PunctaDistance` and `NuclearCellPairIntensity`. `PunctaDistance` is the
+default primary mode. The default puncta-oriented selection also includes
+`CENDot`, `Biorientation`, and `GreenRedIntensity`.
+
+Selecting `NuclearCellPairIntensity` activates the current nuclear/cell-pair
+intensity workflow and exposes its nucleus-contour and measurement controls.
+Mode compatibility determines which additional statistics are active for a
+given run.
+
+The default puncta-oriented selection requires `DIC`, `Red`, and `Green`.
+Mother/daughter parentage is computed automatically from DIC geometry and is
+used by applicable pair-dependent measurements. `Blue` becomes required only
+when a backward-compatible Blue-channel module or all-wavelength enforcement
+is active.
 
 Cell Inclusion Mode is resolved at analysis time. The default is Cell pairs
 only. Single cells only and Single cells and cell pairs can be selected when the


### PR DESCRIPTION
This pull request updates CytoCV to reference its v2.0.0 release throughout the documentation, code, and tests, and ensures all citation, licensing, and documentation links are accurate, versioned, and well-formed. It also clarifies the distinction between primary signal quantification modes and the default plugin set in both documentation and test coverage.

**Documentation and Citation Updates:**

- **CITATION.cff**: Adds full release metadata including version, release date, DOI, repository links, an abstract, and keywords for CytoCV v2.0.0.
- **README.md**: Adds a Citation section with DOI and citation instructions, and clarifies the distinction between primary quantification modes and the default plugin set. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R51) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R266-R278)

**Release Link Versioning and Licensing:**

- **Source and License URLs**: Updates all code and test references to source code, documentation, and license URLs to use the exact v2.0.0 release tag, ensuring links are immutable and accurate for the published release. [[1]](diffhunk://#diff-12e3ac1ee8aca612080297d34f5b5f2933edebab8e57954abf652499bbadb88fL12-R17) [[2]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267L76-R84) [[3]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267L782-R808) [[4]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267L899-R934) [[5]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267L940-R976)
- **Test Coverage**: Adds and updates tests to verify that all rendered pages use the correct, versioned release links and that no malformed or unversioned links are present. [[1]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267R193-R195) [[2]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267R631-R639) [[3]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267R753) [[4]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267R901) [[5]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267R943) [[6]](diffhunk://#diff-118f3e83bb99bccd3a63a5ea0bdb7989829454d1f03c5e025a53973f2e2c8267R1092)

**Analysis Modes and Plugin Documentation:**

- **Test Contracts**: Adds comprehensive tests to check that documentation consistently distinguishes between primary signal quantification modes and the default plugin set, and that all relevant files include up-to-date, accurate descriptions of available workflows and plugins. [[1]](diffhunk://#diff-8b688d1fd3019f0b34f2231bc5a0ba653ee019a48c63d6f3809ab2e54071ca2fR5-R15) [[2]](diffhunk://#diff-8b688d1fd3019f0b34f2231bc5a0ba653ee019a48c63d6f3809ab2e54071ca2fR25-R190)

**Other:**

- **Author and Metadata Verification**: Tests ensure that citation metadata, author lists, keywords, and licensing statements are present and correctly ordered.

These changes ensure that users and researchers can reliably cite, reference, and access the exact CytoCV v2.0.0 release, and that documentation and tests accurately reflect the current state and usage of the software.